### PR TITLE
budget panel + integration validation (Phase 5)

### DIFF
--- a/dashboard/src/app/api/system/budget/route.ts
+++ b/dashboard/src/app/api/system/budget/route.ts
@@ -1,0 +1,81 @@
+import { NextResponse } from "next/server";
+import { assertLoopback } from "@/lib/localhost-guard";
+import { existsSync, readFileSync, writeFileSync, readdirSync, statSync } from "node:fs";
+import path from "node:path";
+
+export const dynamic = "force-dynamic";
+
+function resolveRougeConfigPath(): string | null {
+  const candidates = [
+    path.join(process.cwd(), "rouge.config.json"),
+    path.resolve(process.env.ROUGE_CLI ? path.dirname(process.env.ROUGE_CLI) : "", "..", "..", "rouge.config.json"),
+    path.resolve(__dirname, "../../../../../../rouge.config.json"),
+  ];
+  for (const c of candidates) {
+    if (c && existsSync(c)) return c;
+  }
+  return null;
+}
+
+function projectsRoot(): string {
+  return process.env.ROUGE_PROJECTS_DIR ?? path.join(process.env.HOME ?? "/tmp", ".rouge", "projects");
+}
+
+function readTotalSpend(): { total: number; byProject: Record<string, number> } {
+  const root = projectsRoot();
+  const byProject: Record<string, number> = {};
+  let total = 0;
+  if (!existsSync(root)) return { total, byProject };
+  try {
+    for (const name of readdirSync(root)) {
+      const dir = path.join(root, name);
+      if (!statSync(dir).isDirectory()) continue;
+      // Rouge writes cumulative spend into state.json.costs.cumulative_cost_usd
+      const statePath = path.join(dir, "state.json");
+      if (!existsSync(statePath)) continue;
+      try {
+        const state = JSON.parse(readFileSync(statePath, "utf-8")) as { costs?: { cumulative_cost_usd?: number } };
+        const n = Number(state.costs?.cumulative_cost_usd ?? 0);
+        if (n > 0) {
+          byProject[name] = n;
+          total += n;
+        }
+      } catch { /* skip malformed */ }
+    }
+  } catch { /* fall through */ }
+  return { total, byProject };
+}
+
+// GET /api/system/budget → { cap: number, spend: { total, byProject } }
+export async function GET() {
+  const forbidden = await assertLoopback();
+  if (forbidden) return forbidden;
+
+  const cfgPath = resolveRougeConfigPath();
+  const cfg = cfgPath ? JSON.parse(readFileSync(cfgPath, "utf-8")) as { budget_cap_usd?: number } : {};
+  const cap = Number(cfg.budget_cap_usd ?? 50);
+  const spend = readTotalSpend();
+  return NextResponse.json({ cap, spend, configPath: cfgPath });
+}
+
+// PUT /api/system/budget → body: { cap: number }
+export async function PUT(request: Request) {
+  const forbidden = await assertLoopback();
+  if (forbidden) return forbidden;
+
+  try {
+    const { cap } = (await request.json()) as { cap?: number };
+    const n = Number(cap);
+    if (!Number.isFinite(n) || n < 0) {
+      return NextResponse.json({ error: "cap must be a non-negative number" }, { status: 400 });
+    }
+    const cfgPath = resolveRougeConfigPath();
+    if (!cfgPath) return NextResponse.json({ error: "rouge.config.json not found" }, { status: 500 });
+    const cfg = JSON.parse(readFileSync(cfgPath, "utf-8"));
+    cfg.budget_cap_usd = n;
+    writeFileSync(cfgPath, JSON.stringify(cfg, null, 2) + "\n");
+    return NextResponse.json({ ok: true, cap: n });
+  } catch (err) {
+    return NextResponse.json({ error: err instanceof Error ? err.message : String(err) }, { status: 500 });
+  }
+}

