### PR TITLE
docs: banner stale onboarding guides (Phase 1 of onboarding refactor)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,5 +1,7 @@
 # The Rouge — Technical Architecture
 
+> ⚠️ **Onboarding sections are being refactored.** The canonical user-facing path is now dashboard-first: run `rouge setup`, open the dashboard, click **New Project**. Sections below describing Slack-based seeding as the primary entry point are out of date. See `docs/plans/2026-04-15-onboarding-refactor.md`.
+
 **Date:** 2026-03-17
 **Status:** Approved (explore session complete, pending spec update)
 **Supersedes:** Original spec assumptions about a traditional software runtime

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,5 +1,7 @@
 # Quick Start
 
+> ⚠️ **Onboarding is being refactored.** The canonical path is now: run `rouge setup`, open the dashboard, click **New Project**. The CLI and Slack steps below still work but are no longer the recommended path for new users. See `docs/plans/2026-04-15-onboarding-refactor.md` for the full plan.
+
 Get from zero to your first Rouge-built product in 5 minutes.
 
 ## Prerequisites

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,5 +1,7 @@
 # The Rouge — Setup Guide
 
+> ⚠️ **Onboarding is being refactored.** The canonical path is now: run `rouge setup`, open the dashboard, click **New Project**. The Slack and CLI steps below still work but are no longer the recommended path for new users. See `docs/plans/2026-04-15-onboarding-refactor.md` for the full plan.
+
 One-time setup for running The Rouge on your machine.
 
 ## Prerequisites

--- a/docs/slack-setup.md
+++ b/docs/slack-setup.md
@@ -1,5 +1,7 @@
 # Slack Setup Guide
 
+> 🧪 **Experimental.** Slack as a full control plane is no longer the recommended path. The dashboard is now the primary control surface; Slack is being repositioned as notifications + lightweight remote commands. See `docs/plans/2026-04-15-onboarding-refactor.md`. This guide still works if you want it, but expect the setup flow to move into a dashboard wizard in an upcoming phase.
+
 Connect Rouge to Slack so you can seed products via conversation, monitor autonomous builds, and control everything with slash commands.
 
 ## Prerequisites

--- a/docs/your-first-product.md
+++ b/docs/your-first-product.md
@@ -1,5 +1,7 @@
 # Your first product
 
+> ⚠️ **Onboarding is being refactored.** The canonical path is now: run `rouge setup`, open the dashboard, click **New Project**. The CLI steps below still work but are no longer the recommended path for new users. See `docs/plans/2026-04-15-onboarding-refactor.md` for the full plan.
+
 You've installed Rouge, run `rouge doctor`, and read the [seeding example](seeding-example.md). Now you want to actually build something. Here's what happens end to end.
 
 ## Before you start


### PR DESCRIPTION
## Summary
- Adds a refactor-in-progress banner to 5 onboarding docs that still recommend the old \`rouge seed\` CLI or Slack control-plane path
- Points users at the dashboard-first flow (the canonical path per \`rouge.config.json\` \`control_plane: "frontend"\`)
- Marks \`docs/slack-setup.md\` experimental and signals Slack is moving to notifications-only

Banners only — no content rewrites. Phases 3–6 replace these files properly.

## Why
README already recommends dashboard-first. Every doc it links to contradicts it on click 1. Fresh cloners hit the contradiction immediately. ~30 min fix that unblocks new users while the larger refactor lands.

## Plan
Full refactor plan in \`docs/plans/2026-04-15-onboarding-refactor.md\` (gitignored, shared separately). This PR is Phase 1 of 7.

## Test plan
- [ ] Visually confirm banners render correctly on GitHub
- [ ] Confirm banner text matches across the 4 dashboard-first files
- [ ] Confirm slack-setup.md banner reflects experimental status

🤖 Generated with [Claude Code](https://claude.com/claude-code)