### PR TITLE
rename UX: inline title edit + marketing-suggested name banner

### DIFF
--- a/dashboard/src/app/api/projects/[name]/route.ts
+++ b/dashboard/src/app/api/projects/[name]/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { loadServerConfig } from "@/lib/server-config";
 import {
@@ -8,6 +8,17 @@ import {
 } from "@/lib/project-details";
 
 export const dynamic = "force-dynamic";
+
+// States in which a slug rename is safe (pre-build). Once the Loop starts,
+// git history, deploy targets, and checkpoint filenames key on the slug,
+// so we refuse to rename to avoid orphaning them.
+const SLUG_RENAMEABLE_STATES = new Set([
+  "seeding", "ready",
+]);
+
+function slugify(v: string): string {
+  return v.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 64);
+}
 
 export async function GET(
   _request: Request,
@@ -33,5 +44,81 @@ export async function GET(
     lastCheckpointAt: checkpoint.lastCheckpointAt,
     lastPhase: checkpoint.lastPhase,
     checkpointCount: checkpoint.checkpointCount,
+  });
+}
+
+// PATCH /api/projects/[name]
+// Body: { displayName?: string, slug?: string }
+// - displayName: updates state.json name field. Always safe.
+// - slug: renames the project directory on disk. Only allowed in seeding
+//   or ready states (pre-build). Response includes new slug for client
+//   redirect.
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ name: string }> },
+) {
+  const { name } = await params;
+  const { projectsRoot } = loadServerConfig();
+  const projectDir = join(projectsRoot, name);
+  const stateFile = join(projectDir, "state.json");
+
+  if (!existsSync(stateFile)) {
+    return NextResponse.json({ error: "Project not found" }, { status: 404 });
+  }
+
+  const body = (await request.json().catch(() => ({}))) as {
+    displayName?: string;
+    slug?: string;
+  };
+
+  const state = JSON.parse(readFileSync(stateFile, "utf-8"));
+  const currentState = state.current_state ?? state.state ?? "unknown";
+
+  let slugChanged: string | null = null;
+
+  // Slug rename (filesystem mv)
+  if (body.slug && body.slug !== name) {
+    if (!SLUG_RENAMEABLE_STATES.has(currentState)) {
+      return NextResponse.json({
+        error: `Slug rename not allowed in state "${currentState}". Rename only works during seeding or ready states, before the build loop starts.`,
+      }, { status: 409 });
+    }
+    const newSlug = slugify(body.slug);
+    if (!newSlug || !/^[a-z][a-z0-9-]*$/.test(newSlug)) {
+      return NextResponse.json({
+        error: "Slug must start with a lowercase letter and contain only lowercase letters, digits, and hyphens.",
+      }, { status: 400 });
+    }
+    const newDir = join(projectsRoot, newSlug);
+    if (existsSync(newDir)) {
+      return NextResponse.json({ error: `A project at slug "${newSlug}" already exists.` }, { status: 409 });
+    }
+    try {
+      renameSync(projectDir, newDir);
+      slugChanged = newSlug;
+    } catch (err) {
+      return NextResponse.json({ error: err instanceof Error ? err.message : String(err) }, { status: 500 });
+    }
+  }
+
+  // Display-name update
+  if (body.displayName !== undefined) {
+    const trimmed = body.displayName.trim();
+    if (trimmed.length === 0) {
+      return NextResponse.json({ error: "displayName must not be empty" }, { status: 400 });
+    }
+    // Bridge mapper resolves display name from state.project ?? state.name ??
+    // slug (bridge-mapper.ts:236). Write both so the rename wins regardless
+    // of which field existing seeding output already populated.
+    state.name = trimmed;
+    state.project = trimmed;
+    const targetDir = slugChanged ? join(projectsRoot, slugChanged) : projectDir;
+    writeFileSync(join(targetDir, "state.json"), JSON.stringify(state, null, 2) + "\n");
+  }
+
+  return NextResponse.json({
+    ok: true,
+    slug: slugChanged ?? name,
+    slugChanged: !!slugChanged,
   });
 }