--- a/dashboard/src/app/api/system/secrets/validate/route.ts
+++ b/dashboard/src/app/api/system/secrets/validate/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+import { assertLoopback } from "@/lib/localhost-guard";
+import { requireLauncher } from "@/lib/launcher-bridge";
+
+export const dynamic = "force-dynamic";
+
+// POST /api/system/secrets/validate
+// Body: { integration: string }
+// Runs validateIntegration from secrets.js, which hits each key's live
+// validation endpoint (Stripe, Supabase, Sentry, Vercel, etc.) and returns
+// per-key status. Returns [] for unknown integrations.
+export async function POST(request: Request) {
+  const forbidden = await assertLoopback();
+  if (forbidden) return forbidden;
+
+  try {
+    const { integration } = (await request.json()) as { integration?: string };
+    if (!integration) {
+      return NextResponse.json({ error: "integration is required" }, { status: 400 });
+    }
+    const secrets = requireLauncher("secrets.js");
+    const results = await Promise.resolve(secrets.validateIntegration(integration));
+    return NextResponse.json({ integration, results });
+  } catch (err) {
+    return NextResponse.json({ error: err instanceof Error ? err.message : String(err) }, { status: 500 });
+  }
+}

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -7,6 +7,7 @@ import { ProjectCard } from '@/components/project-card'
 import { TopBar } from '@/components/top-bar'
 import { LiveRefresh } from '@/components/live-refresh'
 import { NewProjectButton } from '@/components/new-project-button'
+import { BudgetPanel } from '@/components/budget-panel'
 import { cn } from '@/lib/utils'
 
 // Render per-request so the same-origin /api/projects fetch resolves.
@@ -145,9 +146,12 @@ export default async function Home() {
           </p>
         </div>
       )}
-      <div className="flex items-start justify-between">
+      <div className="flex flex-wrap items-start justify-between gap-4">
         <TopBar />
-        <NewProjectButton />
+        <div className="flex flex-wrap items-start gap-4">
+          <BudgetPanel />
+          <NewProjectButton />
+        </div>
       </div>
 
       <div className="mt-10 flex flex-col gap-12">

--- a/dashboard/src/components/budget-panel.tsx
+++ b/dashboard/src/components/budget-panel.tsx
@@ -1,0 +1,145 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { DollarSign, Loader2, Save } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+interface BudgetData {
+  cap: number
+  spend: { total: number; byProject: Record<string, number> }
+  configPath?: string | null
+}
+
+export function BudgetPanel() {
+  const [data, setData] = useState<BudgetData | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [editing, setEditing] = useState(false)
+  const [draft, setDraft] = useState<string>('')
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function load() {
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await fetch('/api/system/budget')
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      const d = (await res.json()) as BudgetData
+      setData(d)
+      setDraft(String(d.cap))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => { load() }, [])
+
+  async function save() {
+    const n = Number(draft)
+    if (!Number.isFinite(n) || n < 0) {
+      setError('Cap must be a non-negative number')
+      return
+    }
+    setSaving(true)
+    setError(null)
+    try {
+      const res = await fetch('/api/system/budget', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ cap: n }),
+      })
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}))
+        throw new Error(body.error ?? `HTTP ${res.status}`)
+      }
+      setEditing(false)
+      await load()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (loading && !data) {
+    return (
+      <div className="flex items-center gap-2 rounded-md border border-border bg-card px-3 py-2 text-sm text-muted-foreground">
+        <Loader2 className="h-4 w-4 animate-spin" /> Loading budget…
+      </div>
+    )
+  }
+
+  if (!data) {
+    return error ? (
+      <div className="rounded-md border border-red-300 bg-red-50 px-3 py-2 text-xs text-red-800">{error}</div>
+    ) : null
+  }
+
+  const pct = data.cap > 0 ? Math.min(100, (data.spend.total / data.cap) * 100) : 0
+  const overCap = data.spend.total > data.cap
+  const color = overCap ? 'bg-red-500' : pct > 80 ? 'bg-amber-500' : 'bg-green-500'
+
+  return (
+    <div className="rounded-lg border border-border bg-card p-3 text-sm w-full max-w-xs">
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2 font-medium text-foreground">
+          <DollarSign className="h-4 w-4" />
+          Budget
+        </div>
+        {!editing && (
+          <button
+            type="button"
+            onClick={() => setEditing(true)}
+            className="text-xs text-muted-foreground hover:text-foreground underline underline-offset-2"
+          >
+            Edit cap
+          </button>
+        )}
+      </div>
+
+      <div className="mt-2 flex items-baseline gap-1.5">
+        <span className={cn('text-lg font-semibold tabular-nums', overCap && 'text-red-600')}>
+          ${data.spend.total.toFixed(2)}
+        </span>
+        <span className="text-xs text-muted-foreground">/</span>
+        {editing ? (
+          <div className="flex items-center gap-1">
+            <span className="text-sm text-muted-foreground">$</span>
+            <input
+              type="number" min="0" step="1"
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              className="w-20 rounded-md border border-border bg-background px-2 py-0.5 text-sm tabular-nums focus:outline-none focus:ring-2 focus:ring-ring"
+            />
+            <Button size="sm" onClick={save} disabled={saving}>
+              {saving ? <Loader2 className="h-3 w-3 animate-spin" /> : <Save className="h-3 w-3" />}
+            </Button>
+            <button
+              type="button"
+              onClick={() => { setEditing(false); setDraft(String(data.cap)) }}
+              className="text-xs text-muted-foreground hover:text-foreground px-1"
+            >
+              Cancel
+            </button>
+          </div>
+        ) : (
+          <span className="text-sm text-muted-foreground tabular-nums">${data.cap.toFixed(0)} cap</span>
+        )}
+      </div>
+
+      <div className="mt-2 h-1.5 w-full overflow-hidden rounded-full bg-muted">
+        <div className={cn('h-full rounded-full transition-all', color)} style={{ width: `${Math.max(1, pct)}%` }} />
+      </div>
+
+      {overCap && (
+        <p className="mt-2 text-xs text-red-700">Over cap — raise it or pause active builds.</p>
+      )}
+      {error && (
+        <p className="mt-2 text-xs text-red-700">{error}</p>
+      )}
+    </div>
+  )
+}

