### PR TITLE
setup wizard: finish step + first-run redirect (Phase 3c)

### DIFF
--- a/dashboard/src/app/api/system/setup-state/route.ts
+++ b/dashboard/src/app/api/system/setup-state/route.ts
@@ -1,0 +1,82 @@
+import { NextResponse } from "next/server";
+import { assertLoopback } from "@/lib/localhost-guard";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+
+export const dynamic = "force-dynamic";
+
+// ~/.rouge/setup-complete is written by the wizard's "Finish" step.
+// The file is JSON: { completedAt, skipped, version }. Root layout
+// reads it to decide whether to auto-redirect to /setup.
+function markerPath(): string {
+  const home = process.env.ROUGE_HOME ?? path.join(homedir(), ".rouge");
+  return path.join(home, "setup-complete");
+}
+
+interface MarkerContent {
+  completedAt: string;
+  skipped: boolean;
+  version: number;
+}
+
+// GET /api/system/setup-state
+// Returns { complete: boolean, marker?: MarkerContent }.
+export async function GET() {
+  const forbidden = await assertLoopback();
+  if (forbidden) return forbidden;
+
+  const p = markerPath();
+  if (!existsSync(p)) return NextResponse.json({ complete: false });
+
+  try {
+    const marker = JSON.parse(readFileSync(p, "utf-8")) as MarkerContent;
+    return NextResponse.json({ complete: true, marker });
+  } catch {
+    // Malformed marker — treat as not set so user can redo setup.
+    return NextResponse.json({ complete: false });
+  }
+}
+
+// POST /api/system/setup-state
+// Body: { skipped?: boolean } — writes the marker.
+export async function POST(request: Request) {
+  const forbidden = await assertLoopback();
+  if (forbidden) return forbidden;
+
+  try {
+    const body = (await request.json().catch(() => ({}))) as { skipped?: boolean };
+    const p = markerPath();
+    mkdirSync(path.dirname(p), { recursive: true });
+    const content: MarkerContent = {
+      completedAt: new Date().toISOString(),
+      skipped: !!body.skipped,
+      version: 1,
+    };
+    writeFileSync(p, JSON.stringify(content, null, 2) + "\n", { mode: 0o644 });
+    return NextResponse.json({ ok: true, marker: content });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+// DELETE /api/system/setup-state
+// Removes the marker (re-enters first-time mode). Useful for testing and
+// for a future "Redo setup" action.
+export async function DELETE() {
+  const forbidden = await assertLoopback();
+  if (forbidden) return forbidden;
+
+  try {
+    const p = markerPath();
+    if (existsSync(p)) {
+      const { unlinkSync } = await import("node:fs");
+      unlinkSync(p);
+    }
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -1,5 +1,7 @@
+import { redirect } from 'next/navigation'
 import { projects as mockProjects } from '@/data/projects'
 import { isBridgeEnabled, fetchBridgeProjects } from '@/lib/bridge-client'
+import { isSetupComplete } from '@/lib/setup-state'
 import type { ProjectSummary, ProjectState, Provider } from '@/lib/types'
 import { ProjectCard } from '@/components/project-card'
 import { TopBar } from '@/components/top-bar'
@@ -119,6 +121,13 @@ function sortByUpdated(list: ProjectSummary[]): ProjectSummary[] {
 }
 
 export default async function Home() {
+  // First-time users: no setup-complete marker yet → send them to /setup.
+  // Returning users (marker exists, even if skipped) see the dashboard.
+  // Re-enter /setup anytime via the nav link.
+  if (!isSetupComplete()) {
+    redirect('/setup')
+  }
+
   const { projects, error } = await getProjects()
 
   return (

--- a/dashboard/src/components/setup/finish-step.tsx
+++ b/dashboard/src/components/setup/finish-step.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Loader2, Rocket } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+
+export function FinishStep({ onReady }: { onReady: (ready: boolean) => void }) {
+  const router = useRouter()
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Always "ready" — the whole point of this step is to finish.
+  if (!busy) onReady(true)
+
+  async function finish(skipped: boolean) {
+    setBusy(true)
+    setError(null)
+    try {
+      const res = await fetch('/api/system/setup-state', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ skipped }),
+      })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      // Go to the dashboard home (which will no longer redirect).
+      router.push('/')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="text-xl font-semibold text-foreground">You&apos;re ready</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Click <strong>Finish</strong> to go to the dashboard and create your first project.
+          You can come back to this wizard anytime from the nav.
+        </p>
+      </div>
+
+      {error && (
+        <div className="rounded-md border border-red-300 bg-red-50 p-4 text-sm text-red-800">
+          <strong>Error:</strong> {error}
+        </div>
+      )}
+
+      <div className="rounded-lg border border-border bg-card p-6">
+        <div className="flex items-start gap-4">
+          <Rocket className="h-8 w-8 text-red-500 shrink-0" />
+          <div className="flex-1">
+            <p className="text-sm text-foreground">
+              From here, the fastest path is the <strong>New Project</strong> button on the dashboard.
+              It&apos;ll walk you through naming and seeding your first product.
+            </p>
+            <p className="mt-3 text-xs text-muted-foreground">
+              Seeding usually takes 10–20 minutes of back-and-forth with Claude.
+              You can leave it running and check back.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2 sm:flex-row sm:justify-between">
+        <Button variant="ghost" onClick={() => finish(true)} disabled={busy}>
+          Skip for now
+        </Button>
+        <Button onClick={() => finish(false)} disabled={busy} className="sm:w-auto">
+          {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Rocket className="h-4 w-4" />}
+          <span className="ml-2">Finish & go to dashboard</span>
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/dashboard/src/components/setup/setup-wizard.tsx
+++ b/dashboard/src/components/setup/setup-wizard.tsx
@@ -8,6 +8,7 @@ import { cn } from '@/lib/utils'
 import { DoctorStep } from './doctor-step'
 import { SecretsStep } from './secrets-step'
 import { DaemonStep } from './daemon-step'
+import { FinishStep } from './finish-step'
 
 type StepId = 'prereqs' | 'secrets' | 'slack' | 'daemon' | 'finish'
 
@@ -22,7 +23,7 @@ const steps: Step[] = [
   { id: 'secrets', label: 'Integrations' },
   { id: 'slack', label: 'Slack (optional)', comingSoon: true },
   { id: 'daemon', label: 'Background daemon' },
-  { id: 'finish', label: 'Create first project', comingSoon: true },
+  { id: 'finish', label: 'Finish' },
 ]
 
 export function SetupWizard() {
@@ -46,12 +47,28 @@ export function SetupWizard() {
 
   return (
     <div className="mx-auto w-full max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
-      <header className="mb-8">
-        <h1 className="text-3xl font-bold tracking-tight text-foreground">Set up Rouge</h1>
-        <p className="mt-2 text-sm text-muted-foreground">
-          One-time setup — takes under 5 minutes. You can come back to this page
-          anytime from the nav.
-        </p>
+      <header className="mb-8 flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight text-foreground">Set up Rouge</h1>
+          <p className="mt-2 text-sm text-muted-foreground">
+            One-time setup — takes under 5 minutes. You can come back to this page
+            anytime from the nav.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={async () => {
+            await fetch('/api/system/setup-state', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ skipped: true }),
+            })
+            window.location.href = '/'
+          }}
+          className="shrink-0 text-sm text-muted-foreground hover:text-foreground underline underline-offset-4"
+        >
+          Skip for now
+        </button>
       </header>
 
       {/* Step indicator */}
@@ -95,6 +112,7 @@ export function SetupWizard() {
         {active.id === 'prereqs' && <DoctorStep onReady={(r) => markReady('prereqs', r)} />}
         {active.id === 'secrets' && <SecretsStep onReady={(r) => markReady('secrets', r)} />}
         {active.id === 'daemon' && <DaemonStep onReady={(r) => markReady('daemon', r)} />}
+        {active.id === 'finish' && <FinishStep onReady={(r) => markReady('finish', r)} />}
       </div>
 
       {/* Footer actions */}

--- a/dashboard/src/lib/setup-state.ts
+++ b/dashboard/src/lib/setup-state.ts
@@ -1,0 +1,28 @@
+// Server-side helpers for reading the ~/.rouge/setup-complete marker
+// without going through HTTP. Used by the root page for first-time redirect.
+
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+
+export interface SetupMarker {
+  completedAt: string;
+  skipped: boolean;
+  version: number;
+}
+
+export function setupMarkerPath(): string {
+  const home = process.env.ROUGE_HOME ?? path.join(homedir(), ".rouge");
+  return path.join(home, "setup-complete");
+}
+
+export function isSetupComplete(): boolean {
+  const p = setupMarkerPath();
+  if (!existsSync(p)) return false;
+  try {
+    JSON.parse(readFileSync(p, "utf-8"));
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
Completes the first-run onboarding loop: first-time users land in \`/setup\` automatically; the Finish step writes a marker that flips root back to the dashboard.

## What's in
- \`/api/system/setup-state\` — GET/POST/DELETE on \`~/.rouge/setup-complete\` marker
- \`lib/setup-state.ts\` — in-process reader for Server Components
- \`app/page.tsx\` — redirects to \`/setup\` when no marker exists
- Finish step: "Finish & go to dashboard" + "Skip for now"
- Persistent "Skip for now" link in wizard header (any step)

## Flow
1. First launch: \`/\` → redirect to \`/setup\`
2. Prereqs → Integrations → Daemon → Finish
3. Finish writes marker → routes to \`/\` which now serves dashboard
4. Returning users land on \`/\` directly; /setup reachable via nav
5. DELETE endpoint resets to first-time (for testing + future "Redo setup")

## Verified end-to-end
- [x] No marker → 307 redirect
- [x] POST writes marker, GET returns \`{ complete: true, marker }\`
- [x] Root serves 200 once marker exists
- [x] Skipped flag round-trips
- [x] 285/285 CLI tests, dashboard typechecks

## Phase 3 complete
With 3c merged, Phase 3 of the onboarding refactor is done. Next: Phase 4 (Slack setup wizard), Phase 5 (integrations + budget panels), Phase 6 (docs restructure + CI checks), Phase 7 (self-documenting inline help).

🤖 Generated with [Claude Code](https://claude.com/claude-code)