### PR TITLE
lifecycle: top-level status/stop/start/uninstall + macOS daemon + shutdown button (Phase 2.5a)

### DIFF
--- a/dashboard/src/app/api/system/shutdown/route.ts
+++ b/dashboard/src/app/api/system/shutdown/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+// POST /api/system/shutdown
+// Responds 200, then exits the dashboard process on the next tick so the
+// response actually flushes before the server dies. Called by the "Shut
+// down Rouge" button in the top-right menu of the dashboard.
+export async function POST() {
+  setTimeout(() => {
+    process.exit(0);
+  }, 100);
+  return NextResponse.json({ ok: true, message: "Rouge is shutting down." });
+}

--- a/dashboard/src/components/nav.tsx
+++ b/dashboard/src/components/nav.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { cn } from '@/lib/utils'
 import { catalogue } from '@/data/catalogue'
+import { ShutdownButton } from '@/components/shutdown-button'
 
 const links = [
   { href: '/', label: 'Dashboard' },
@@ -87,6 +88,11 @@ export function Nav() {
           <span className="text-foreground font-medium">{catalogueEntity.name}</span>
         </div>
       )}
+
+      {/* Shutdown button — always right-aligned, never pushed off by breadcrumbs */}
+      <div className={cn('flex items-center gap-2', !(breadcrumb || catalogueEntity) && 'ml-auto', (breadcrumb || catalogueEntity) && 'ml-4')}>
+        <ShutdownButton />
+      </div>
     </nav>
   )
 }