--- a/dashboard/src/components/setup/secrets-step.tsx
+++ b/dashboard/src/components/setup/secrets-step.tsx
@@ -1,9 +1,15 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { Check, Loader2, Save, Trash2 } from 'lucide-react'
+import { AlertCircle, Check, Loader2, Save, ShieldCheck, Trash2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
+
+interface ValidationResult {
+  key: string
+  status: 'valid' | 'invalid' | 'error'
+  message?: string
+}
 
 type IntegrationMap = Record<string, Record<string, boolean>>
 
@@ -18,6 +24,47 @@ const INTEGRATION_BLURBS: Record<string, string> = {
   vercel: 'Deployment target. Needed for Vercel-hosted products.',
 }
 
+function ValidationSection({
+  integration, results, validating, onValidate, storedCount,
+}: {
+  integration: string
+  results?: ValidationResult[]
+  validating: boolean
+  onValidate: () => void
+  storedCount: number
+}) {
+  if (storedCount === 0) return null
+  return (
+    <div className="flex flex-wrap items-center gap-2 rounded-md bg-muted/40 px-3 py-2 text-xs">
+      <Button size="sm" variant="outline" onClick={onValidate} disabled={validating}>
+        {validating ? <Loader2 className="h-3 w-3 animate-spin" /> : <ShieldCheck className="h-3 w-3" />}
+        <span className="ml-1.5">{validating ? 'Checking' : 'Validate live'}</span>
+      </Button>
+      {results && results.length > 0 && (
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+          {results.map((r) => (
+            <span key={r.key} className={cn(
+              'flex items-center gap-1',
+              r.status === 'valid' && 'text-green-700',
+              r.status === 'invalid' && 'text-red-700',
+              r.status === 'error' && 'text-amber-700',
+            )}>
+              {r.status === 'valid' ? <Check className="h-3 w-3" /> : <AlertCircle className="h-3 w-3" />}
+              <code className="font-mono">{r.key}</code>
+              {r.message && <span className="text-muted-foreground">— {r.message}</span>}
+            </span>
+          ))}
+        </div>
+      )}
+      {!results && (
+        <span className="text-muted-foreground">
+          Checks {integration} keys against the live API.
+        </span>
+      )}
+    </div>
+  )
+}
+
 export function SecretsStep({ onReady }: { onReady: (ready: boolean) => void }) {
   const [integrations, setIntegrations] = useState<IntegrationMap>({})
   const [loading, setLoading] = useState(true)
@@ -25,6 +72,8 @@ export function SecretsStep({ onReady }: { onReady: (ready: boolean) => void }) 
   const [drafts, setDrafts] = useState<Record<string, string>>({})
   const [saving, setSaving] = useState<string | null>(null)
   const [savedBanner, setSavedBanner] = useState<string | null>(null)
+  const [validating, setValidating] = useState<string | null>(null)
+  const [validationByIntegration, setValidationByIntegration] = useState<Record<string, ValidationResult[]>>({})
 
   async function load() {
     setLoading(true)
@@ -70,6 +119,24 @@ export function SecretsStep({ onReady }: { onReady: (ready: boolean) => void }) 
       setError(err instanceof Error ? err.message : String(err))
     } finally {
       setSaving(null)
+    }
+  }
+
+  async function validate(integration: string) {
+    setValidating(integration)
+    try {
+      const res = await fetch('/api/system/secrets/validate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ integration }),
+      })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      const body = await res.json()
+      setValidationByIntegration((v) => ({ ...v, [integration]: body.results ?? [] }))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setValidating(null)
     }
   }
 
