### PR TITLE
setup wizard: Slack step with copy-paste-validate flow (Phase 4)

### DIFF
--- a/dashboard/src/app/api/system/slack/manifest/route.ts
+++ b/dashboard/src/app/api/system/slack/manifest/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+import { assertLoopback } from "@/lib/localhost-guard";
+import { rougeSrcDir } from "@/lib/launcher-bridge";
+import { readFileSync, existsSync } from "node:fs";
+import path from "node:path";
+
+export const dynamic = "force-dynamic";
+
+// GET /api/system/slack/manifest
+// Returns the Slack app manifest YAML for copy-paste into the Slack app
+// creator. Sourced from src/slack/manifest.yaml — single source of truth.
+export async function GET() {
+  const forbidden = await assertLoopback();
+  if (forbidden) return forbidden;
+
+  try {
+    const manifestPath = path.join(rougeSrcDir(), "slack", "manifest.yaml");
+    if (!existsSync(manifestPath)) {
+      return NextResponse.json({ error: "manifest.yaml not found", path: manifestPath }, { status: 500 });
+    }
+    const yaml = readFileSync(manifestPath, "utf-8");
+    return NextResponse.json({ yaml, path: manifestPath });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/dashboard/src/app/api/system/slack/test-webhook/route.ts
+++ b/dashboard/src/app/api/system/slack/test-webhook/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from "next/server";
+import { assertLoopback } from "@/lib/localhost-guard";
+
+export const dynamic = "force-dynamic";
+
+// POST /api/system/slack/test-webhook
+// Body: { webhookUrl: string }
+// Sends a real "Rouge setup test" message to the webhook. Returns
+// { ok: true } if Slack returned "ok" (200), else the error text.
+export async function POST(request: Request) {
+  const forbidden = await assertLoopback();
+  if (forbidden) return forbidden;
+
+  try {
+    const { webhookUrl } = (await request.json()) as { webhookUrl?: string };
+    if (!webhookUrl) {
+      return NextResponse.json({ ok: false, error: "webhookUrl is required" }, { status: 400 });
+    }
+    if (!webhookUrl.startsWith("https://hooks.slack.com/")) {
+      return NextResponse.json({
+        ok: false,
+        error: "Webhook URLs start with https://hooks.slack.com/. Check Incoming Webhooks in your Slack app settings.",
+      }, { status: 400 });
+    }
+
+    const res = await fetch(webhookUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        text: "✅ Rouge setup test — if you can read this, your webhook works.",
+      }),
+    });
+
+    if (res.ok) {
+      return NextResponse.json({ ok: true });
+    }
+    const errorText = await res.text();
+    return NextResponse.json({ ok: false, error: errorText || `HTTP ${res.status}` }, { status: 400 });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}

