### PR TITLE
chore: revert budget cap to 50 (test value leaked)

### DIFF
--- a/rouge.config.json
+++ b/rouge.config.json
@@ -9,7 +9,7 @@
     ],
     "custom_pre_hooks": []
   },
-  "budget_cap_usd": 300,
+  "budget_cap_usd": 50,
   "spin_detection": {
     "zero_delta_threshold": 3,
     "time_stall_minutes": 30,


### PR DESCRIPTION
My $300 test value got committed via the budget panel UI while verifying #120. Restoring the project default.