### PR TITLE
setup wizard: secrets + daemon steps + APIs (Phase 3b)

### DIFF
--- a/dashboard/src/app/api/system/daemon/route.ts
+++ b/dashboard/src/app/api/system/daemon/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from "next/server";
+import { assertLoopback } from "@/lib/localhost-guard";
+import { requireLauncher } from "@/lib/launcher-bridge";
+
+export const dynamic = "force-dynamic";
+
+// GET /api/system/daemon
+// Returns the launch-agent/daemon status. Localhost-only.
+export async function GET() {
+  const forbidden = await assertLoopback();
+  if (forbidden) return forbidden;
+
+  try {
+    const daemon = requireLauncher("daemon.js");
+    return NextResponse.json(daemon.statusSummary());
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+// POST /api/system/daemon
+// Installs the launch agent (macOS) / returns "not supported" otherwise.
+// Localhost-only.
+export async function POST() {
+  const forbidden = await assertLoopback();
+  if (forbidden) return forbidden;
+
+  try {
+    const daemon = requireLauncher("daemon.js");
+    const result = daemon.install();
+    const status = result.ok ? 200 : 400;
+    return NextResponse.json(result, { status });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+// DELETE /api/system/daemon
+// Unloads and removes the launch agent. Localhost-only.
+export async function DELETE() {
+  const forbidden = await assertLoopback();
+  if (forbidden) return forbidden;
+
+  try {
+    const daemon = requireLauncher("daemon.js");
+    const result = daemon.uninstall();
+    const status = result.ok ? 200 : 400;
+    return NextResponse.json(result, { status });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/dashboard/src/app/api/system/secrets/route.ts
+++ b/dashboard/src/app/api/system/secrets/route.ts
@@ -1,0 +1,79 @@
+import { NextResponse } from "next/server";
+import { assertLoopback } from "@/lib/localhost-guard";
+import { requireLauncher } from "@/lib/launcher-bridge";
+
+export const dynamic = "force-dynamic";
+
+// GET /api/system/secrets
+// Returns which integrations have which keys stored. NEVER returns values —
+// only presence. Localhost-only.
+export async function GET() {
+  const forbidden = await assertLoopback();
+  if (forbidden) return forbidden;
+
+  try {
+    const secrets = requireLauncher("secrets.js");
+    const integrations: Record<string, Record<string, boolean>> = {};
+    for (const [integration, keys] of Object.entries(secrets.INTEGRATION_KEYS) as [string, string[]][]) {
+      integrations[integration] = {};
+      for (const key of keys) {
+        integrations[integration][key] = !!secrets.getSecret(integration, key);
+      }
+    }
+    return NextResponse.json({ integrations });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+// POST /api/system/secrets
+// Body: { integration: 'stripe', key: 'STRIPE_SECRET_KEY', value: 'sk_...' }
+// Writes to the OS keychain via the launcher's secrets backend. Localhost-only.
+export async function POST(request: Request) {
+  const forbidden = await assertLoopback();
+  if (forbidden) return forbidden;
+
+  try {
+    const body = (await request.json()) as { integration?: string; key?: string; value?: string };
+    if (!body.integration || !body.key || typeof body.value !== "string") {
+      return NextResponse.json({ error: "integration, key, and value are required" }, { status: 400 });
+    }
+    const secrets = requireLauncher("secrets.js");
+    const allowedKeys = (secrets.INTEGRATION_KEYS[body.integration] ?? []) as string[];
+    if (!allowedKeys.includes(body.key)) {
+      return NextResponse.json({ error: `Unknown key ${body.key} for integration ${body.integration}` }, { status: 400 });
+    }
+    // Refuse empty strings — users hit "Save" with a blank field by accident.
+    if (body.value.length === 0) {
+      return NextResponse.json({ error: "value must not be empty (use DELETE to clear)" }, { status: 400 });
+    }
+    secrets.storeSecret(body.integration, body.key, body.value);
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+// DELETE /api/system/secrets?integration=...&key=...
+// Removes a single keychain entry. Localhost-only.
+export async function DELETE(request: Request) {
+  const forbidden = await assertLoopback();
+  if (forbidden) return forbidden;
+
+  try {
+    const url = new URL(request.url);
+    const integration = url.searchParams.get("integration");
+    const key = url.searchParams.get("key");
+    if (!integration || !key) {
+      return NextResponse.json({ error: "integration and key are required query params" }, { status: 400 });
+    }
+    const secrets = requireLauncher("secrets.js");
+    const removed = secrets.deleteSecret(integration, key);
+    return NextResponse.json({ ok: true, removed });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/dashboard/src/components/setup/daemon-step.tsx
+++ b/dashboard/src/components/setup/daemon-step.tsx
@@ -1,0 +1,157 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { CheckCircle2, Loader2, Power, Trash2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+interface DaemonStatus {
+  platform: 'macos' | 'linux' | 'windows' | 'unsupported'
+  supported: boolean
+  installed: boolean
+  loaded?: boolean
+  path?: string
+}
+
+export function DaemonStep({ onReady }: { onReady: (ready: boolean) => void }) {
+  const [status, setStatus] = useState<DaemonStatus | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function load() {
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await fetch('/api/system/daemon')
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      setStatus(await res.json())
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    load()
+    onReady(true)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  async function install() {
+    setBusy(true)
+    setError(null)
+    try {
+      const res = await fetch('/api/system/daemon', { method: 'POST' })
+      const body = await res.json()
+      if (!res.ok || !body.ok) throw new Error(body.reason ?? `HTTP ${res.status}`)
+      await load()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function uninstall() {
+    setBusy(true)
+    setError(null)
+    try {
+      const res = await fetch('/api/system/daemon', { method: 'DELETE' })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      await load()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="text-xl font-semibold text-foreground">Background daemon</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Keep the Rouge dashboard running in the background so it's there when you need it.
+          Install once and it auto-starts at login. Shut down anytime via the Power icon in the nav.
+        </p>
+      </div>
+
+      {error && (
+        <div className="rounded-md border border-red-300 bg-red-50 p-4 text-sm text-red-800">
+          <strong>Error:</strong> {error}
+        </div>
+      )}
+
+      {loading && !status && (
+        <div className="flex items-center gap-2 rounded-md border border-border bg-muted/30 p-4 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" /> Checking daemon status…
+        </div>
+      )}
+
+      {status && !status.supported && (
+        <div className="rounded-md border border-amber-300 bg-amber-50 p-4 text-sm text-amber-900">
+          Background daemon isn&apos;t supported on <strong>{status.platform}</strong> yet (planned for Phase 2.5b).
+          You can still run the dashboard manually with <code className="rounded bg-amber-100 px-1">rouge start</code>.
+        </div>
+      )}
+
+      {status && status.supported && (
+        <div className={cn(
+          'rounded-lg border p-4',
+          status.installed && status.loaded && 'border-green-300 bg-green-50',
+          status.installed && !status.loaded && 'border-amber-300 bg-amber-50',
+          !status.installed && 'border-border bg-card',
+        )}>
+          <div className="flex items-start justify-between gap-4">
+            <div className="space-y-1">
+              {status.installed && status.loaded && (
+                <div className="flex items-center gap-2 text-green-800">
+                  <CheckCircle2 className="h-5 w-5" />
+                  <span className="font-medium">Installed and loaded</span>
+                </div>
+              )}
+              {status.installed && !status.loaded && (
+                <div className="text-amber-900">
+                  <span className="font-medium">Installed but not loaded</span>
+                  <p className="mt-0.5 text-xs">Reinstall to reload.</p>
+                </div>
+              )}
+              {!status.installed && (
+                <div className="text-foreground">
+                  <span className="font-medium">Not installed</span>
+                  <p className="mt-0.5 text-sm text-muted-foreground">
+                    Dashboard won&apos;t auto-start at login. Start manually with <code className="rounded bg-muted px-1">rouge start</code>.
+                  </p>
+                </div>
+              )}
+              {status.path && (
+                <p className="mt-2 text-xs text-muted-foreground font-mono break-all">{status.path}</p>
+              )}
+            </div>
+            <div className="flex shrink-0 gap-2">
+              {!status.installed && (
+                <Button onClick={install} disabled={busy}>
+                  {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Power className="h-4 w-4" />}
+                  <span className="ml-2">Install daemon</span>
+                </Button>
+              )}
+              {status.installed && (
+                <>
+                  <Button variant="outline" onClick={install} disabled={busy} title="Reload the launch agent">
+                    {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Power className="h-4 w-4" />}
+                    <span className="ml-2">Reinstall</span>
+                  </Button>
+                  <Button variant="ghost" onClick={uninstall} disabled={busy} title="Remove the launch agent">
+                    <Trash2 className="h-4 w-4 text-red-600" />
+                  </Button>
+                </>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/dashboard/src/components/setup/secrets-step.tsx
+++ b/dashboard/src/components/setup/secrets-step.tsx
@@ -1,0 +1,204 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Check, Loader2, Save, Trash2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+type IntegrationMap = Record<string, Record<string, boolean>>
+
+// Keep Slack out — it lives in its own step (Phase 4 wizard).
+const CORE_INTEGRATIONS = ['stripe', 'supabase', 'sentry', 'cloudflare', 'vercel']
+
+const INTEGRATION_BLURBS: Record<string, string> = {
+  stripe: 'Payments. Needed if a Rouge-built product takes money.',
+  supabase: 'Postgres + auth. Default database for most builds.',
+  sentry: 'Error tracking for deployed products.',
+  cloudflare: 'DNS and edge. Optional — for custom domains.',
+  vercel: 'Deployment target. Needed for Vercel-hosted products.',
+}
+
+export function SecretsStep({ onReady }: { onReady: (ready: boolean) => void }) {
+  const [integrations, setIntegrations] = useState<IntegrationMap>({})
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [drafts, setDrafts] = useState<Record<string, string>>({})
+  const [saving, setSaving] = useState<string | null>(null)
+  const [savedBanner, setSavedBanner] = useState<string | null>(null)
+
+  async function load() {
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await fetch('/api/system/secrets')
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      const data = await res.json()
+      setIntegrations(data.integrations ?? {})
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    load()
+    // Secrets are optional for continuing — mark ready immediately.
+    onReady(true)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  async function save(integration: string, key: string) {
+    const value = drafts[`${integration}.${key}`]
+    if (!value) return
+    setSaving(`${integration}.${key}`)
+    try {
+      const res = await fetch('/api/system/secrets', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ integration, key, value }),
+      })
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}))
+        throw new Error(body.error ?? `HTTP ${res.status}`)
+      }
+      setDrafts((d) => ({ ...d, [`${integration}.${key}`]: '' }))
+      setSavedBanner(`${integration} · ${key} saved`)
+      setTimeout(() => setSavedBanner(null), 2500)
+      await load()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setSaving(null)
+    }
+  }
+
+  async function remove(integration: string, key: string) {
+    setSaving(`${integration}.${key}`)
+    try {
+      const params = new URLSearchParams({ integration, key })
+      const res = await fetch(`/api/system/secrets?${params}`, { method: 'DELETE' })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      await load()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setSaving(null)
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="text-xl font-semibold text-foreground">Integrations</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Optional. Store API keys for the integrations Rouge can wire into products.
+          Values go to your OS keychain under the <code className="rounded bg-muted px-1">rouge-*</code> prefix —
+          your personal keychain entries are not touched. You can add these later.
+        </p>
+      </div>
+
+      {error && (
+        <div className="rounded-md border border-red-300 bg-red-50 p-4 text-sm text-red-800">
+          <strong>Error:</strong> {error}
+        </div>
+      )}
+
+      {savedBanner && (
+        <div className="rounded-md border border-green-300 bg-green-50 p-3 text-sm text-green-800">
+          <Check className="inline h-4 w-4 mr-1" />
+          {savedBanner}
+        </div>
+      )}
+
+      {loading && Object.keys(integrations).length === 0 && (
+        <div className="flex items-center gap-2 rounded-md border border-border bg-muted/30 p-4 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" /> Loading integrations…
+        </div>
+      )}
+
+      <div className="space-y-3">
+        {CORE_INTEGRATIONS.map((integration) => {
+          const keys = integrations[integration]
+          if (!keys) return null
+          const storedCount = Object.values(keys).filter(Boolean).length
+          const totalCount = Object.keys(keys).length
+          return (
+            <details
+              key={integration}
+              className="group rounded-lg border border-border bg-card open:shadow-sm"
+              open={storedCount > 0 && storedCount < totalCount}
+            >
+              <summary className="flex cursor-pointer items-center justify-between gap-3 p-4 list-none">
+                <div>
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium capitalize text-foreground">{integration}</span>
+                    <span className={cn(
+                      'rounded-full px-2 py-0.5 text-xs font-medium',
+                      storedCount === totalCount && 'bg-green-100 text-green-800',
+                      storedCount > 0 && storedCount < totalCount && 'bg-amber-100 text-amber-800',
+                      storedCount === 0 && 'bg-muted text-muted-foreground',
+                    )}>
+                      {storedCount}/{totalCount} stored
+                    </span>
+                  </div>
+                  <p className="mt-0.5 text-xs text-muted-foreground">
+                    {INTEGRATION_BLURBS[integration]}
+                  </p>
+                </div>
+                <span className="text-xs text-muted-foreground group-open:rotate-90 transition-transform">▶</span>
+              </summary>
+
+              <div className="border-t border-border p-4 space-y-3">
+                {Object.entries(keys).map(([key, stored]) => {
+                  const draftKey = `${integration}.${key}`
+                  const isSaving = saving === draftKey
+                  return (
+                    <div key={key} className="space-y-1.5">
+                      <div className="flex items-center justify-between gap-2">
+                        <label className="text-sm font-medium font-mono text-foreground">{key}</label>
+                        {stored && (
+                          <span className="flex items-center gap-1 text-xs text-green-700">
+                            <Check className="h-3 w-3" /> stored
+                          </span>
+                        )}
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <input
+                          type="password"
+                          autoComplete="off"
+                          placeholder={stored ? '(value stored — paste new to replace)' : 'paste value'}
+                          value={drafts[draftKey] ?? ''}
+                          onChange={(e) => setDrafts((d) => ({ ...d, [draftKey]: e.target.value }))}
+                          className="flex-1 rounded-md border border-border bg-background px-3 py-1.5 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-ring"
+                        />
+                        <Button
+                          size="sm"
+                          onClick={() => save(integration, key)}
+                          disabled={!drafts[draftKey] || isSaving}
+                        >
+                          {isSaving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
+                        </Button>
+                        {stored && (
+                          <Button
+                            size="sm"
+                            variant="ghost"
+                            onClick={() => remove(integration, key)}
+                            disabled={isSaving}
+                            title="Delete stored value"
+                          >
+                            <Trash2 className="h-4 w-4 text-red-600" />
+                          </Button>
+                        )}
+                      </div>
+                    </div>
+                  )
+                })}
+              </div>
+            </details>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/dashboard/src/components/setup/setup-wizard.tsx
+++ b/dashboard/src/components/setup/setup-wizard.tsx
@@ -6,20 +6,43 @@ import { Check } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { DoctorStep } from './doctor-step'
+import { SecretsStep } from './secrets-step'
+import { DaemonStep } from './daemon-step'
 
-// Phase 3a ships the wizard shell + the doctor (prereqs) step only.
-// Phases 3b and 3c will fill in Secrets, Slack, Daemon, and Finish.
-const steps = [
-  { id: 'prereqs', label: 'Prerequisites', status: 'active' as const },
-  { id: 'secrets', label: 'Integrations', status: 'coming-soon' as const },
-  { id: 'slack', label: 'Slack (optional)', status: 'coming-soon' as const },
-  { id: 'daemon', label: 'Background daemon', status: 'coming-soon' as const },
-  { id: 'finish', label: 'Create first project', status: 'coming-soon' as const },
+type StepId = 'prereqs' | 'secrets' | 'slack' | 'daemon' | 'finish'
+
+interface Step {
+  id: StepId
+  label: string
+  comingSoon?: boolean
+}
+
+const steps: Step[] = [
+  { id: 'prereqs', label: 'Prerequisites' },
+  { id: 'secrets', label: 'Integrations' },
+  { id: 'slack', label: 'Slack (optional)', comingSoon: true },
+  { id: 'daemon', label: 'Background daemon' },
+  { id: 'finish', label: 'Create first project', comingSoon: true },
 ]
 
 export function SetupWizard() {
-  const [activeId, setActiveId] = useState('prereqs')
-  const [prereqsReady, setPrereqsReady] = useState(false)
+  const [activeIdx, setActiveIdx] = useState(0)
+  const [readyMap, setReadyMap] = useState<Record<StepId, boolean>>({
+    prereqs: false, secrets: false, slack: false, daemon: false, finish: false,
+  })
+
+  const active = steps[activeIdx]
+  const canAdvance = readyMap[active.id]
+
+  function goTo(idx: number) {
+    if (idx < 0 || idx >= steps.length) return
+    if (steps[idx].comingSoon) return
+    setActiveIdx(idx)
+  }
+
+  function markReady(id: StepId, ready: boolean) {
+    setReadyMap((m) => ({ ...m, [id]: ready }))
+  }
 
   return (
     <div className="mx-auto w-full max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
@@ -34,20 +57,20 @@ export function SetupWizard() {
       {/* Step indicator */}
       <nav className="mb-8 flex flex-wrap items-center gap-2" aria-label="Setup progress">
         {steps.map((step, i) => {
-          const isActive = step.id === activeId
-          const isDone = step.id === 'prereqs' && prereqsReady
-          const isComingSoon = step.status === 'coming-soon'
+          const isActive = i === activeIdx
+          const isDone = readyMap[step.id] && i !== activeIdx
+          const disabled = step.comingSoon
           return (
             <div key={step.id} className="flex items-center gap-2">
               <button
                 type="button"
-                disabled={isComingSoon}
-                onClick={() => !isComingSoon && setActiveId(step.id)}
+                disabled={disabled}
+                onClick={() => goTo(i)}
                 className={cn(
                   'flex items-center gap-2 rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
                   isActive && 'bg-accent text-accent-foreground',
-                  !isActive && !isComingSoon && 'text-muted-foreground hover:bg-accent/50 hover:text-foreground',
-                  isComingSoon && 'cursor-not-allowed text-muted-foreground/50',
+                  !isActive && !disabled && 'text-muted-foreground hover:bg-accent/50 hover:text-foreground',
+                  disabled && 'cursor-not-allowed text-muted-foreground/50',
                 )}
               >
                 <span className={cn(
@@ -59,7 +82,7 @@ export function SetupWizard() {
                   {isDone ? <Check className="h-3 w-3" /> : i + 1}
                 </span>
                 {step.label}
-                {isComingSoon && <span className="text-xs opacity-70">(soon)</span>}
+                {disabled && <span className="text-xs opacity-70">(soon)</span>}
               </button>
               {i < steps.length - 1 && <span className="text-muted-foreground/40">→</span>}
             </div>
@@ -69,7 +92,9 @@ export function SetupWizard() {
 
       {/* Step body */}
       <div className="rounded-xl border border-border bg-background p-6 shadow-sm">
-        {activeId === 'prereqs' && <DoctorStep onReady={setPrereqsReady} />}
+        {active.id === 'prereqs' && <DoctorStep onReady={(r) => markReady('prereqs', r)} />}
+        {active.id === 'secrets' && <SecretsStep onReady={(r) => markReady('secrets', r)} />}
+        {active.id === 'daemon' && <DaemonStep onReady={(r) => markReady('daemon', r)} />}
       </div>
 
       {/* Footer actions */}
@@ -78,20 +103,32 @@ export function SetupWizard() {
           ← Back to dashboard
         </Link>
         <div className="flex items-center gap-3">
-          {!prereqsReady && (
-            <span className="text-xs text-muted-foreground">
-              Fix the red items above to continue.
-            </span>
+          {activeIdx > 0 && (
+            <Button variant="outline" onClick={() => {
+              // Skip any "coming-soon" steps when going back.
+              let i = activeIdx - 1
+              while (i >= 0 && steps[i].comingSoon) i--
+              if (i >= 0) setActiveIdx(i)
+            }}>
+              Back
+            </Button>
           )}
-          <Button disabled title="Coming in Phase 3b">
-            Next: Integrations
-          </Button>
+          {activeIdx < steps.length - 1 && (
+            <Button
+              onClick={() => {
+                // Skip any "coming-soon" steps when advancing.
+                let i = activeIdx + 1
+                while (i < steps.length && steps[i].comingSoon) i++
+                if (i < steps.length) setActiveIdx(i)
+              }}
+              disabled={!canAdvance}
+              title={!canAdvance && active.id === 'prereqs' ? 'Fix the red items above first' : undefined}
+            >
+              Next
+            </Button>
+          )}
         </div>
       </div>
-
-      <p className="mt-8 text-center text-xs text-muted-foreground">
-        Phase 3a: prerequisite check only. Integrations, Slack, daemon, and first-project steps land in upcoming phases.
-      </p>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
Adds two working wizard steps (Integrations, Daemon) with their backing APIs.

## What's in
- \`/api/system/secrets\` GET/POST/DELETE — presence only on GET (never values)
- \`/api/system/daemon\` GET/POST/DELETE — delegates to launcher daemon.js
- Secrets step: collapsible panels for Stripe/Supabase/Sentry/Cloudflare/Vercel with save/delete
- Daemon step: status + Install/Reinstall/Uninstall; handles non-macOS gracefully
- Wizard: Back/Next nav; skips "(soon)" steps automatically
- All endpoints gated by \`assertLoopback()\`

## Not in this PR (Phase 3c next)
- First-project step
- \`~/.rouge/setup-complete\` marker + auto-redirect for first-time users

## Test plan
- [x] 285/285 CLI tests
- [x] Dashboard typechecks
- [x] Build includes new routes
- [x] Secrets GET returns boolean presence map
- [x] Daemon GET reflects current launch-agent state
- [ ] Manual: wizard Next/Back navigation, save a test secret, install/uninstall daemon

🤖 Generated with [Claude Code](https://claude.com/claude-code)