--- a/dashboard/src/app/api/system/slack/validate/route.ts
+++ b/dashboard/src/app/api/system/slack/validate/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from "next/server";
+import { assertLoopback } from "@/lib/localhost-guard";
+
+export const dynamic = "force-dynamic";
+
+// POST /api/system/slack/validate
+// Body: { botToken?: string, appToken?: string }
+// Bot token (xoxb-) is validated against Slack's auth.test — returns workspace name.
+// App token (xapp-) has no cheap validation endpoint; we only sanity-check the prefix.
+export async function POST(request: Request) {
+  const forbidden = await assertLoopback();
+  if (forbidden) return forbidden;
+
+  try {
+    const { botToken, appToken } = (await request.json()) as {
+      botToken?: string;
+      appToken?: string;
+    };
+
+    const result: {
+      bot?: { ok: boolean; team?: string; user?: string; error?: string };
+      app?: { ok: boolean; error?: string };
+    } = {};
+
+    if (botToken !== undefined) {
+      if (!botToken.startsWith("xoxb-")) {
+        result.bot = { ok: false, error: "Bot tokens start with xoxb-. Check OAuth & Permissions → Bot User OAuth Token." };
+      } else {
+        try {
+          const res = await fetch("https://slack.com/api/auth.test", {
+            method: "POST",
+            headers: {
+              Authorization: `Bearer ${botToken}`,
+              "Content-Type": "application/x-www-form-urlencoded",
+            },
+          });
+          const body = (await res.json()) as { ok: boolean; team?: string; user?: string; error?: string };
+          if (body.ok) {
+            result.bot = { ok: true, team: body.team, user: body.user };
+          } else {
+            result.bot = { ok: false, error: body.error ?? "auth.test returned ok=false" };
+          }
+        } catch (err) {
+          result.bot = { ok: false, error: err instanceof Error ? err.message : String(err) };
+        }
+      }
+    }
+
+    if (appToken !== undefined) {
+      if (!appToken.startsWith("xapp-")) {
+        result.app = { ok: false, error: "App tokens start with xapp-. Generate one under Basic Information → App-Level Tokens." };
+      } else {
+        // App tokens don't have a cheap validation endpoint — they're used
+        // via Socket Mode. Accept prefix-valid tokens as "probably ok."
+        result.app = { ok: true };
+      }
+    }
+
+    return NextResponse.json(result);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/dashboard/src/components/setup/setup-wizard.tsx
+++ b/dashboard/src/components/setup/setup-wizard.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { DoctorStep } from './doctor-step'
 import { SecretsStep } from './secrets-step'
+import { SlackStep } from './slack-step'
 import { DaemonStep } from './daemon-step'
 import { FinishStep } from './finish-step'
 
@@ -21,7 +22,7 @@ interface Step {
 const steps: Step[] = [
   { id: 'prereqs', label: 'Prerequisites' },
   { id: 'secrets', label: 'Integrations' },
-  { id: 'slack', label: 'Slack (optional)', comingSoon: true },
+  { id: 'slack', label: 'Slack (optional)' },
   { id: 'daemon', label: 'Background daemon' },
   { id: 'finish', label: 'Finish' },
 ]
@@ -111,6 +112,7 @@ export function SetupWizard() {
       <div className="rounded-xl border border-border bg-background p-6 shadow-sm">
         {active.id === 'prereqs' && <DoctorStep onReady={(r) => markReady('prereqs', r)} />}
         {active.id === 'secrets' && <SecretsStep onReady={(r) => markReady('secrets', r)} />}
+        {active.id === 'slack' && <SlackStep onReady={(r) => markReady('slack', r)} />}
         {active.id === 'daemon' && <DaemonStep onReady={(r) => markReady('daemon', r)} />}
         {active.id === 'finish' && <FinishStep onReady={(r) => markReady('finish', r)} />}
       </div>

--- a/dashboard/src/components/setup/slack-step.tsx
+++ b/dashboard/src/components/setup/slack-step.tsx
@@ -1,0 +1,288 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Check, Copy, ExternalLink, Loader2, Save, AlertCircle } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+type ValidationState = 'idle' | 'checking' | 'ok' | 'error'
+
+// Slack's "create app from manifest" deep link. The Slack UI accepts the
+// manifest as a query param but it's huge — we just deep-link the creator
+// and tell the user to paste.
+const SLACK_CREATE_URL = 'https://api.slack.com/apps?new_app=1'
+
+export function SlackStep({ onReady }: { onReady: (ready: boolean) => void }) {
+  const [manifest, setManifest] = useState<string>('')
+  const [manifestCopied, setManifestCopied] = useState(false)
+  const [botToken, setBotToken] = useState('')
+  const [appToken, setAppToken] = useState('')
+  const [webhookUrl, setWebhookUrl] = useState('')
+  const [botState, setBotState] = useState<{ s: ValidationState; msg?: string }>({ s: 'idle' })
+  const [appState, setAppState] = useState<{ s: ValidationState; msg?: string }>({ s: 'idle' })
+  const [webhookState, setWebhookState] = useState<{ s: ValidationState; msg?: string }>({ s: 'idle' })
+  const [saving, setSaving] = useState(false)
+  const [savedBanner, setSavedBanner] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    // Slack is optional — mark step ready immediately.
+    onReady(true)
+    fetch('/api/system/slack/manifest')
+      .then((r) => r.json())
+      .then((d) => setManifest(d.yaml ?? ''))
+      .catch(() => { /* non-fatal */ })
+    // Preload already-stored state from /api/system/secrets so returning
+    // users see green ticks without re-pasting.
+    fetch('/api/system/secrets')
+      .then((r) => r.json())
+      .then((d) => {
+        const slack = d.integrations?.slack ?? {}
+        if (slack.SLACK_BOT_TOKEN) setBotState({ s: 'ok', msg: 'Stored (paste new to replace)' })
+        if (slack.SLACK_APP_TOKEN) setAppState({ s: 'ok', msg: 'Stored' })
+        if (slack.ROUGE_SLACK_WEBHOOK) setWebhookState({ s: 'ok', msg: 'Stored' })
+      })
+      .catch(() => { /* non-fatal */ })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  async function copyManifest() {
+    try {
+      await navigator.clipboard.writeText(manifest)
+      setManifestCopied(true)
+      setTimeout(() => setManifestCopied(false), 2000)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  async function validateBot() {
+    if (!botToken) return
+    setBotState({ s: 'checking' })
+    try {
+      const res = await fetch('/api/system/slack/validate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ botToken }),
+      })
+      const body = await res.json()
+      if (body.bot?.ok) {
+        setBotState({ s: 'ok', msg: `Connected to ${body.bot.team} as ${body.bot.user}` })
+      } else {
+        setBotState({ s: 'error', msg: body.bot?.error ?? 'auth.test failed' })
+      }
+    } catch (err) {
+      setBotState({ s: 'error', msg: err instanceof Error ? err.message : String(err) })
+    }
+  }
+
+  async function validateApp() {
+    if (!appToken) return
+    setAppState({ s: 'checking' })
+    try {
+      const res = await fetch('/api/system/slack/validate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ appToken }),
+      })
+      const body = await res.json()
+      if (body.app?.ok) {
+        setAppState({ s: 'ok', msg: 'Format looks right (no live check for app tokens)' })
+      } else {
+        setAppState({ s: 'error', msg: body.app?.error ?? 'Invalid' })
+      }
+    } catch (err) {
+      setAppState({ s: 'error', msg: err instanceof Error ? err.message : String(err) })
+    }
+  }
+
+  async function testWebhook() {
+    if (!webhookUrl) return
+    setWebhookState({ s: 'checking' })
+    try {
+      const res = await fetch('/api/system/slack/test-webhook', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ webhookUrl }),
+      })
+      const body = await res.json()
+      if (body.ok) {
+        setWebhookState({ s: 'ok', msg: 'Test message sent — check your Slack channel.' })
+      } else {
+        setWebhookState({ s: 'error', msg: body.error ?? 'Webhook call failed' })
+      }
+    } catch (err) {
+      setWebhookState({ s: 'error', msg: err instanceof Error ? err.message : String(err) })
+    }
+  }
+
+  async function saveAll() {
+    setSaving(true)
+    setError(null)
+    const writes: Array<Promise<Response>> = []
+    if (botToken) {
+      writes.push(fetch('/api/system/secrets', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ integration: 'slack', key: 'SLACK_BOT_TOKEN', value: botToken }),
+      }))
+    }
+    if (appToken) {
+      writes.push(fetch('/api/system/secrets', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ integration: 'slack', key: 'SLACK_APP_TOKEN', value: appToken }),
+      }))
+    }
+    if (webhookUrl) {
+      writes.push(fetch('/api/system/secrets', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ integration: 'slack', key: 'ROUGE_SLACK_WEBHOOK', value: webhookUrl }),
+      }))
+    }
+    try {
+      const results = await Promise.all(writes)
+      const failed = results.filter((r) => !r.ok)
+      if (failed.length > 0) throw new Error(`${failed.length} save(s) failed`)
+      setBotToken('')
+      setAppToken('')
+      setWebhookUrl('')
+      setSavedBanner(`Saved ${writes.length} Slack credential${writes.length > 1 ? 's' : ''}`)
+      setTimeout(() => setSavedBanner(null), 3000)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="text-xl font-semibold text-foreground">Slack (optional)</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Wire up Slack for build notifications and lightweight remote commands.
+          The dashboard is your primary control surface — Slack is secondary.
+          Skip this step if you&apos;re not using Slack.
+        </p>
+      </div>
+
+      {error && (
+        <div className="rounded-md border border-red-300 bg-red-50 p-4 text-sm text-red-800">
+          <strong>Error:</strong> {error}
+        </div>
+      )}
+
+      {savedBanner && (
+        <div className="rounded-md border border-green-300 bg-green-50 p-3 text-sm text-green-800">
+          <Check className="inline h-4 w-4 mr-1" /> {savedBanner}
+        </div>
+      )}
+
+      {/* Step 1: create the app */}
+      <section className="rounded-lg border border-border bg-card p-4">
+        <h3 className="text-sm font-semibold text-foreground">1. Create the Slack app</h3>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Open Slack&apos;s app creator, choose <strong>From a manifest</strong>, pick a workspace, paste the YAML.
+        </p>
+        <div className="mt-3 flex flex-wrap items-center gap-2">
+          <Button variant="outline" size="sm" onClick={copyManifest} disabled={!manifest}>
+            {manifestCopied ? <Check className="h-4 w-4 text-green-600" /> : <Copy className="h-4 w-4" />}
+            <span className="ml-2">{manifestCopied ? 'Copied' : 'Copy manifest YAML'}</span>
+          </Button>
+          <a
+            href={SLACK_CREATE_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex h-9 items-center rounded-md border border-border bg-background px-3 text-sm font-medium hover:bg-accent hover:text-accent-foreground transition-colors"
+          >
+            <ExternalLink className="h-4 w-4" />
+            <span className="ml-2">Open Slack app creator</span>
+          </a>
+        </div>
+      </section>
+
+      {/* Step 2: bot token */}
+      <section className="rounded-lg border border-border bg-card p-4 space-y-2">
+        <h3 className="text-sm font-semibold text-foreground">2. Bot token</h3>
+        <p className="text-xs text-muted-foreground">
+          In your Slack app: <strong>OAuth &amp; Permissions</strong> → <em>Install to Workspace</em> → copy the <code className="rounded bg-muted px-1">xoxb-…</code> token.
+        </p>
+        <div className="flex items-center gap-2">
+          <input
+            type="password" autoComplete="off" placeholder="xoxb-…"
+            value={botToken} onChange={(e) => { setBotToken(e.target.value); setBotState({ s: 'idle' }) }}
+            className="flex-1 rounded-md border border-border bg-background px-3 py-1.5 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-ring"
+          />
+          <Button size="sm" variant="outline" onClick={validateBot} disabled={!botToken || botState.s === 'checking'}>
+            {botState.s === 'checking' ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Validate'}
+          </Button>
+        </div>
+        <ValidationRow state={botState} />
+      </section>
+
+      {/* Step 3: app token */}
+      <section className="rounded-lg border border-border bg-card p-4 space-y-2">
+        <h3 className="text-sm font-semibold text-foreground">3. App token (Socket Mode)</h3>
+        <p className="text-xs text-muted-foreground">
+          <strong>Basic Information</strong> → <em>App-Level Tokens</em> → <em>Generate Token and Scopes</em> → add <code className="rounded bg-muted px-1">connections:write</code> → copy the <code className="rounded bg-muted px-1">xapp-…</code> token.
+        </p>
+        <div className="flex items-center gap-2">
+          <input
+            type="password" autoComplete="off" placeholder="xapp-…"
+            value={appToken} onChange={(e) => { setAppToken(e.target.value); setAppState({ s: 'idle' }) }}
+            className="flex-1 rounded-md border border-border bg-background px-3 py-1.5 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-ring"
+          />
+          <Button size="sm" variant="outline" onClick={validateApp} disabled={!appToken || appState.s === 'checking'}>
+            {appState.s === 'checking' ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Check'}
+          </Button>
+        </div>
+        <ValidationRow state={appState} />
+      </section>
+
+      {/* Step 4: webhook */}
+      <section className="rounded-lg border border-border bg-card p-4 space-y-2">
+        <h3 className="text-sm font-semibold text-foreground">4. Incoming webhook</h3>
+        <p className="text-xs text-muted-foreground">
+          <strong>Incoming Webhooks</strong> → enable → <em>Add New Webhook to Workspace</em> → pick a channel → copy the URL.
+        </p>
+        <div className="flex items-center gap-2">
+          <input
+            type="url" autoComplete="off" placeholder="https://hooks.slack.com/services/…"
+            value={webhookUrl} onChange={(e) => { setWebhookUrl(e.target.value); setWebhookState({ s: 'idle' }) }}
+            className="flex-1 rounded-md border border-border bg-background px-3 py-1.5 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-ring"
+          />
+          <Button size="sm" variant="outline" onClick={testWebhook} disabled={!webhookUrl || webhookState.s === 'checking'}>
+            {webhookState.s === 'checking' ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Test'}
+          </Button>
+        </div>
+        <ValidationRow state={webhookState} />
+      </section>
+
+      {/* Save */}
+      <div className="flex items-center justify-end pt-2">
+        <Button onClick={saveAll} disabled={saving || (!botToken && !appToken && !webhookUrl)}>
+          {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
+          <span className="ml-2">Save Slack credentials</span>
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+function ValidationRow({ state }: { state: { s: ValidationState; msg?: string } }) {
+  if (state.s === 'idle' || !state.msg) return null
+  return (
+    <div className={cn(
+      'flex items-start gap-2 text-xs',
+      state.s === 'ok' && 'text-green-700',
+      state.s === 'error' && 'text-red-700',
+      state.s === 'checking' && 'text-muted-foreground',
+    )}>
+      {state.s === 'ok' && <Check className="h-3 w-3 mt-0.5 shrink-0" />}
+      {state.s === 'error' && <AlertCircle className="h-3 w-3 mt-0.5 shrink-0" />}
+      <span>{state.msg}</span>
+    </div>
+  )
+}

--- a/dashboard/src/lib/launcher-bridge.ts
+++ b/dashboard/src/lib/launcher-bridge.ts
@@ -41,3 +41,10 @@ export function requireLauncher(mod: string): any {
   const nodeRequire: NodeRequire = eval("require");
   return nodeRequire(full);
 }
+
+// Returns the src/ root alongside the launcher dir — e.g. for finding
+// src/slack/manifest.yaml from a route handler.
+export function rougeSrcDir(): string {
+  // resolveLauncherDir() returns .../src/launcher; parent is src/.
+  return path.resolve(resolveLauncherDir(), "..");
+}


### PR DESCRIPTION
## Summary
Replaces \`docs/slack-setup.md\` as the primary onboarding path for Slack. Four-section wizard step with real token validation and webhook testing.

## What's in
- \`/api/system/slack/manifest\` — serves \`src/slack/manifest.yaml\` for copy
- \`/api/system/slack/validate\` — real Slack \`auth.test\` call; returns workspace + user
- \`/api/system/slack/test-webhook\` — sends real test message, verifies 200
- \`components/setup/slack-step.tsx\` — four-section flow with live validation
- \`rougeSrcDir()\` helper in launcher-bridge
- Preloads stored state so returning users see "Stored" labels

## Verified
- [x] 285/285 CLI tests
- [x] Dashboard typechecks
- [x] Manifest endpoint returns YAML
- [x] Validate rejects malformed tokens with helpful messages
- [x] Webhook refuses non-hooks.slack.com URLs
- [ ] Manual: walk the full flow with a real Slack app

🤖 Generated with [Claude Code](https://claude.com/claude-code)