@@ -150,6 +217,13 @@ export function SecretsStep({ onReady }: { onReady: (ready: boolean) => void }) 
               </summary>
 
               <div className="border-t border-border p-4 space-y-3">
+                <ValidationSection
+                  integration={integration}
+                  results={validationByIntegration[integration]}
+                  validating={validating === integration}
+                  onValidate={() => validate(integration)}
+                  storedCount={storedCount}
+                />
                 {Object.entries(keys).map(([key, stored]) => {
                   const draftKey = `${integration}.${key}`
                   const isSaving = saving === draftKey

--- a/rouge.config.json
+++ b/rouge.config.json
@@ -3,7 +3,10 @@
   "control_plane_lock": true,
   "safety": {
     "blocked_commands": [],
-    "allowed_deploy_targets": ["staging", "preview"],
+    "allowed_deploy_targets": [
+      "staging",
+      "preview"
+    ],
     "custom_pre_hooks": []
   },
   "budget_cap_usd": 50,
@@ -15,8 +18,17 @@
   "model_overrides": {},
   "self_improvement": {
     "enabled": true,
-    "allowlist": ["src/prompts/loop/*.md", "src/prompts/seeding/*.md", "docs/design/*.md"],
-    "blocklist": ["src/launcher/*.js", ".claude/settings.json", "rouge.config.json", "rouge-safety-check.sh"],
+    "allowlist": [
+      "src/prompts/loop/*.md",
+      "src/prompts/seeding/*.md",
+      "docs/design/*.md"
+    ],
+    "blocklist": [
+      "src/launcher/*.js",
+      ".claude/settings.json",
+      "rouge.config.json",
+      "rouge-safety-check.sh"
+    ],
     "test_budget_usd": 5
   },
   "linked_projects": {


### PR DESCRIPTION
## Summary
- \`/api/system/budget\` — GET aggregates spend across projects; PUT updates \`budget_cap_usd\` in rouge.config.json
- \`/api/system/secrets/validate\` — live API check via \`validateIntegration()\`
- \`BudgetPanel\` mounted on dashboard homepage next to New Project button
- Per-integration "Validate live" button added to secrets step

Replaces manual JSON editing of rouge.config.json for budget adjustments and surfaces spend at a glance.

## Verified
- [x] GET /api/system/budget returns real spend (\$162 across 4 projects on dev machine)
- [x] PUT round-trips to rouge.config.json
- [x] /api/system/secrets/validate returns per-key status
- [x] 285/285 CLI tests
- [x] Dashboard typechecks

🤖 Generated with [Claude Code](https://claude.com/claude-code)