### PR TITLE
self-documenting dashboard: inline help (Phase 7) — final

### DIFF
--- a/dashboard/src/components/budget-panel.tsx
+++ b/dashboard/src/components/budget-panel.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react'
 import { DollarSign, Loader2, Save } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { Help } from '@/components/ui/help'
 import { cn } from '@/lib/utils'
 
 interface BudgetData {
@@ -140,6 +141,13 @@ export function BudgetPanel() {
       {error && (
         <p className="mt-2 text-xs text-red-700">{error}</p>
       )}
+      <div className="mt-2">
+        <Help>
+          <p><strong>What counts as spend?</strong> Cumulative Claude API cost across all projects, read from each project&apos;s <code>state.json</code> (<code>costs.cumulative_cost_usd</code>).</p>
+          <p><strong>What does the cap do?</strong> Rouge pauses a running loop if its project&apos;s spend exceeds <code>budget_cap_usd</code>. The cap here is global in rouge.config.json; per-project caps are a future addition.</p>
+          <p><strong>Saving the cap</strong> writes to <code>rouge.config.json</code> directly — same file <code>rouge</code> reads.</p>
+        </Help>
+      </div>
     </div>
   )
 }

--- a/dashboard/src/components/setup/daemon-step.tsx
+++ b/dashboard/src/components/setup/daemon-step.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react'
 import { CheckCircle2, Loader2, Power, Trash2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { Help } from '@/components/ui/help'
 import { cn } from '@/lib/utils'
 
 interface DaemonStatus {
@@ -73,9 +74,15 @@ export function DaemonStep({ onReady }: { onReady: (ready: boolean) => void }) {
       <div>
         <h2 className="text-xl font-semibold text-foreground">Background daemon</h2>
         <p className="mt-1 text-sm text-muted-foreground">
-          Keep the Rouge dashboard running in the background so it's there when you need it.
+          Keep the Rouge dashboard running in the background so it&apos;s there when you need it.
           Install once and it auto-starts at login. Shut down anytime via the Power icon in the nav.
         </p>
+        <Help className="mt-2">
+          <p><strong>What exactly gets installed?</strong> A macOS launch agent at <code className="break-all">~/Library/LaunchAgents/com.rouge.dashboard.plist</code>. It runs <code>rouge dashboard start --no-open</code> at login — just starts the server, doesn&apos;t auto-open your browser.</p>
+          <p><strong>Can I stop it temporarily?</strong> Yes. Click the Power icon in the top-right of the dashboard, or run <code>rouge stop</code>.</p>
+          <p><strong>Can I remove it later?</strong> Yes. Reinstall and Uninstall buttons are here; <code>rouge uninstall</code> removes it as part of full cleanup.</p>
+          <p><strong>Linux/Windows:</strong> not yet supported. Start manually with <code>rouge start</code>.</p>
+        </Help>
       </div>
 
       {error && (

--- a/dashboard/src/components/setup/doctor-step.tsx
+++ b/dashboard/src/components/setup/doctor-step.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react'
 import { CheckCircle2, XCircle, AlertTriangle, Loader2, RefreshCw } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { Help } from '@/components/ui/help'
 import { cn } from '@/lib/utils'
 import type { DoctorResult, DoctorCheck } from '@/lib/doctor-types'
 
@@ -47,6 +48,11 @@ export function DoctorStep({ onReady }: { onReady: (ready: boolean) => void }) {
           <p className="mt-1 text-sm text-muted-foreground">
             Rouge needs a few tools on your system. Green is ready. Red blocks builds. Amber is optional.
           </p>
+          <Help className="mt-2">
+            <p><strong>Why these tools?</strong></p>
+            <p><strong>Claude Code CLI</strong> runs the actual builds. <strong>Git</strong> + <strong>GitHub CLI</strong> are how Rouge ships code. <strong>jq</strong> is required by the safety hook that gates Claude&apos;s tool calls — without it every build fails mysteriously.</p>
+            <p>The amber items (Supabase CLI, Vercel CLI, GStack) are only needed for specific deployment targets. Skip if you&apos;re not using them.</p>
+          </Help>
         </div>
         <Button
           variant="outline"

--- a/dashboard/src/components/setup/secrets-step.tsx
+++ b/dashboard/src/components/setup/secrets-step.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react'
 import { AlertCircle, Check, Loader2, Save, ShieldCheck, Trash2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { Help } from '@/components/ui/help'
 import { cn } from '@/lib/utils'
 
 interface ValidationResult {
@@ -163,6 +164,11 @@ export function SecretsStep({ onReady }: { onReady: (ready: boolean) => void }) 
           Values go to your OS keychain under the <code className="rounded bg-muted px-1">rouge-*</code> prefix —
           your personal keychain entries are not touched. You can add these later.
         </p>
+        <Help className="mt-2">
+          <p><strong>Do I need these now?</strong> No — you can skip this step and add creds later via the Setup tab.</p>
+          <p><strong>Which ones?</strong> Only the services your product will use. Stripe for payments, Supabase for database+auth, Sentry for error tracking, Cloudflare for DNS, Vercel for deployment. Rouge won&apos;t try to wire up integrations whose keys aren&apos;t set.</p>
+          <p><strong>Safety:</strong> Rouge stores under the <code>rouge-*</code> prefix. Your existing Stripe/Supabase/etc keychain entries for other projects are not touched, and <code>rouge uninstall</code> only removes <code>rouge-*</code> entries.</p>
+        </Help>
       </div>
 
       {error && (

--- a/dashboard/src/components/setup/setup-wizard.tsx
+++ b/dashboard/src/components/setup/setup-wizard.tsx
@@ -119,9 +119,19 @@ export function SetupWizard() {
 
       {/* Footer actions */}
       <div className="mt-6 flex items-center justify-between">
-        <Link href="/" className="text-sm text-muted-foreground hover:text-foreground">
-          ← Back to dashboard
-        </Link>
+        <div className="flex items-center gap-4 text-sm text-muted-foreground">
+          <Link href="/" className="hover:text-foreground">
+            ← Back to dashboard
+          </Link>
+          <a
+            href="https://github.com/gregario/the-rouge/tree/main/docs"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-foreground"
+          >
+            Full docs ↗
+          </a>
+        </div>
         <div className="flex items-center gap-3">
           {activeIdx > 0 && (
             <Button variant="outline" onClick={() => {

--- a/dashboard/src/components/setup/slack-step.tsx
+++ b/dashboard/src/components/setup/slack-step.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react'
 import { Check, Copy, ExternalLink, Loader2, Save, AlertCircle } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { Help } from '@/components/ui/help'
 import { cn } from '@/lib/utils'
 
 type ValidationState = 'idle' | 'checking' | 'ok' | 'error'
@@ -166,6 +167,13 @@ export function SlackStep({ onReady }: { onReady: (ready: boolean) => void }) {
           The dashboard is your primary control surface — Slack is secondary.
           Skip this step if you&apos;re not using Slack.
         </p>
+        <Help className="mt-2">
+          <p><strong>Bot token vs App token vs Webhook — what are they?</strong></p>
+          <p><strong>Bot token</strong> (<code>xoxb-…</code>): identifies your bot when it posts or reads messages. Required.</p>
+          <p><strong>App token</strong> (<code>xapp-…</code>): enables Socket Mode, which lets the bot receive events over a websocket instead of a public webhook URL. Required — Rouge uses Socket Mode so you don&apos;t need to expose a public URL.</p>
+          <p><strong>Webhook</strong> (<code>https://hooks.slack.com/…</code>): one-way channel for Rouge to post build notifications. Optional but recommended — it works without the bot being running.</p>
+          <p><strong>Full docs:</strong> see <a href="/docs/how-to/slack-setup" className="underline">how-to/slack-setup</a> for the manual version.</p>
+        </Help>
       </div>
 
       {error && (

--- a/dashboard/src/components/ui/help.tsx
+++ b/dashboard/src/components/ui/help.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import { useState } from 'react'
+import { HelpCircle } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+/**
+ * Inline help: click the (?) icon to expand a short explanation.
+ * Lightweight alternative to a full tooltip library — one-line trigger,
+ * revealed content is right there for accessibility and keyboard users.
+ *
+ * Usage:
+ *   <Help>
+ *     <p>Stripe needs a secret key (sk_live_… or sk_test_…) for payments.</p>
+ *     <p>Skip if you're not taking money.</p>
+ *   </Help>
+ */
+export function Help({ children, className }: { children: React.ReactNode; className?: string }) {
+  const [open, setOpen] = useState(false)
+  return (
+    <span className={cn('inline-flex flex-col items-start gap-1', className)}>
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+        aria-expanded={open}
+      >
+        <HelpCircle className="h-3.5 w-3.5" />
+        <span className="underline underline-offset-2">{open ? 'Hide' : 'Why?'}</span>
+      </button>
+      {open && (
+        <div className="mt-1 w-full max-w-xl rounded-md border border-border bg-muted/50 p-3 text-xs text-muted-foreground space-y-1.5">
+          {children}
+        </div>
+      )}
+    </span>
+  )
+}


### PR DESCRIPTION
## Summary
Adds a \`<Help>\` disclosure component and sprinkles contextual explanations through the setup wizard and budget panel. Completes the onboarding refactor.

## What's in
- \`components/ui/help.tsx\` — collapsible "Why?" disclosure with HelpCircle icon
- Help blurbs added to: doctor step, secrets step, slack step, daemon step, budget panel
- Wizard footer: "Full docs ↗" link to GitHub docs tree

## Design note
Chose inline disclosure over tooltips: accessible (keyboard-navigable), not size-constrained, visible to users who don't hover. Each Help stays collapsed so the wizard doesn't feel wordy.

## Phase 7 — and the refactor — complete
Seven phases, all merged:
- 0: plan + scope locks (\`docs/plans/2026-04-15-onboarding-refactor.md\`)
- 1: stale-doc banners (#108)
- 2: CLI deprecation markers + help regroup (#110)
- 2.5a: top-level lifecycle verbs + macOS daemon + shutdown button (#111)
- 3a/b/c: setup wizard — doctor + secrets/daemon + finish/first-run redirect (#112/#113/#114)
- 4: Slack setup wizard (#115)
- 5: budget panel + live integration validation (#116)
- 6: Diátaxis docs restructure + CI rot prevention (#117)
- 7: inline help (this PR)

**Release:** ready to cut v0.4.0 (or v1.0.0) to npm after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)