### PR TITLE
dashboard: Specs section with sortable table + promote-to-build

### DIFF
--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -8,6 +8,7 @@ import { TopBar } from '@/components/top-bar'
 import { LiveRefresh } from '@/components/live-refresh'
 import { NewProjectButton } from '@/components/new-project-button'
 import { BudgetPanel } from '@/components/budget-panel'
+import { SpecsTable } from '@/components/specs-table'
 import { cn } from '@/lib/utils'
 
 // Render per-request so the same-origin /api/projects fetch resolves.
@@ -84,6 +85,8 @@ const buildingStates = new Set<ProjectState>([
 ])
 const specStates = new Set<ProjectState>(['seeding', 'ready'])
 
+// Card-based sections (needs-attention / building / shipped). Specs are
+// rendered as a separate table layout so they get their own section below.
 const sections: Section[] = [
   {
     id: 'needs-attention',
@@ -98,13 +101,6 @@ const sections: Section[] = [
     accentBorder: 'border-blue-500',
     accentText: 'text-blue-600',
     filter: (p) => buildingStates.has(p.state),
-  },
-  {
-    id: 'in-spec',
-    title: 'In Spec',
-    accentBorder: 'border-purple-500',
-    accentText: 'text-purple-600',
-    filter: (p) => specStates.has(p.state),
   },
   {
     id: 'shipped',
@@ -155,25 +151,51 @@ export default async function Home() {
       </div>
 
       <div className="mt-10 flex flex-col gap-12">
-        {sections.map((section) => {
-          const sectionProjects = sortByUpdated(projects.filter(section.filter))
-          if (sectionProjects.length === 0) return null
-
+        {/* Needs Attention — cards, only renders when non-empty */}
+        {(() => {
+          const section = sections[0]
+          const list = sortByUpdated(projects.filter(section.filter))
+          if (list.length === 0) return null
           return (
             <div key={section.id}>
-              {/* Section header */}
               <div className={cn('mb-6 flex items-center gap-3 border-l-4 pl-4', section.accentBorder)}>
                 <h2 className="text-xl font-bold text-foreground">{section.title}</h2>
-                <span className={cn('text-sm font-semibold tabular-nums', section.accentText)}>
-                  {sectionProjects.length}
-                </span>
+                <span className={cn('text-sm font-semibold tabular-nums', section.accentText)}>{list.length}</span>
               </div>
-
-              {/* Project cards */}
               <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
-                {sectionProjects.map((project) => (
-                  <ProjectCard key={project.id} project={project} />
-                ))}
+                {list.map((project) => <ProjectCard key={project.id} project={project} />)}
+              </div>
+            </div>
+          )
+        })()}
+
+        {/* Specs — dense table, sortable. Always visible so users can start
+            one from empty. Specs live here forever, even unbuilt. */}
+        <div>
+          <div className="mb-6 flex items-center gap-3 border-l-4 border-purple-500 pl-4">
+            <h2 className="text-xl font-bold text-foreground">Specs</h2>
+            <span className="text-sm font-semibold tabular-nums text-purple-600">
+              {projects.filter((p) => specStates.has(p.state)).length}
+            </span>
+            <span className="ml-2 text-xs text-muted-foreground">
+              Ideas in development. Sit here until you promote them to a build.
+            </span>
+          </div>
+          <SpecsTable specs={projects.filter((p) => specStates.has(p.state))} />
+        </div>
+
+        {/* Building + Shipped — cards, only render when non-empty */}
+        {sections.slice(1).map((section) => {
+          const list = sortByUpdated(projects.filter(section.filter))
+          if (list.length === 0) return null
+          return (
+            <div key={section.id}>
+              <div className={cn('mb-6 flex items-center gap-3 border-l-4 pl-4', section.accentBorder)}>
+                <h2 className="text-xl font-bold text-foreground">{section.title}</h2>
+                <span className={cn('text-sm font-semibold tabular-nums', section.accentText)}>{list.length}</span>
+              </div>
+              <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+                {list.map((project) => <ProjectCard key={project.id} project={project} />)}
               </div>
             </div>
           )

--- a/dashboard/src/components/spec-depth-pill.tsx
+++ b/dashboard/src/components/spec-depth-pill.tsx
@@ -1,0 +1,47 @@
+'use client'
+
+import { cn } from '@/lib/utils'
+import type { ProjectSummary } from '@/lib/types'
+
+// Depth = how far along the seeding conversation is. Drives the pill color
+// on the Specs table so you can scan which ideas are half-baked vs ready to
+// build. Derived from state + milestone/progress hints; more granular
+// stages land later when we surface per-discipline completion.
+
+type Depth = 'brainstorm' | 'researched' | 'specced' | 'designed' | 'ready'
+
+const LABEL: Record<Depth, string> = {
+  brainstorm: 'brainstorm',
+  researched: 'researched',
+  specced: 'specced',
+  designed: 'designed',
+  ready: 'ready to build',
+}
+
+const STYLES: Record<Depth, string> = {
+  brainstorm: 'bg-violet-100 text-violet-800 border-violet-300',
+  researched: 'bg-cyan-100 text-cyan-800 border-cyan-300',
+  specced: 'bg-blue-100 text-blue-800 border-blue-300',
+  designed: 'bg-purple-100 text-purple-800 border-purple-300',
+  ready: 'bg-green-100 text-green-800 border-green-300',
+}
+
+export function depthForProject(p: ProjectSummary): Depth {
+  if (p.state === 'ready') return 'ready'
+  // For now, seeding = brainstorm. Future: read per-discipline completion
+  // from state.json and map brainstorm/competition/taste/spec/design/marketing
+  // progress to the five depths.
+  return 'brainstorm'
+}
+
+export function SpecDepthPill({ project }: { project: ProjectSummary }) {
+  const depth = depthForProject(project)
+  return (
+    <span className={cn(
+      'inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium',
+      STYLES[depth],
+    )}>
+      {LABEL[depth]}
+    </span>
+  )
+}

--- a/dashboard/src/components/specs-table.tsx
+++ b/dashboard/src/components/specs-table.tsx
@@ -1,0 +1,215 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import Link from 'next/link'
+import { ArrowUpDown, Loader2, Rocket, Search } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import type { ProjectSummary } from '@/lib/types'
+import { SpecDepthPill, depthForProject } from './spec-depth-pill'
+
+type SortKey = 'touched' | 'depth' | 'name' | 'cost'
+
+const DEPTH_ORDER: Record<ReturnType<typeof depthForProject>, number> = {
+  brainstorm: 0, researched: 1, specced: 2, designed: 3, ready: 4,
+}
+
+function timeAgo(iso?: string): string {
+  if (!iso) return '—'
+  const then = new Date(iso).getTime()
+  if (Number.isNaN(then)) return '—'
+  const diff = Math.max(0, Date.now() - then)
+  const days = Math.floor(diff / 86400000)
+  if (days >= 1) return `${days}d ago`
+  const hours = Math.floor(diff / 3600000)
+  if (hours >= 1) return `${hours}h ago`
+  const mins = Math.floor(diff / 60000)
+  if (mins >= 1) return `${mins}m ago`
+  return 'just now'
+}
+
+export function SpecsTable({ specs }: { specs: ProjectSummary[] }) {
+  const [query, setQuery] = useState('')
+  const [sortKey, setSortKey] = useState<SortKey>('touched')
+  const [sortDir, setSortDir] = useState<'asc' | 'desc'>('desc')
+  const [promoting, setPromoting] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    let list = specs
+    if (q) {
+      list = specs.filter((p) =>
+        p.name.toLowerCase().includes(q) || (p.description ?? '').toLowerCase().includes(q))
+    }
+    const sign = sortDir === 'asc' ? 1 : -1
+    list = [...list].sort((a, b) => {
+      switch (sortKey) {
+        case 'touched': {
+          const ta = new Date(a.updatedAt ?? a.lastCheckpointAt ?? 0).getTime()
+          const tb = new Date(b.updatedAt ?? b.lastCheckpointAt ?? 0).getTime()
+          return sign * (tb - ta)
+        }
+        case 'depth':
+          return sign * (DEPTH_ORDER[depthForProject(b)] - DEPTH_ORDER[depthForProject(a)])
+        case 'name':
+          return sign * b.name.localeCompare(a.name) * -1
+        case 'cost':
+          return sign * ((b.cost?.totalSpend ?? 0) - (a.cost?.totalSpend ?? 0))
+      }
+    })
+    return list
+  }, [specs, query, sortKey, sortDir])
+
+  function onSort(k: SortKey) {
+    if (sortKey === k) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'))
+    } else {
+      setSortKey(k)
+      setSortDir(k === 'name' ? 'asc' : 'desc')
+    }
+  }
+
+  async function promote(slug: string) {
+    setPromoting(slug)
+    setError(null)
+    try {
+      // "Promotion" = starting the build loop. A spec in the `ready` state
+      // has everything it needs; /start kicks off the Karpathy Loop and
+      // the project moves into `foundation` (building).
+      const res = await fetch(`/api/projects/${encodeURIComponent(slug)}/start`, {
+        method: 'POST',
+      })
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}))
+        throw new Error(body.error ?? `HTTP ${res.status}`)
+      }
+      // The project moves out of Specs and into Building on next render.
+      window.location.reload()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+      setPromoting(null)
+    }
+  }
+
+  if (specs.length === 0) {
+    return (
+      <div className="rounded-lg border border-dashed border-border bg-muted/20 p-8 text-center text-sm text-muted-foreground">
+        No specs yet. Click <strong>+ New Project</strong> to start one.
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      {/* Controls */}
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="relative flex-1 min-w-[180px]">
+          <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+          <input
+            type="search"
+            placeholder="Search specs…"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            className="w-full rounded-md border border-border bg-background py-1.5 pl-8 pr-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+          />
+        </div>
+        <div className="flex items-center gap-1 text-xs text-muted-foreground">
+          Sort:
+          {(['touched', 'depth', 'name', 'cost'] as SortKey[]).map((k) => (
+            <button
+              key={k}
+              type="button"
+              onClick={() => onSort(k)}
+              className={cn(
+                'rounded-md px-2 py-1 transition-colors',
+                sortKey === k
+                  ? 'bg-accent text-accent-foreground font-medium'
+                  : 'hover:bg-accent/50 hover:text-foreground',
+              )}
+            >
+              {k === 'touched' ? 'Last touched' : k[0].toUpperCase() + k.slice(1)}
+              {sortKey === k && <ArrowUpDown className={cn('ml-1 inline h-3 w-3', sortDir === 'asc' && 'rotate-180')} />}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {error && (
+        <div className="rounded-md border border-red-300 bg-red-50 p-3 text-sm text-red-800">
+          <strong>Error:</strong> {error}
+        </div>
+      )}
+
+      {/* Table */}
+      <div className="overflow-hidden rounded-lg border border-border">
+        <div
+          className="grid gap-3 border-b border-border bg-muted/40 px-4 py-2 text-[11px] font-medium uppercase tracking-wide text-muted-foreground"
+          style={{ gridTemplateColumns: '1fr 140px 100px 100px 110px' }}
+        >
+          <span>Spec</span>
+          <span>Depth</span>
+          <span className="text-right tabular-nums">Cost</span>
+          <span className="text-right tabular-nums">Touched</span>
+          <span className="text-right">Action</span>
+        </div>
+        <ul className="divide-y divide-border">
+          {filtered.map((p) => {
+            const depth = depthForProject(p)
+            const isReady = depth === 'ready'
+            const isPromoting = promoting === p.slug
+            return (
+              <li
+                key={p.id}
+                className="grid items-center gap-3 px-4 py-3 text-sm transition-colors hover:bg-muted/40"
+                style={{ gridTemplateColumns: '1fr 140px 100px 100px 110px' }}
+              >
+                <Link
+                  href={`/projects/${p.slug}`}
+                  className="min-w-0 flex-col hover:underline underline-offset-2"
+                >
+                  <div className="truncate font-medium text-foreground">{p.name}</div>
+                  {p.description && (
+                    <div className="truncate text-xs text-muted-foreground">{p.description}</div>
+                  )}
+                </Link>
+                <div><SpecDepthPill project={p} /></div>
+                <div className="text-right tabular-nums text-muted-foreground">
+                  ${(p.cost?.totalSpend ?? 0).toFixed(2)}
+                </div>
+                <div className="text-right tabular-nums text-muted-foreground">
+                  {timeAgo(p.updatedAt ?? p.lastCheckpointAt)}
+                </div>
+                <div className="flex justify-end">
+                  {isReady ? (
+                    <Button
+                      size="sm"
+                      onClick={() => promote(p.slug)}
+                      disabled={isPromoting}
+                      className="h-7"
+                    >
+                      {isPromoting ? <Loader2 className="h-3 w-3 animate-spin" /> : <Rocket className="h-3 w-3" />}
+                      <span className="ml-1.5 text-xs">Build this</span>
+                    </Button>
+                  ) : (
+                    <Link
+                      href={`/projects/${p.slug}`}
+                      className="text-xs text-muted-foreground hover:text-foreground underline underline-offset-2"
+                    >
+                      Open →
+                    </Link>
+                  )}
+                </div>
+              </li>
+            )
+          })}
+        </ul>
+        {filtered.length === 0 && query && (
+          <div className="px-4 py-6 text-center text-sm text-muted-foreground">
+            No specs match &ldquo;{query}&rdquo;.
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
Reshapes the dashboard around the mental model we landed on: **specs are first-class, long-lived artifacts**. You can have ten specs sitting around as ideas; the ones you commit to building graduate to the Building section.

## What's in
- **SpecsTable** — dense table layout (columns: Spec / Depth / Cost / Touched / Action), sort (last-touched / depth / name / cost), search, whole-row hover, empty state
- **SpecDepthPill** — 5-level color-coded pills (brainstorm → researched → specced → designed → ready to build); brainstorm and ready distinguishable today, intermediate levels land when per-discipline completion is exposed via the bridge
- **"Build this"** action on \`ready\` specs — POSTs to existing \`/api/projects/{slug}/start\` to kick off the Loop
- Dashboard layout reordered: Needs Attention → Specs → Building → Shipped; "In Spec" card section removed (terminology collision)

## Design source
Patterns borrowed from The Works' portfolio table (\`prototypes/dashboard-v1/src/app/page.tsx\`): dense rows, right-aligned numerics, hover state, color-coded stage pills.

## Not in this PR (follow-ups)
- Per-discipline depth mapping (needs bridge field: which seeding phases have completed)
- Click depth pill → modal with phase breakdown
- Archive/unarchive specs
- Tighter build card redesign (unchanged here)

## Verified
- [x] Typechecks clean
- [x] 285/285 CLI tests
- [x] \`docs:check\` green
- [x] Homepage renders Specs section with table, Depth pills, Ideas-in-development label

🤖 Generated with [Claude Code](https://claude.com/claude-code)