--- a/dashboard/src/components/shutdown-button.tsx
+++ b/dashboard/src/components/shutdown-button.tsx
@@ -1,0 +1,66 @@
+'use client'
+
+import { useState } from 'react'
+import { Power } from 'lucide-react'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog'
+
+export function ShutdownButton() {
+  const [pending, setPending] = useState(false)
+  const [done, setDone] = useState(false)
+
+  async function handleConfirm() {
+    setPending(true)
+    try {
+      await fetch('/api/system/shutdown', { method: 'POST' })
+    } catch {
+      // Expected: the server exits ~100ms after responding, so the fetch may
+      // or may not complete cleanly depending on timing. Either way, show the
+      // "stopped" state.
+    }
+    setDone(true)
+  }
+
+  if (done) {
+    return (
+      <div className="text-xs text-muted-foreground">
+        Rouge stopped. Run <code className="rounded bg-muted px-1">rouge start</code> or relaunch to resume.
+      </div>
+    )
+  }
+
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger
+        title="Shut down Rouge"
+        className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-accent/50 hover:text-foreground transition-colors"
+      >
+        <Power className="h-4 w-4" />
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Shut down Rouge?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This stops the dashboard server. Any build in progress will pause and resume when you restart.
+            You can restart anytime with <code className="rounded bg-muted px-1">rouge start</code>.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={pending}>Cancel</AlertDialogCancel>
+          <AlertDialogAction onClick={handleConfirm} disabled={pending}>
+            {pending ? 'Shutting down…' : 'Shut down'}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/dashboard/src/lib/bridge-client.ts
+++ b/dashboard/src/lib/bridge-client.ts
@@ -1,16 +1,28 @@
 // Bridge client — connects the dashboard to the Rouge API routes.
 //
 // Post-unification, the bridge runs as Next route handlers under /api/* on
-// the same origin as the frontend. BRIDGE_URL defaults to empty (relative
-// URLs hit the same host/port). NEXT_PUBLIC_BRIDGE_URL is kept as an
-// override for dev scenarios where the frontend is served from one host
-// and the API from another.
+// the same origin as the frontend. In the browser, relative URLs resolve
+// against window.location. On the server (Server Components, SSR), Node's
+// fetch requires absolute URLs — so we synthesize http://localhost:${PORT}
+// for same-process calls. NEXT_PUBLIC_BRIDGE_URL overrides both for dev
+// scenarios where frontend and API live on different hosts.
 //
 // isBridgeEnabled() now always returns true — the API routes always exist,
 // even if the backing projects directory is empty. Retained for callers
 // that still branch on it; safe to drop in a follow-up.
 
-const BRIDGE_URL = process.env.NEXT_PUBLIC_BRIDGE_URL ?? ''
+function resolveBridgeUrl(): string {
+  const override = process.env.NEXT_PUBLIC_BRIDGE_URL
+  if (override) return override
+  // Browser: relative URLs are fine.
+  if (typeof window !== 'undefined') return ''
+  // Server: Node fetch needs absolute URLs. We're in-process with the
+  // route handlers, so http://localhost:${PORT} is always correct.
+  const port = process.env.PORT ?? process.env.ROUGE_DASHBOARD_PORT ?? '3001'
+  return `http://localhost:${port}`
+}
+
+const BRIDGE_URL = resolveBridgeUrl()
 
 export function isBridgeEnabled(): boolean {
   return true

--- a/src/launcher/daemon.js
+++ b/src/launcher/daemon.js
@@ -1,0 +1,150 @@
+/**
+ * Daemon install/uninstall — keeps the Rouge dashboard running at login.
+ *
+ * Phase 2.5a: macOS (launch agent) only. Linux/Windows return "not supported"
+ * and will be filled in by Phase 2.5b (systemd --user unit / Scheduled Task).
+ *
+ * User-facing contract:
+ *   - `rouge setup` asks "Keep Rouge running in the background at login? [Y/n]"
+ *   - `rouge uninstall` removes the daemon as part of cleanup
+ *   - `rouge status` reports whether the daemon is installed and loaded
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { execSync, spawnSync } = require('child_process');
+
+const AGENT_LABEL = 'com.rouge.dashboard';
+const AGENT_PLIST = path.join(os.homedir(), 'Library', 'LaunchAgents', `${AGENT_LABEL}.plist`);
+
+function platform() {
+  if (process.platform === 'darwin') return 'macos';
+  if (process.platform === 'linux') return 'linux';
+  if (process.platform === 'win32') return 'windows';
+  return 'unsupported';
+}
+
+function resolveRougeBin() {
+  // Prefer the globally installed `rouge` on PATH; fall back to this script's
+  // sibling rouge-cli.js so daemon works from source checkouts too.
+  try {
+    const found = execSync('command -v rouge', { encoding: 'utf8' }).trim();
+    if (found) return found;
+  } catch { /* not on PATH — fall through */ }
+  return path.resolve(__dirname, 'rouge-cli.js');
+}
+
+function buildPlist() {
+  const bin = resolveRougeBin();
+  const logDir = path.join(os.homedir(), '.rouge', 'logs');
+  const node = process.execPath;
+  // If we fell back to rouge-cli.js, we need node to launch it.
+  const programArgs = bin.endsWith('.js')
+    ? `    <string>${node}</string>\n    <string>${bin}</string>`
+    : `    <string>${bin}</string>`;
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${AGENT_LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+${programArgs}
+    <string>dashboard</string>
+    <string>start</string>
+    <string>--no-open</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <false/>
+  <key>StandardOutPath</key>
+  <string>${logDir}/daemon.log</string>
+  <key>StandardErrorPath</key>
+  <string>${logDir}/daemon.log</string>
+</dict>
+</plist>
+`;
+}
+
+function isInstalled() {
+  if (platform() !== 'macos') return false;
+  return fs.existsSync(AGENT_PLIST);
+}
+
+function isLoaded() {
+  if (platform() !== 'macos') return false;
+  try {
+    const out = execSync(`launchctl list | grep ${AGENT_LABEL}`, { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] });
+    return out.trim().length > 0;
+  } catch {
+    return false;
+  }
+}
+
+function install() {
+  const p = platform();
+  if (p !== 'macos') {
+    return { ok: false, reason: `Daemon install not yet supported on ${p} (planned for Phase 2.5b). \`rouge dashboard start\` still works manually.` };
+  }
+
+  const logDir = path.join(os.homedir(), '.rouge', 'logs');
+  fs.mkdirSync(logDir, { recursive: true });
+  fs.mkdirSync(path.dirname(AGENT_PLIST), { recursive: true });
+  fs.writeFileSync(AGENT_PLIST, buildPlist(), { mode: 0o644 });
+
+  // Unload first in case a stale version exists, then load.
+  spawnSync('launchctl', ['unload', AGENT_PLIST], { stdio: 'ignore' });
+  const loadResult = spawnSync('launchctl', ['load', AGENT_PLIST], { stdio: 'pipe', encoding: 'utf8' });
+  if (loadResult.status !== 0) {
+    return { ok: false, reason: `launchctl load failed: ${(loadResult.stderr || '').trim()}` };
+  }
+
+  return { ok: true, path: AGENT_PLIST };
+}
+
+function uninstall() {
+  const p = platform();
+  if (p !== 'macos') {
+    // Nothing to uninstall on unsupported platforms; treat as success.
+    return { ok: true, removed: false };
+  }
+  if (!fs.existsSync(AGENT_PLIST)) {
+    return { ok: true, removed: false };
+  }
+  spawnSync('launchctl', ['unload', AGENT_PLIST], { stdio: 'ignore' });
+  try {
+    fs.unlinkSync(AGENT_PLIST);
+  } catch (err) {
+    return { ok: false, reason: `Failed to remove ${AGENT_PLIST}: ${err.message}` };
+  }
+  return { ok: true, removed: true };
+}
+
+function statusSummary() {
+  const p = platform();
+  if (p !== 'macos') {
+    return { platform: p, supported: false, installed: false, loaded: false };
+  }
+  return {
+    platform: p,
+    supported: true,
+    installed: isInstalled(),
+    loaded: isLoaded(),
+    path: AGENT_PLIST,
+  };
+}
+
+module.exports = {
+  AGENT_LABEL,
+  AGENT_PLIST,
+  platform,
+  isInstalled,
+  isLoaded,
+  install,
+  uninstall,
+  statusSummary,
+};

