### PR TITLE
docs: tier the commercial license to close the hosted-resale loophole

### DIFF
--- a/COMMERCIAL.md
+++ b/COMMERCIAL.md
@@ -1,0 +1,97 @@
+# Commercial Licensing
+
+The Rouge is source-available under [PolyForm Noncommercial 1.0.0](LICENSE) for personal, research, educational, and other noncommercial use.
+
+Commercial use requires a commercial license. There are three tiers.
+
+---
+
+## Tier 1 — Free (Noncommercial)
+
+**License:** [PolyForm Noncommercial 1.0.0](LICENSE)
+
+**Permitted:** Personal projects, research, learning, teaching, hobby work, tinkering, private experimentation, use by charitable and educational organizations as defined in the PolyForm NC license.
+
+**Not permitted:** Any commercial use, including using Rouge to build products you sell, use inside a for-profit business, or offer to third parties.
+
+Free forever. No action required.
+
+---
+
+## Tier 2 — Internal Commercial — $100/month
+
+For small teams using Rouge inside their own business.
+
+**Purchase:** [GitHub Sponsors — Commercial tier](https://github.com/sponsors/gregario)
+
+**Permitted:**
+- Use by a single legal entity (your company)
+- **Internal use only** — building your own products, for your own customers, using your own staff
+- Up to **5 developers** actively using Rouge
+- Company annual revenue up to **$1,000,000 USD**
+- Modification, private forks, and deployment within your organization
+
+**Not permitted** under this tier:
+- Hosting Rouge (or a modified version, wrapper, or derivative) as a service available to third parties
+- Reselling, relicensing, or sublicensing Rouge
+- White-labeling, OEM bundling, or redistributing Rouge as part of a commercial product
+- Offering Rouge-powered services, consulting, or agency work to third parties where Rouge (or a derivative) is a primary functional component of what you deliver
+- Use by more than 5 developers, or by an organization with revenue above $1,000,000 USD/year
+
+If any of those apply to you, you need Tier 3.
+
+---
+
+## Tier 3 — Enterprise / Scale / Hosting — Contact Us
+
+For everything outside the Internal Commercial caps.
+
+**Contact:** gregj64@gmail.com
+
+**Required for:**
+- Hosted or managed Rouge services (SaaS, PaaS, or any third-party-facing deployment)
+- Reselling, OEM, or white-label distribution
+- Teams above 5 developers or $1M ARR
+- Consulting or agency offerings where Rouge is a primary functional component delivered to clients
+- Any use where Rouge (or a derivative) is a primary functional component of a product or service offered to third parties
+
+Pricing is custom and depends on scale, deployment model, and support requirements.
+
+---
+
+## Definitions
+
+- **"Primary functional component"** — Rouge (or a derivative) provides a material portion of the value the customer is paying for. If removing Rouge would substantially reduce the utility of your offering, Rouge is a primary component.
+- **"Third party"** — any person or organization that is not your company or its employees. Customers, users, clients, and contractors working on behalf of others are third parties.
+- **"Internal use"** — use by your own employees, on infrastructure your company controls, in support of your company's own products.
+- **"Developer"** — any individual who installs, runs, or directly operates Rouge. Passive beneficiaries (e.g., end users of a product Rouge helped you build) do not count.
+
+---
+
+## FAQ
+
+**Q: I'm a solo founder building a SaaS product using Rouge to accelerate development. Do I need Tier 2 or Tier 3?**
+A: Tier 2. Rouge is an internal tool helping you build your product — your product is what you sell. As long as Rouge isn't the primary component of what the customer pays for, you're fine at Tier 2 (assuming you're under the caps).
+
+**Q: I want to offer "Rouge hosting" or "Rouge as a service" to my clients.**
+A: Tier 3. This is exactly the case Tier 3 exists for. Contact us.
+
+**Q: I'm an agency using Rouge to build products for clients.**
+A: Depends. If you're using Rouge internally to accelerate your team's delivery (and the client pays for the product, not for Rouge access), Tier 2 is fine. If Rouge access, orchestration, or configuration is part of what the client is paying for, that's Tier 3.
+
+**Q: We're a 50-person company, only 2 devs will use Rouge, revenue is $20M. What tier?**
+A: Tier 3. The revenue cap applies to the whole company, not per-team. Contact us — pricing will be reasonable given the small footprint.
+
+**Q: I want to contribute back to Rouge. Does my contributor work need a license?**
+A: No. Contributing to Rouge is not "commercial use." Contribute freely.
+
+**Q: My usage straddles the line. What should I do?**
+A: Email gregj64@gmail.com. Being asked is always better than being wrong.
+
+---
+
+## Legal note
+
+This document summarizes the commercial licensing terms in plain language. The authoritative legal terms for commercial use are provided in the commercial license agreement you receive when you purchase or enter a Tier 2 or Tier 3 license. In case of conflict between this summary and the executed license agreement, the agreement governs.
+
+The base noncommercial license ([LICENSE](LICENSE)) is the standard PolyForm Noncommercial 1.0.0 text and is not modified by this document.

--- a/README.md
+++ b/README.md
@@ -259,8 +259,10 @@ Early access to new capabilities for [sponsors](https://github.com/sponsors/greg
 
 ## License
 
-[PolyForm Noncommercial 1.0.0](LICENSE)
+Rouge is source-available under [PolyForm Noncommercial 1.0.0](LICENSE) with a tiered commercial license on top. See [COMMERCIAL.md](COMMERCIAL.md) for full terms.
 
-Free for personal and non-commercial use. Personal projects, research, learning, tinkering, hobby work, education.
+- **Free (Noncommercial)** — personal projects, research, learning, teaching, hobby work.
+- **Internal Commercial — $100/month** via [GitHub Sponsors](https://github.com/sponsors/gregario). Single company, internal use only, ≤ 5 developers, ≤ $1M ARR. Does **not** permit hosting Rouge as a service, reselling, white-labeling, or offering Rouge-powered services to third parties as a primary component.
+- **Enterprise / Scale / Hosting** — contact gregj64@gmail.com. Required for hosted services, resale, OEM, teams above the caps, or any use where Rouge is a primary functional component of a product or service offered to third parties.
 
-Commercial use available via the [$100/month Commercial tier on GitHub Sponsors](https://github.com/sponsors/gregario).
+Not sure which tier fits? See the FAQ in [COMMERCIAL.md](COMMERCIAL.md) or email gregj64@gmail.com.


### PR DESCRIPTION
## Summary
- Splits the flat \$100/mo commercial tier into three scope-limited tiers (Free / Internal Commercial / Enterprise)
- Adds \`COMMERCIAL.md\` with full terms, definitions, and FAQ
- Updates README license section to point at the tiered structure
- Base \`LICENSE\` (PolyForm NC text) unchanged

## Why
The flat \$100/mo tier had no scope limits — a company could pay \$100, wrap Rouge as a hosted SaaS, and resell it for any price. This is the classic source-available exploitation vector MongoDB/Sentry/Elastic all closed with similar tiering.

New structure:
- **Free** — PolyForm NC (unchanged)
- **Internal Commercial — \$100/mo** — single company, internal use only, ≤ 5 devs, ≤ \$1M ARR. Prohibits hosting/resale/white-label/agency-Rouge-as-primary-deliverable.
- **Enterprise / Scale / Hosting** — contact for custom licensing

## Caveat
Plain-language summary only. Recommend legal review before enforcement, especially the caps, the "primary functional component" test, and how Tier 2/3 terms will be papered when someone purchases (GitHub Sponsors doesn't execute a license agreement by itself).

## Test plan
- [ ] COMMERCIAL.md reads clearly to a non-lawyer
- [ ] FAQ covers the common ambiguous cases (solo founder, agency, low-dev-count at high-revenue company)
- [ ] README link resolves
- [ ] No change to LICENSE file content

🤖 Generated with [Claude Code](https://claude.com/claude-code)