--- a/dashboard/src/components/name-suggestion-banner.tsx
+++ b/dashboard/src/components/name-suggestion-banner.tsx
@@ -1,0 +1,116 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Loader2, Sparkles, X } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+
+/**
+ * Shows a banner on Untitled specs when the seeding swarm has proposed
+ * a product name. Reads `state.json.suggestedName` via the project API
+ * (no type plumbing). One-click accept renames display + slug.
+ * Dismissible. Inert today until the marketing prompt starts emitting
+ * suggestedName — the scaffolding is ready.
+ */
+export function NameSuggestionBanner({
+  slug,
+  currentName,
+  state,
+}: {
+  slug: string
+  currentName: string
+  state: string
+}) {
+  const router = useRouter()
+  const [suggestedName, setSuggestedName] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [dismissed, setDismissed] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Poll for a suggestedName — cheap, only runs while on an Untitled spec.
+  useEffect(() => {
+    if (currentName.trim().toLowerCase() !== 'untitled') return
+    let cancelled = false
+    const check = async () => {
+      try {
+        const res = await fetch(`/api/projects/${encodeURIComponent(slug)}`)
+        if (!res.ok) return
+        const body = await res.json()
+        if (cancelled) return
+        if (typeof body.suggestedName === 'string' && body.suggestedName.trim()) {
+          setSuggestedName(body.suggestedName.trim())
+        }
+      } catch { /* silent */ }
+    }
+    check()
+    const interval = setInterval(check, 15000)
+    return () => { cancelled = true; clearInterval(interval) }
+  }, [slug, currentName])
+
+  // Only show when:
+  // - there IS a suggestion
+  // - current name is still a placeholder (Untitled)
+  // - suggestion differs from current
+  // - user hasn't dismissed it this session
+  const show =
+    !dismissed &&
+    !!suggestedName &&
+    currentName.trim().toLowerCase() === 'untitled' &&
+    suggestedName.trim().toLowerCase() !== currentName.trim().toLowerCase()
+
+  if (!show || !suggestedName) return null
+
+  async function accept() {
+    setBusy(true)
+    setError(null)
+    try {
+      const res = await fetch(`/api/projects/${encodeURIComponent(slug)}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          displayName: suggestedName,
+          // Only rename slug while still seeding/ready.
+          slug: state === 'seeding' || state === 'ready' ? suggestedName : undefined,
+        }),
+      })
+      const body = await res.json()
+      if (!res.ok) throw new Error(body.error ?? `HTTP ${res.status}`)
+      if (body.slugChanged) {
+        router.push(`/projects/${body.slug}`)
+        router.refresh()
+      } else {
+        router.refresh()
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="rounded-lg border border-violet-200 bg-violet-50 p-3 flex items-start gap-3">
+      <Sparkles className="h-5 w-5 text-violet-600 shrink-0 mt-0.5" />
+      <div className="flex-1 min-w-0">
+        <p className="text-sm text-violet-900">
+          The seeding swarm suggests naming this <strong>{suggestedName}</strong>.
+        </p>
+        {error && <p className="mt-1 text-xs text-red-700">{error}</p>}
+      </div>
+      <div className="flex items-center gap-2 shrink-0">
+        <Button size="sm" onClick={accept} disabled={busy}>
+          {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+          <span className={busy ? 'ml-2' : ''}>Use this name</span>
+        </Button>
+        <button
+          type="button"
+          onClick={() => setDismissed(true)}
+          className="p-1 text-violet-700 hover:text-violet-900"
+          title="Dismiss"
+          disabled={busy}
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/dashboard/src/components/project-header.tsx
+++ b/dashboard/src/components/project-header.tsx
@@ -5,6 +5,8 @@ import { StackBar } from '@/components/stack-icons'
 import { ProjectStack } from '@/components/project-stack'
 import { InfrastructureStack } from '@/components/infrastructure-stack'
 import { CycleRhythm } from '@/components/cycle-rhythm'
+import { ProjectTitleEditable } from '@/components/project-title-editable'
+import { NameSuggestionBanner } from '@/components/name-suggestion-banner'
 import { ExternalLink, ArrowLeft } from 'lucide-react'
 import Link from 'next/link'
 import { cn } from '@/lib/utils'
@@ -65,10 +67,13 @@ export function ProjectHeader({
         Dashboard
       </Link>
 
+      {/* Marketing / seeding-swarm name suggestion — only shows on Untitled specs */}
+      <NameSuggestionBanner slug={project.slug} currentName={project.name} state={project.state} />
+
       {/* Title row with inline metrics */}
       <div className="flex flex-wrap items-center justify-between gap-4">
         <div className="flex flex-wrap items-center gap-4">
-          <h1 className="text-2xl font-bold tracking-tight text-gray-900">{project.name}</h1>
+          <ProjectTitleEditable slug={project.slug} name={project.name} state={project.state} />
           <StateBadge state={project.state} size="lg" />
         </div>
 

--- a/dashboard/src/components/project-title-editable.tsx
+++ b/dashboard/src/components/project-title-editable.tsx
@@ -1,0 +1,138 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Check, Loader2, Pencil, X } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+/**
+ * Inline-editable project title. Click to edit — updates display name
+ * via PATCH /api/projects/[slug]. If the current state allows slug
+ * rename (seeding/ready), the slug is regenerated from the new name
+ * and the URL follows.
+ */
+export function ProjectTitleEditable({
+  slug,
+  name,
+  state,
+  className,
+}: {
+  slug: string
+  name: string
+  state: string
+  className?: string
+}) {
+  const router = useRouter()
+  const [editing, setEditing] = useState(false)
+  const [draft, setDraft] = useState(name)
+  const [alsoRenameSlug, setAlsoRenameSlug] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const canRenameSlug = state === 'seeding' || state === 'ready'
+
+  function startEdit() {
+    setDraft(name)
+    setAlsoRenameSlug(canRenameSlug && name === 'Untitled') // default on when renaming from Untitled
+    setError(null)
+    setEditing(true)
+  }
+
+  function cancel() {
+    setDraft(name)
+    setEditing(false)
+    setError(null)
+  }
+
+  async function save() {
+    const trimmed = draft.trim()
+    if (!trimmed || trimmed === name) { cancel(); return }
+    setSaving(true)
+    setError(null)
+    try {
+      const payload: { displayName: string; slug?: string } = { displayName: trimmed }
+      if (alsoRenameSlug && canRenameSlug) {
+        payload.slug = trimmed
+      }
+      const res = await fetch(`/api/projects/${encodeURIComponent(slug)}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+      const body = await res.json()
+      if (!res.ok) throw new Error(body.error ?? `HTTP ${res.status}`)
+      if (body.slugChanged) {
+        router.push(`/projects/${body.slug}`)
+        router.refresh()
+      } else {
+        router.refresh()
+      }
+      setEditing(false)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (!editing) {
+    return (
+      <button
+        type="button"
+        onClick={startEdit}
+        className={cn(
+          'group inline-flex items-center gap-2 rounded-md -mx-1.5 px-1.5 py-0.5 hover:bg-muted/60 transition-colors',
+          className,
+        )}
+        title="Rename"
+      >
+        <span className="text-2xl font-bold tracking-tight text-gray-900">{name}</span>
+        <Pencil className="h-4 w-4 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity" />
+      </button>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="flex items-center gap-2">
+        <input
+          type="text"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') save()
+            if (e.key === 'Escape') cancel()
+          }}
+          autoFocus
+          disabled={saving}
+          className="rounded-md border border-border bg-background px-2 py-1 text-2xl font-bold text-gray-900 focus:outline-none focus:ring-2 focus:ring-ring"
+        />
+        <button type="button" onClick={save} disabled={saving} className="rounded-md border border-border p-1.5 hover:bg-accent" title="Save (Enter)">
+          {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Check className="h-4 w-4 text-green-600" />}
+        </button>
+        <button type="button" onClick={cancel} disabled={saving} className="rounded-md border border-border p-1.5 hover:bg-accent" title="Cancel (Esc)">
+          <X className="h-4 w-4 text-muted-foreground" />
+        </button>
+      </div>
+      {canRenameSlug && (
+        <label className="flex items-center gap-2 text-xs text-muted-foreground">
+          <input
+            type="checkbox"
+            checked={alsoRenameSlug}
+            onChange={(e) => setAlsoRenameSlug(e.target.checked)}
+            disabled={saving}
+          />
+          Also rename the project directory (URL will change)
+        </label>
+      )}
+      {!canRenameSlug && (
+        <p className="text-xs text-muted-foreground">
+          Directory slug is locked once the build loop starts — only the display name will change.
+        </p>
+      )}
+      {error && (
+        <p className="text-xs text-red-700">{error}</p>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
Closes the loop on chat-first project creation (#123).

## What's in
- **Inline title edit** — click the project title, type, Enter. Pre-build specs can also rename the slug (URL follows); post-build is display-only.
- **Name suggestion banner** — shows on Untitled specs when \`state.json.suggestedName\` is set. One-click accept renames display + slug. Dismissible. Polls every 15s.
- **PATCH /api/projects/[name]** with safety: slug rename 403s once state is past \`ready\`; writes both \`state.project\` and \`state.name\` so bridge mapper resolves the new name regardless of which field existing seeding output populated.

## Follow-up (not in this PR)
Wire the marketing prompt (or earlier seeding phases) to emit \`suggestedName\` in state.json. Today the banner is inert — scaffolding ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)