--- a/src/launcher/daemon.js
+++ b/src/launcher/daemon.js
@@ -25,24 +25,23 @@ function platform() {
   return 'unsupported';
 }
 
-function resolveRougeBin() {
-  // Prefer the globally installed `rouge` on PATH; fall back to this script's
-  // sibling rouge-cli.js so daemon works from source checkouts too.
-  try {
-    const found = execSync('command -v rouge', { encoding: 'utf8' }).trim();
-    if (found) return found;
-  } catch { /* not on PATH — fall through */ }
+function resolveRougeCliJs() {
+  // Always invoke rouge-cli.js by absolute path using the exact node binary
+  // we're running under. Launch agents run with a minimal PATH that usually
+  // doesn't include Homebrew's node, so `#!/usr/bin/env node` shebangs fail.
+  // Two candidates:
+  //   1. Our own __dirname + rouge-cli.js (works in source and global installs
+  //      — the global install's `rouge` symlink points at this same file)
   return path.resolve(__dirname, 'rouge-cli.js');
 }
 
 function buildPlist() {
-  const bin = resolveRougeBin();
-  const logDir = path.join(os.homedir(), '.rouge', 'logs');
+  const rougeCli = resolveRougeCliJs();
   const node = process.execPath;
-  // If we fell back to rouge-cli.js, we need node to launch it.
-  const programArgs = bin.endsWith('.js')
-    ? `    <string>${node}</string>\n    <string>${bin}</string>`
-    : `    <string>${bin}</string>`;
+  const logDir = path.join(os.homedir(), '.rouge', 'logs');
+  // Extend PATH so rouge-cli.js subprocesses (git, jq, claude, npm, etc.)
+  // can be found. Cover Homebrew (Apple Silicon + Intel), system dirs.
+  const daemonPath = '/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/sbin:/usr/sbin';
 
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -52,11 +51,19 @@ function buildPlist() {
   <string>${AGENT_LABEL}</string>
   <key>ProgramArguments</key>
   <array>
-${programArgs}
+    <string>${node}</string>
+    <string>${rougeCli}</string>
     <string>dashboard</string>
     <string>start</string>
     <string>--no-open</string>
   </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>${daemonPath}</string>
+    <key>HOME</key>
+    <string>${os.homedir()}</string>
+  </dict>
   <key>RunAtLoad</key>
   <true/>
   <key>KeepAlive</key>

--- a/src/launcher/rouge-cli.js
+++ b/src/launcher/rouge-cli.js
@@ -604,11 +604,14 @@ async function cmdUninstall() {
   const keepProjects = process.argv.includes('--keep-projects');
   const daemon = require('./daemon.js');
 
+  const rougeKeys = Object.keys(INTEGRATION_KEYS).map((k) => `rouge-${k}`).join(', ');
   console.log('\n  This will remove Rouge from your machine:');
   console.log(`    - Stop the dashboard if running`);
   console.log(`    - Unload and remove the launch agent (${daemon.statusSummary().supported ? daemon.platform() : 'n/a'})`);
   console.log(`    - Remove ${ROUGE_HOME}${keepProjects ? ' (but keep projects/)' : ''}`);
-  console.log(`    - Delete keychain entries for: ${Object.keys(INTEGRATION_KEYS).join(', ')}`);
+  console.log(`    - Delete Rouge's keychain entries (${rougeKeys}).`);
+  console.log(`      Your personal keychain entries for these services are NOT touched —`);
+  console.log(`      Rouge stores its creds under the \`rouge-*\` prefix only.`);
   console.log(`\n  It will NOT uninstall the \`rouge\` npm package — run`);
   console.log(`  \`npm uninstall -g rouge\` yourself if you installed globally.\n`);
 

--- a/src/launcher/rouge-cli.js
+++ b/src/launcher/rouge-cli.js
@@ -149,6 +149,9 @@ function createPrompt() {
 // ---------------------------------------------------------------------------
 
 async function cmdSetup(integration) {
+  // Flags aren't integration names — `rouge setup --yes` should mean
+  // "first-run setup, accept defaults," not "integration named --yes."
+  if (integration && integration.startsWith('-')) integration = undefined;
   // First-run setup: `rouge setup` with no args installs everything
   if (!integration) {
     console.log('\n  Rouge first-time setup');
@@ -188,14 +191,32 @@ async function cmdSetup(integration) {
     }
 
     // 4. Daemon install (macOS only for Phase 2.5a; Linux/Windows stubbed)
+    // Non-interactive flags for scripted/CI setup and for Claude Code's bash
+    // tool (which can't feed stdin to an interactive prompt):
+    //   --yes / -y      : accept defaults (install daemon)
+    //   --no-daemon     : skip daemon install
+    const cliArgs = process.argv.slice(2);
+    const autoYes = cliArgs.includes('--yes') || cliArgs.includes('-y');
+    const noDaemon = cliArgs.includes('--no-daemon');
+
     const daemon = require('./daemon.js');
     const daemonStatus = daemon.statusSummary();
     if (daemonStatus.supported && !daemonStatus.installed) {
       console.log('\n  Step 4: Background daemon');
-      const prompt = createPrompt();
-      const ans = (await prompt.ask('    Keep Rouge dashboard running at login? [Y/n]: ')).trim().toLowerCase();
-      prompt.close();
-      if (ans === '' || ans === 'y' || ans === 'yes') {
+      let install;
+      if (noDaemon) {
+        install = false;
+        console.log('    --no-daemon: skipping launch agent install.');
+      } else if (autoYes) {
+        install = true;
+        console.log('    --yes: installing launch agent.');
+      } else {
+        const prompt = createPrompt();
+        const ans = (await prompt.ask('    Keep Rouge dashboard running at login? [Y/n]: ')).trim().toLowerCase();
+        prompt.close();
+        install = (ans === '' || ans === 'y' || ans === 'yes');
+      }
+      if (install) {
         const r = daemon.install();
         if (r.ok) {
           console.log(`    Launch agent installed ✅ (${r.path})`);
@@ -1390,7 +1411,7 @@ if (command === 'doctor') {
   commands under SETUP — everything else is power-user / automation territory.
 
   SETUP & LIFECYCLE
-    rouge setup                     One-time setup (prereqs, deps, projects dir, daemon)
+    rouge setup [--yes|--no-daemon] One-time setup (prereqs, deps, projects dir, daemon)
     rouge setup <integration>       Store credentials for an integration
     rouge doctor                    Check prerequisites and dependencies
     rouge dashboard                 Open the dashboard (foreground, auto-opens browser)

--- a/src/launcher/rouge-cli.js
+++ b/src/launcher/rouge-cli.js
@@ -57,6 +57,43 @@ function dashboardLiveness() {
   return { running: isPidRunning(pid), pid, pids };
 }
 
+// Returns the first PID listening on `port` (IPv4 OR IPv6), or null.
+// Used to fail loud instead of silently binding a different address family
+// when another service holds the port — e.g. The Works on IPv6 :3001 while
+// Rouge would happily take IPv4 :3001, leaving the browser to pick one by
+// DNS resolution order.
+function findPortListener(port) {
+  try {
+    const out = execSync(`lsof -iTCP:${port} -sTCP:LISTEN -P -n`, {
+      encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    const lines = out.trim().split('\n').slice(1); // drop header
+    const entries = lines.map((l) => {
+      const [cmd, pid] = l.trim().split(/\s+/);
+      return { cmd, pid: parseInt(pid, 10) };
+    }).filter((e) => e.pid && !Number.isNaN(e.pid));
+    // Exclude our own dashboard's PID — if we just wrote the PID file and
+    // the process is already us, we shouldn't refuse to restart ourselves.
+    const ours = dashboardLiveness();
+    const foreign = entries.filter((e) => !ours.pid || e.pid !== ours.pid);
+    return foreign[0] || null;
+  } catch {
+    return null; // lsof missing, no listeners, or permission denied — don't block startup
+  }
+}
+
+// Returns true if something answers HTTP on the dashboard port — a cheap
+// way to tell "the running dashboard is actually serving" vs "PID is alive
+// but server died."
+function isDashboardResponsive(timeoutMs = 500) {
+  try {
+    execSync(`curl -s -o /dev/null --max-time ${Math.max(1, Math.ceil(timeoutMs / 1000))} ${DASHBOARD_URL}/`, { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Experimental-command warning. The dashboard is the canonical control
 // surface (see docs/plans/2026-04-15-onboarding-refactor.md). CLI verbs
@@ -1181,7 +1218,9 @@ if (command === 'doctor') {
     console.log('');
   }
 } else if (command === 'dashboard') {
-  const subcommand = args[1];
+  // Flags aren't subcommands — `rouge dashboard --no-open` means "foreground
+  // with --no-open," not "unknown subcommand --no-open."
+  const subcommand = args[1] && !args[1].startsWith('-') ? args[1] : undefined;
   const dashboardDir = path.join(__dirname, '..', '..', 'dashboard');
   const standaloneServer = path.join(dashboardDir, 'dist', 'server.js');
   const standaloneMarker = path.join(dashboardDir, 'dist', 'ROUGE_STANDALONE');
@@ -1268,6 +1307,18 @@ if (command === 'doctor') {
       process.exit(0);
     }
 
+    // Port discipline: fail loud if something else holds the port. Binding
+    // only one address family silently (IPv4 while another app has IPv6,
+    // or vice versa) leaves the browser to pick by DNS resolution order —
+    // confusing when `http://localhost:PORT` reaches the other app.
+    const blocker = findPortListener(DASHBOARD_PORT);
+    if (blocker) {
+      console.error(`\n  ❌ Port ${DASHBOARD_PORT} is already in use by PID ${blocker.pid} (${blocker.cmd}).`);
+      console.error(`     Either stop that process, or run Rouge on a different port:`);
+      console.error(`       ROUGE_DASHBOARD_PORT=3101 rouge dashboard start\n`);
+      process.exit(1);
+    }
+
     if (!hasPrebuilt && !hasDevDeps) {
       console.log('Dashboard dependencies not installed. Installing...');
       execSync('npm install', { cwd: dashboardDir, stdio: 'inherit' });
@@ -1345,9 +1396,37 @@ if (command === 'doctor') {
 
   } else if (!subcommand) {
     assertControlPlaneAllowed('frontend');
-    console.log(`Starting dashboard in foreground (${hasPrebuilt ? 'prebuilt' : 'dev mode'}, Ctrl+C to stop)...`);
-    console.log(`  URL:       ${DASHBOARD_URL}`);
-    console.log(`  Background mode: rouge dashboard start\n`);
+
+    // Daemon-aware redirect: if a background instance is already serving,
+    // don't spin up a redundant foreground one. Open the browser and exit.
+    // This is the common case when a launch agent is installed.
+    const existing = readPids();
+    const daemonAlive = existing && existing.pid && isRunning(existing.pid) && isDashboardResponsive();
+    if (daemonAlive) {
+      console.log(`Dashboard is already running in the background (PID ${existing.pid}).`);
+      console.log(`  URL:   ${DASHBOARD_URL}`);
+      console.log(`  Stop:  rouge stop`);
+      console.log(`  For a fresh foreground instance: rouge stop, then rouge dashboard.\n`);
+      const noOpen = args.includes('--no-open');
+      if (!noOpen) openBrowser(DASHBOARD_URL);
+      process.exit(0);
+    }
+
+    // Port discipline — same logic as `dashboard start`.
+    const blocker = findPortListener(DASHBOARD_PORT);
+    if (blocker) {
+      console.error(`\n  ❌ Port ${DASHBOARD_PORT} is already in use by PID ${blocker.pid} (${blocker.cmd}).`);
+      console.error(`     Either stop that process, or run Rouge on a different port:`);
+      console.error(`       ROUGE_DASHBOARD_PORT=3101 rouge dashboard\n`);
+      process.exit(1);
+    }
+
+    console.log(`Starting dashboard in foreground (${hasPrebuilt ? 'prebuilt' : 'dev mode'}).`);
+    console.log(`  URL:             ${DASHBOARD_URL}`);
+    console.log(`  Ctrl+C or closing this terminal stops THIS instance only.`);
+    console.log(`  The launch-agent daemon (if installed) is a separate process`);
+    console.log(`  and is unaffected. Check with \`rouge status\`.`);
+    console.log(`  Background mode: rouge start\n`);
 
     if (!hasPrebuilt && !hasDevDeps) {
       console.log('Dashboard dependencies not installed. Installing...');

--- a/src/launcher/rouge-cli.js
+++ b/src/launcher/rouge-cli.js
@@ -33,6 +33,31 @@ function resolveProjectsDir() {
 const PROJECTS_DIR = resolveProjectsDir();
 
 // ---------------------------------------------------------------------------
+// Lifecycle primitives (shared by `dashboard`, top-level `status/stop/start`,
+// and `uninstall`). Kept at module scope so every command sees the same
+// PID file, port, and URL.
+// ---------------------------------------------------------------------------
+
+const ROUGE_HOME = process.env.ROUGE_HOME || path.join(require('os').homedir(), '.rouge');
+const PID_FILE = path.join(ROUGE_HOME, 'dashboard.pid');
+const DASHBOARD_PORT = parseInt(process.env.ROUGE_DASHBOARD_PORT || '3001', 10);
+const DASHBOARD_URL = `http://localhost:${DASHBOARD_PORT}`;
+
+function readDashboardPids() {
+  try { return JSON.parse(fs.readFileSync(PID_FILE, 'utf8')); } catch { return null; }
+}
+function isPidRunning(pid) {
+  if (!pid) return false;
+  try { process.kill(pid, 0); return true; } catch { return false; }
+}
+function dashboardLiveness() {
+  const pids = readDashboardPids();
+  if (!pids) return { running: false, pid: null, pids: null };
+  const pid = pids.pid || pids.bridge; // back-compat
+  return { running: isPidRunning(pid), pid, pids };
+}
+
+// ---------------------------------------------------------------------------
 // Experimental-command warning. The dashboard is the canonical control
 // surface (see docs/plans/2026-04-15-onboarding-refactor.md). CLI verbs
 // like `seed`, `init`, `build`, and `slack start` still work but are no
@@ -162,7 +187,33 @@ async function cmdSetup(integration) {
       console.log(`\n  Step 3: Projects directory exists at ${PROJECTS_DIR}`);
     }
 
-    // 4. Summary
+    // 4. Daemon install (macOS only for Phase 2.5a; Linux/Windows stubbed)
+    const daemon = require('./daemon.js');
+    const daemonStatus = daemon.statusSummary();
+    if (daemonStatus.supported && !daemonStatus.installed) {
+      console.log('\n  Step 4: Background daemon');
+      const prompt = createPrompt();
+      const ans = (await prompt.ask('    Keep Rouge dashboard running at login? [Y/n]: ')).trim().toLowerCase();
+      prompt.close();
+      if (ans === '' || ans === 'y' || ans === 'yes') {
+        const r = daemon.install();
+        if (r.ok) {
+          console.log(`    Launch agent installed ✅ (${r.path})`);
+        } else {
+          console.log(`    ⚠️  ${r.reason}`);
+          console.log(`    You can still run the dashboard manually with \`rouge start\`.`);
+        }
+      } else {
+        console.log('    Skipped. Start manually anytime with `rouge start`.');
+      }
+    } else if (daemonStatus.supported && daemonStatus.installed) {
+      console.log('\n  Step 4: Launch agent already installed');
+    } else {
+      console.log(`\n  Step 4: Background daemon — not yet supported on ${daemonStatus.platform} (Phase 2.5b).`);
+      console.log(`          Start manually with \`rouge start\`.`);
+    }
+
+    // 5. Summary
     console.log('\n  ' + '-'.repeat(40));
     console.log('  Setup complete! Next step:');
     console.log('');
@@ -477,6 +528,9 @@ function cmdStatus(name) {
     return;
   }
 
+  // Multi-signal system status first, then all-projects table.
+  printSystemStatus();
+
   // All projects
   if (!fs.existsSync(PROJECTS_DIR)) {
     console.log('\n  No projects directory found.\n');
@@ -501,6 +555,115 @@ function cmdStatus(name) {
     printProjectStatus(projectName, path.join(PROJECTS_DIR, projectName));
   }
   console.log('');
+}
+
+function printSystemStatus() {
+  const daemon = require('./daemon.js');
+  const dash = dashboardLiveness();
+  const d = daemon.statusSummary();
+
+  console.log('');
+  console.log('  System');
+  console.log(`  ${'-'.repeat(60)}`);
+  if (dash.running) {
+    console.log(`  Dashboard:   ✅ running (PID ${dash.pid})   ${DASHBOARD_URL}`);
+    if (dash.pids && dash.pids.started_at) {
+      console.log(`               started ${dash.pids.started_at}${dash.pids.mode ? `, mode ${dash.pids.mode}` : ''}`);
+    }
+  } else {
+    console.log(`  Dashboard:   ❌ not running   (start: \`rouge start\`)`);
+  }
+  if (d.supported) {
+    const tag = d.installed ? (d.loaded ? '✅ installed & loaded' : '⚠️  installed but not loaded') : '○ not installed';
+    console.log(`  Daemon:      ${tag}   (${d.platform})`);
+  } else {
+    console.log(`  Daemon:      — not yet supported on ${d.platform} (Phase 2.5b)`);
+  }
+  console.log('');
+  console.log('  Projects');
+  console.log(`  ${'-'.repeat(60)}`);
+}
+
+function cmdStart() {
+  // Thin wrapper: delegates to `rouge dashboard start` so there's one code path.
+  const child = spawn(process.argv[0], [process.argv[1], 'dashboard', 'start', ...process.argv.slice(3)], {
+    stdio: 'inherit', env: process.env,
+  });
+  child.on('close', (code) => process.exit(code || 0));
+}
+
+function cmdStop() {
+  const child = spawn(process.argv[0], [process.argv[1], 'dashboard', 'stop'], {
+    stdio: 'inherit', env: process.env,
+  });
+  child.on('close', (code) => process.exit(code || 0));
+}
+
+async function cmdUninstall() {
+  const yes = process.argv.includes('--yes') || process.argv.includes('-y');
+  const keepProjects = process.argv.includes('--keep-projects');
+  const daemon = require('./daemon.js');
+
+  console.log('\n  This will remove Rouge from your machine:');
+  console.log(`    - Stop the dashboard if running`);
+  console.log(`    - Unload and remove the launch agent (${daemon.statusSummary().supported ? daemon.platform() : 'n/a'})`);
+  console.log(`    - Remove ${ROUGE_HOME}${keepProjects ? ' (but keep projects/)' : ''}`);
+  console.log(`    - Delete keychain entries for: ${Object.keys(INTEGRATION_KEYS).join(', ')}`);
+  console.log(`\n  It will NOT uninstall the \`rouge\` npm package — run`);
+  console.log(`  \`npm uninstall -g rouge\` yourself if you installed globally.\n`);
+
+  if (!yes) {
+    const prompt = createPrompt();
+    const ans = (await prompt.ask('  Type "uninstall" to confirm: ')).trim();
+    prompt.close();
+    if (ans !== 'uninstall') {
+      console.log('  Aborted.\n');
+      process.exit(0);
+    }
+  }
+
+  // 1. Stop dashboard
+  const live = dashboardLiveness();
+  if (live.running) {
+    process.stdout.write('  Stopping dashboard... ');
+    try { process.kill(live.pid, 'SIGTERM'); console.log('✅'); } catch (err) { console.log(`⚠️  ${err.message}`); }
+  }
+
+  // 2. Remove launch agent
+  const d = daemon.uninstall();
+  if (d.ok) {
+    console.log(`  Launch agent: ${d.removed ? 'removed ✅' : 'nothing to remove'}`);
+  } else {
+    console.log(`  Launch agent: ⚠️  ${d.reason}`);
+  }
+
+  // 3. Delete keychain entries
+  let secretCount = 0;
+  for (const [integration, keys] of Object.entries(INTEGRATION_KEYS)) {
+    for (const key of keys) {
+      try {
+        if (deleteSecret(integration, key)) secretCount++;
+      } catch { /* best-effort */ }
+    }
+  }
+  console.log(`  Keychain:    removed ${secretCount} entr${secretCount === 1 ? 'y' : 'ies'}`);
+
+  // 4. Remove ~/.rouge (or everything except projects/)
+  if (fs.existsSync(ROUGE_HOME)) {
+    if (keepProjects) {
+      const entries = fs.readdirSync(ROUGE_HOME);
+      for (const e of entries) {
+        if (e === 'projects') continue;
+        fs.rmSync(path.join(ROUGE_HOME, e), { recursive: true, force: true });
+      }
+      console.log(`  ${ROUGE_HOME}: cleared (projects/ preserved)`);
+    } else {
+      fs.rmSync(ROUGE_HOME, { recursive: true, force: true });
+      console.log(`  ${ROUGE_HOME}: removed`);
+    }
+  }
+
+  console.log('\n  Rouge uninstalled. To remove the CLI itself: `npm uninstall -g rouge`\n');
 }
 
 function printProjectStatus(name, projectPath) {
@@ -920,6 +1083,15 @@ if (command === 'doctor') {
   cmdBuild(args[1]);
 } else if (command === 'status') {
   cmdStatus(args[1]);
+} else if (command === 'start') {
+  cmdStart();
+} else if (command === 'stop') {
+  cmdStop();
+} else if (command === 'uninstall') {
+  cmdUninstall().catch((err) => {
+    console.error(err.message);
+    process.exit(1);
+  });
 } else if (command === 'cost') {
   cmdCost(args[1]);
 } else if (command === 'setup') {
@@ -989,10 +1161,7 @@ if (command === 'doctor') {
   const dashboardDir = path.join(__dirname, '..', '..', 'dashboard');
   const standaloneServer = path.join(dashboardDir, 'dist', 'server.js');
   const standaloneMarker = path.join(dashboardDir, 'dist', 'ROUGE_STANDALONE');
-  const ROUGE_HOME = process.env.ROUGE_HOME || path.join(require('os').homedir(), '.rouge');
-  const PID_FILE = path.join(ROUGE_HOME, 'dashboard.pid');
-  const DASHBOARD_PORT = parseInt(process.env.ROUGE_DASHBOARD_PORT || '3001', 10);
-  const DASHBOARD_URL = `http://localhost:${DASHBOARD_PORT}`;
+  // ROUGE_HOME, PID_FILE, DASHBOARD_PORT, DASHBOARD_URL now at module scope.
 
   if (!fs.existsSync(dashboardDir)) {
     console.error('Dashboard not found at', dashboardDir);
@@ -1005,9 +1174,7 @@ if (command === 'doctor') {
   const hasPrebuilt = fs.existsSync(standaloneServer) && fs.existsSync(standaloneMarker);
   const hasDevDeps = fs.existsSync(path.join(dashboardDir, 'node_modules', 'next'));
 
-  function readPids() {
-    try { return JSON.parse(fs.readFileSync(PID_FILE, 'utf8')); } catch { return null; }
-  }
+  const readPids = readDashboardPids;
   function writePids(pids) {
     if (!fs.existsSync(ROUGE_HOME)) fs.mkdirSync(ROUGE_HOME, { recursive: true });
     fs.writeFileSync(PID_FILE, JSON.stringify(pids, null, 2) + '\n');
@@ -1015,9 +1182,7 @@ if (command === 'doctor') {
   function clearPids() {
     try { fs.unlinkSync(PID_FILE); } catch {}
   }
-  function isRunning(pid) {
-    try { process.kill(pid, 0); return true; } catch { return false; }
-  }
+  const isRunning = isPidRunning;
   function openBrowser(url) {
     // Cross-platform URL open. Best effort — swallow failures (headless
     // boxes, CI, users who've disabled the default handler).
@@ -1221,21 +1386,20 @@ if (command === 'doctor') {
   The dashboard is the primary control surface. Most users only need the
   commands under SETUP — everything else is power-user / automation territory.
 
-  SETUP
-    rouge setup                     One-time setup (prereqs, deps, projects dir)
+  SETUP & LIFECYCLE
+    rouge setup                     One-time setup (prereqs, deps, projects dir, daemon)
     rouge setup <integration>       Store credentials for an integration
     rouge doctor                    Check prerequisites and dependencies
     rouge dashboard                 Open the dashboard (foreground, auto-opens browser)
-    rouge dashboard start           Start dashboard in background
-    rouge dashboard stop            Stop dashboard
-    rouge dashboard status          Check dashboard status
+    rouge start                     Start the dashboard in the background
+    rouge stop                      Stop the dashboard
+    rouge status                    Show system + project status
+    rouge uninstall                 Remove Rouge files, launch agent, and keychain entries
     rouge dashboard restart         Restart background dashboard
     rouge dashboard install         Install dev deps (source checkouts only)
-    # TODO (Phase 2.5): rouge status / stop / start / uninstall as top-level
-    # lifecycle verbs. Today only \`rouge dashboard <verb>\` is available.
 
   ADVANCED / AUTOMATION
-    rouge status [name]             Show project state summary
+    rouge status <name>             Show state for a single project
     rouge cost <name> [--actual]    Show cost estimate or actuals
     rouge secrets list              List stored secret names
     rouge secrets check <dir>       Check project against stored secrets


### PR DESCRIPTION
## Summary
Phase 2.5a of the onboarding refactor. Makes Rouge's lifecycle visible and manageable without reaching for \`rouge dashboard <verb>\`.

**CLI:**
- \`rouge status\` — now shows system state (dashboard, daemon) plus project table
- \`rouge start\` / \`rouge stop\` — thin wrappers over dashboard lifecycle
- \`rouge uninstall\` — stops dashboard, removes launch agent, clears keychain, removes \`~/.rouge\`. Confirms via typed "uninstall"; \`--yes\` skips, \`--keep-projects\` preserves project dirs.
- \`rouge setup\` asks "Keep Rouge running at login? [Y/n]" (macOS only for 2.5a)
- Help regrouped: lifecycle verbs promoted into SETUP & LIFECYCLE

**Daemon** (\`src/launcher/daemon.js\`, new):
- macOS launch agent at \`~/Library/LaunchAgents/com.rouge.dashboard.plist\`
- install/uninstall via \`launchctl\`, cleans up stale loads
- Linux/Windows return "not supported" — graceful degradation for 2.5b

**Dashboard:**
- \`POST /api/system/shutdown\` — responds 200 then exits on next tick
- Power-icon button in top-right nav with confirm dialog; shows "Rouge stopped" state after

## Explicitly NOT in 2.5a
Per plan decisions (docs/plans/2026-04-15-onboarding-refactor.md):
- Idle auto-shutdown — explicitly rejected
- Linux/Windows daemon parity — Phase 2.5b
- Menubar/tray icon — deferred
- Build-in-progress shutdown warning — nice-to-have, later phase

## Test plan
- [x] \`npm test\` — 285/285 pass
- [x] \`npx tsc --noEmit\` in dashboard — clean
- [x] \`rouge status\` shows system + projects
- [x] \`rouge uninstall\` confirms before acting; \`no\` aborts cleanly
- [ ] Manual: \`rouge setup\` installs launch agent on macOS login
- [ ] Manual: dashboard Power button triggers shutdown, shows "stopped" message
- [ ] Manual: \`launchctl list | grep com.rouge\` after setup
- [ ] Manual: \`rouge uninstall\` leaves no keychain entries, no plist, no \`~/.rouge\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)