### PR TITLE
fix(setup): hydration bug breaking all clicks on /setup

### DIFF
--- a/dashboard/src/components/setup/finish-step.tsx
+++ b/dashboard/src/components/setup/finish-step.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { Loader2, Rocket } from 'lucide-react'
 import { Button } from '@/components/ui/button'
@@ -11,7 +11,11 @@ export function FinishStep({ onReady }: { onReady: (ready: boolean) => void }) {
   const [error, setError] = useState<string | null>(null)
 
   // Always "ready" — the whole point of this step is to finish.
-  if (!busy) onReady(true)
+  // MUST run in useEffect, not during render. Calling setState on the
+  // parent mid-render breaks React hydration and kills all click
+  // handlers in the surrounding tree.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => { onReady(true) }, [])
 
   async function finish(skipped: boolean) {
     setBusy(true)

--- a/dashboard/src/components/setup/setup-wizard.tsx
+++ b/dashboard/src/components/setup/setup-wizard.tsx
@@ -21,7 +21,7 @@ interface Step {
 
 const steps: Step[] = [
   { id: 'prereqs', label: 'Prerequisites' },
-  { id: 'secrets', label: 'Integrations' },
+  { id: 'secrets', label: 'Integrations (optional)' },
   { id: 'slack', label: 'Slack (optional)' },
   { id: 'daemon', label: 'Background daemon' },
   { id: 'finish', label: 'Finish' },


### PR DESCRIPTION
## Root cause
\`FinishStep\` called \`onReady(true)\` directly during render, triggering React's mid-render setState error. During SSR hydration that becomes fatal and aborts hydration for the whole subtree — all buttons render correctly but have no click handlers attached.

## Symptom
- Next/Back buttons dead on all wizard steps
- "Skip for now" in header dead
- "Back to dashboard" / "Full docs" links dead
- Top nav (Dashboard/Platform/Catalogue) also dead because hydration failed high up the tree

## Fix
One line: wrap the \`onReady(true)\` in \`useEffect\`. Matches the pattern every other step already uses.

Also: label the Integrations step \"(optional)\" to match Slack — both can be skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)