### PR TITLE
auth: multi-provider env mux + per-spec authMode (Phase A)

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -47,7 +47,7 @@ The Rouge CLI
     rouge slack start               Start the Slack bot
     rouge slack test                Send a test webhook message
 
-  Integrations: stripe, supabase, sentry, slack, cloudflare, vercel
+  Integrations: stripe, supabase, sentry, slack, cloudflare, vercel, llm
 
   Suppress experimental warnings: ROUGE_SUPPRESS_EXPERIMENTAL_WARNING=1
 ```

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@slack/bolt": "^4.6.0"
   },
   "scripts": {
-    "test": "node tests/secrets.test.js && node tests/cli.test.js && node tests/self-improve.test.js && node --test test/launcher/*.test.js test/prompts/*.test.js test/integration/*.test.js",
+    "test": "node tests/secrets.test.js && node tests/cli.test.js && node tests/self-improve.test.js && node tests/auth-mode.test.js && node --test test/launcher/*.test.js test/prompts/*.test.js test/integration/*.test.js",
     "dashboard": "cd dashboard && npm run dev",
     "dashboard:install": "cd dashboard && npm install",
     "dashboard:build": "cd dashboard && npm ci --include=dev && npm run build && node ../scripts/stage-standalone.js",

--- a/schemas/state.json
+++ b/schemas/state.json
@@ -52,6 +52,12 @@
         "capabilities_activated": { "type": "array", "items": { "type": "string", "enum": ["foundation-cycle", "dependency-ordering", "parallel-building", "integration-pass", "integration-escalation", "foundation-evaluation"] } }
       }
     },
+    "authMode": {
+      "type": "string",
+      "enum": ["subscription", "api", "bedrock", "vertex"],
+      "default": "subscription",
+      "description": "Which Anthropic auth path the Claude subprocess uses. Set per-spec. Default subscription."
+    },
     "timestamp": { "type": "string", "format": "date-time" }
   }
 }

--- a/src/launcher/auth-mode.js
+++ b/src/launcher/auth-mode.js
@@ -1,0 +1,72 @@
+/**
+ * Multi-provider Claude auth mux.
+ *
+ * Phase A of LLM provider support — pure plumbing, no UI. Given a project
+ * state and the keychain-loaded secrets env, produce the spawn env that
+ * routes Claude Code to the chosen provider (subscription | api | bedrock |
+ * vertex).
+ *
+ * Precedence for selecting the mode:
+ *   1. ROUGE_LLM_PROVIDER env var (CI / power-user override)
+ *   2. state.authMode
+ *   3. default 'subscription'
+ *
+ * Subscription mode MUST remove any inherited ANTHROPIC_API_KEY from the
+ * child env — Claude Code warns on dual creds and can silently bill the
+ * user's API account instead of using the subscription. Verified 2026-04-15.
+ */
+
+const VALID_MODES = ['subscription', 'api', 'bedrock', 'vertex'];
+
+function resolveAuthMode(state) {
+  const override = process.env.ROUGE_LLM_PROVIDER;
+  if (override && VALID_MODES.includes(override)) return override;
+  const stateMode = state && state.authMode;
+  if (stateMode && VALID_MODES.includes(stateMode)) return stateMode;
+  return 'subscription';
+}
+
+/**
+ * Build the env for `spawn('claude', …)` based on auth mode.
+ *
+ * @param {object} opts
+ * @param {object} [opts.state] — project state.json contents (may be null)
+ * @param {Record<string,string>} [opts.secretsEnv] — keychain-loaded secrets
+ * @param {Record<string,string>} [opts.baseEnv] — starting env (defaults to process.env)
+ * @returns {{ env: Record<string,string>, mode: string }}
+ */
+function buildClaudeEnv({ state, secretsEnv = {}, baseEnv = process.env } = {}) {
+  const mode = resolveAuthMode(state);
+  const env = { ...baseEnv, ...secretsEnv };
+
+  // Scrub every provider-selection var first. Each mode sets only what it needs.
+  delete env.ANTHROPIC_API_KEY;
+  delete env.CLAUDE_CODE_USE_BEDROCK;
+  delete env.CLAUDE_CODE_USE_VERTEX;
+
+  if (mode === 'api') {
+    const key = secretsEnv.ANTHROPIC_API_KEY || baseEnv.ANTHROPIC_API_KEY;
+    if (key) env.ANTHROPIC_API_KEY = key;
+  } else if (mode === 'bedrock') {
+    env.CLAUDE_CODE_USE_BEDROCK = '1';
+    const id = secretsEnv.AWS_BEDROCK_ACCESS_KEY_ID || baseEnv.AWS_BEDROCK_ACCESS_KEY_ID;
+    const secret = secretsEnv.AWS_BEDROCK_SECRET_ACCESS_KEY || baseEnv.AWS_BEDROCK_SECRET_ACCESS_KEY;
+    const region = secretsEnv.AWS_BEDROCK_REGION || baseEnv.AWS_BEDROCK_REGION || baseEnv.AWS_REGION;
+    if (id) env.AWS_ACCESS_KEY_ID = id;
+    if (secret) env.AWS_SECRET_ACCESS_KEY = secret;
+    if (region) env.AWS_REGION = region;
+  } else if (mode === 'vertex') {
+    env.CLAUDE_CODE_USE_VERTEX = '1';
+    const project = secretsEnv.GCP_VERTEX_PROJECT || baseEnv.GCP_VERTEX_PROJECT;
+    const region = secretsEnv.GCP_VERTEX_REGION || baseEnv.GCP_VERTEX_REGION;
+    const adc = secretsEnv.GCP_VERTEX_ADC || baseEnv.GCP_VERTEX_ADC;
+    if (project) env.ANTHROPIC_VERTEX_PROJECT_ID = project;
+    if (region) env.CLOUD_ML_REGION = region;
+    if (adc) env.GOOGLE_APPLICATION_CREDENTIALS = adc;
+  }
+  // subscription mode: no provider vars set (already scrubbed above)
+
+  return { env, mode };
+}
+
+module.exports = { buildClaudeEnv, resolveAuthMode, VALID_MODES };

--- a/src/launcher/doctor.js
+++ b/src/launcher/doctor.js
@@ -75,12 +75,25 @@ function runDoctor({ ROUGE_ROOT, getSecret } = {}) {
       : { id: 'slack', label: 'Slack tokens', status: 'blocker', detail: 'not configured', installHint: 'rouge setup slack' });
   }
 
-  // Anthropic auth
+  // Anthropic auth — mode-aware. Reports which provider(s) are configured and
+  // which one the subprocess would actually pick today (env override > state
+  // default of subscription).
   if (claudeOut) {
-    const authCheck = tryExec('claude -p "test" --max-turns 0', 10000);
-    push(authCheck !== null
-      ? { id: 'anthropic-auth', label: 'Anthropic auth', status: 'ok', detail: 'valid' }
-      : { id: 'anthropic-auth', label: 'Anthropic auth', status: 'blocker', detail: 'invalid', installHint: 'claude login' });
+    const override = process.env.ROUGE_LLM_PROVIDER;
+    const activeMode = override || 'subscription';
+    const modes = [];
+    // Subscription: claude login-based; the -p --max-turns 0 call hits it.
+    const subOk = tryExec('claude -p "test" --max-turns 0', 10000) !== null;
+    if (subOk) modes.push('subscription (claude login)');
+    if (getSecret && getSecret('llm', 'ANTHROPIC_API_KEY')) modes.push('api key');
+    if (getSecret && getSecret('llm', 'AWS_BEDROCK_ACCESS_KEY_ID')) modes.push('bedrock');
+    if (getSecret && getSecret('llm', 'GCP_VERTEX_PROJECT')) modes.push('vertex');
+
+    if (modes.length === 0) {
+      push({ id: 'anthropic-auth', label: 'Anthropic auth', status: 'blocker', detail: 'no provider configured', installHint: 'claude login (for subscription) or configure an API key in dashboard setup' });
+    } else {
+      push({ id: 'anthropic-auth', label: 'Anthropic auth', status: 'ok', detail: `active: ${activeMode} · available: ${modes.join(', ')}` });
+    }
   }
 
   // Optional: Supabase CLI

--- a/src/launcher/rouge-cli.js
+++ b/src/launcher/rouge-cli.js
@@ -159,6 +159,7 @@ const {
   getExpiringSecrets,
   INTEGRATION_KEYS,
 } = require('./secrets.js');
+const { buildClaudeEnv } = require('./auth-mode.js');
 
 // ---------------------------------------------------------------------------
 // Interactive input helper
@@ -539,8 +540,14 @@ function cmdSeed(name) {
   }
 
   const promptContent = fs.readFileSync(promptFile, 'utf8');
+  // Route seeding through the same provider the project will use for build.
+  const statePath = path.join(projectPath, 'state.json');
+  let state = null;
+  try { state = JSON.parse(fs.readFileSync(statePath, 'utf8')); } catch {}
+  const { env: claudeEnv } = buildClaudeEnv({ state });
   const child = spawn('claude', ['-p', '--project', projectPath], {
     stdio: ['pipe', 'inherit', 'inherit'],
+    env: claudeEnv,
   });
   child.stdin.write(promptContent);
   child.stdin.end();

--- a/src/launcher/rouge-loop.js
+++ b/src/launcher/rouge-loop.js
@@ -16,6 +16,7 @@ const { migrateV2StateToV3 } = require('./state-migration.js');
 const { injectPreamble } = require('./preamble-injector.js');
 const { getMilestoneTagName } = require('./branch-strategy.js');
 const { getModelForPhase } = require('./model-selection.js');
+const { buildClaudeEnv } = require('./auth-mode.js');
 
 // Load .env from Rouge root (for ROUGE_SLACK_WEBHOOK, etc.)
 {
@@ -1598,6 +1599,13 @@ async function runPhase(projectDir) {
       path.join(ROUGE_ROOT, 'library'),
     ];
 
+    // Mode-aware env: routes Claude Code to subscription / api / bedrock / vertex.
+    const { env: claudeEnv, mode: authMode } = buildClaudeEnv({
+      state: readJson(stateFile),
+      secretsEnv,
+    });
+    log(`[${projectName}] Auth mode: ${authMode}`);
+
     // spawn (not execFile) for real-time stdout streaming
     const child = spawn('claude', [
       '-p',
@@ -1608,7 +1616,7 @@ async function runPhase(projectDir) {
       ...addDirs.flatMap(dir => ['--add-dir', dir]),
     ], {
       cwd: projectDir,
-      env: { ...process.env, ...secretsEnv },
+      env: claudeEnv,
       stdio: ['pipe', 'pipe', 'pipe'],
     });
 

--- a/src/launcher/secrets.js
+++ b/src/launcher/secrets.js
@@ -378,6 +378,15 @@ const INTEGRATION_KEYS = {
   slack: ['ROUGE_SLACK_WEBHOOK', 'SLACK_BOT_TOKEN', 'SLACK_APP_TOKEN'],
   cloudflare: ['CLOUDFLARE_API_TOKEN', 'CLOUDFLARE_ACCOUNT_ID'],
   vercel: ['VERCEL_TOKEN'],
+  llm: [
+    'ANTHROPIC_API_KEY',
+    'AWS_BEDROCK_ACCESS_KEY_ID',
+    'AWS_BEDROCK_SECRET_ACCESS_KEY',
+    'AWS_BEDROCK_REGION',
+    'GCP_VERTEX_PROJECT',
+    'GCP_VERTEX_REGION',
+    'GCP_VERTEX_ADC',
+  ],
 };
 
 // ---------------------------------------------------------------------------

--- a/tests/auth-mode.test.js
+++ b/tests/auth-mode.test.js
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+/**
+ * Tests for src/launcher/auth-mode.js — spawn env mux across the four
+ * auth modes (subscription / api / bedrock / vertex).
+ */
+
+const { buildClaudeEnv, resolveAuthMode, VALID_MODES } = require('../src/launcher/auth-mode.js');
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, message) {
+  if (condition) { passed++; console.log(`  PASS: ${message}`); }
+  else { failed++; console.error(`  FAIL: ${message}`); }
+}
+function assertEqual(actual, expected, message) {
+  assert(actual === expected, `${message} — expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+}
+
+// Snapshot + restore the one env var we mutate in tests.
+const SAVED_OVERRIDE = process.env.ROUGE_LLM_PROVIDER;
+delete process.env.ROUGE_LLM_PROVIDER;
+
+console.log('\nauth-mode tests');
+console.log('='.repeat(50));
+
+console.log('\n[VALID_MODES]');
+assert(VALID_MODES.includes('subscription') && VALID_MODES.includes('api') &&
+       VALID_MODES.includes('bedrock') && VALID_MODES.includes('vertex'),
+       'exports all four modes');
+
+console.log('\n[resolveAuthMode default]');
+assertEqual(resolveAuthMode(null), 'subscription', 'null state → subscription');
+assertEqual(resolveAuthMode({}), 'subscription', 'empty state → subscription');
+assertEqual(resolveAuthMode({ authMode: 'api' }), 'api', 'state.authMode honored');
+assertEqual(resolveAuthMode({ authMode: 'bogus' }), 'subscription', 'invalid mode falls back');
+
+console.log('\n[ROUGE_LLM_PROVIDER override]');
+process.env.ROUGE_LLM_PROVIDER = 'bedrock';
+assertEqual(resolveAuthMode({ authMode: 'api' }), 'bedrock', 'env var wins over state');
+process.env.ROUGE_LLM_PROVIDER = 'garbage';
+assertEqual(resolveAuthMode({ authMode: 'api' }), 'api', 'invalid override ignored');
+delete process.env.ROUGE_LLM_PROVIDER;
+
+const INHERITED = {
+  ANTHROPIC_API_KEY: 'leaked-from-shell',
+  CLAUDE_CODE_USE_BEDROCK: '1',
+  CLAUDE_CODE_USE_VERTEX: '1',
+  PATH: '/usr/bin',
+};
+
+console.log('\n[subscription mode]');
+{
+  const { env, mode } = buildClaudeEnv({ state: { authMode: 'subscription' }, baseEnv: INHERITED });
+  assertEqual(mode, 'subscription', 'mode reported');
+  assertEqual(env.ANTHROPIC_API_KEY, undefined, 'inherited ANTHROPIC_API_KEY scrubbed');
+  assertEqual(env.CLAUDE_CODE_USE_BEDROCK, undefined, 'Bedrock flag scrubbed');
+  assertEqual(env.CLAUDE_CODE_USE_VERTEX, undefined, 'Vertex flag scrubbed');
+  assertEqual(env.PATH, '/usr/bin', 'unrelated env preserved');
+}
+
+console.log('\n[api mode]');
+{
+  const { env } = buildClaudeEnv({
+    state: { authMode: 'api' },
+    secretsEnv: { ANTHROPIC_API_KEY: 'sk-from-keychain' },
+    baseEnv: INHERITED,
+  });
+  assertEqual(env.ANTHROPIC_API_KEY, 'sk-from-keychain', 'keychain key wins over inherited');
+  assertEqual(env.CLAUDE_CODE_USE_BEDROCK, undefined, 'Bedrock not set');
+  assertEqual(env.CLAUDE_CODE_USE_VERTEX, undefined, 'Vertex not set');
+}
+
+console.log('\n[api mode falls back to inherited ANTHROPIC_API_KEY when no keychain]');
+{
+  const { env } = buildClaudeEnv({ state: { authMode: 'api' }, baseEnv: INHERITED });
+  assertEqual(env.ANTHROPIC_API_KEY, 'leaked-from-shell', 'inherited key used when keychain empty');
+}
+
+console.log('\n[bedrock mode]');
+{
+  const { env } = buildClaudeEnv({
+    state: { authMode: 'bedrock' },
+    secretsEnv: {
+      AWS_BEDROCK_ACCESS_KEY_ID: 'AKIA_X',
+      AWS_BEDROCK_SECRET_ACCESS_KEY: 'secret_x',
+      AWS_BEDROCK_REGION: 'us-west-2',
+    },
+    baseEnv: INHERITED,
+  });
+  assertEqual(env.CLAUDE_CODE_USE_BEDROCK, '1', 'Bedrock flag set');
+  assertEqual(env.ANTHROPIC_API_KEY, undefined, 'ANTHROPIC_API_KEY scrubbed in bedrock mode');
+  assertEqual(env.CLAUDE_CODE_USE_VERTEX, undefined, 'Vertex not set');
+  assertEqual(env.AWS_ACCESS_KEY_ID, 'AKIA_X', 'AWS_ACCESS_KEY_ID mapped');
+  assertEqual(env.AWS_SECRET_ACCESS_KEY, 'secret_x', 'AWS_SECRET_ACCESS_KEY mapped');
+  assertEqual(env.AWS_REGION, 'us-west-2', 'AWS_REGION mapped');
+}
+
+console.log('\n[vertex mode]');
+{
+  const { env } = buildClaudeEnv({
+    state: { authMode: 'vertex' },
+    secretsEnv: {
+      GCP_VERTEX_PROJECT: 'my-proj',
+      GCP_VERTEX_REGION: 'us-central1',
+      GCP_VERTEX_ADC: '/tmp/adc.json',
+    },
+    baseEnv: INHERITED,
+  });
+  assertEqual(env.CLAUDE_CODE_USE_VERTEX, '1', 'Vertex flag set');
+  assertEqual(env.ANTHROPIC_API_KEY, undefined, 'ANTHROPIC_API_KEY scrubbed in vertex mode');
+  assertEqual(env.CLAUDE_CODE_USE_BEDROCK, undefined, 'Bedrock not set');
+  assertEqual(env.ANTHROPIC_VERTEX_PROJECT_ID, 'my-proj', 'project id mapped');
+  assertEqual(env.CLOUD_ML_REGION, 'us-central1', 'region mapped');
+  assertEqual(env.GOOGLE_APPLICATION_CREDENTIALS, '/tmp/adc.json', 'ADC path mapped');
+}
+
+console.log('\n[override wins: state says api, env says subscription]');
+{
+  process.env.ROUGE_LLM_PROVIDER = 'subscription';
+  const { env, mode } = buildClaudeEnv({
+    state: { authMode: 'api' },
+    secretsEnv: { ANTHROPIC_API_KEY: 'sk-from-keychain' },
+    baseEnv: INHERITED,
+  });
+  assertEqual(mode, 'subscription', 'override wins');
+  assertEqual(env.ANTHROPIC_API_KEY, undefined, 'no API key leaked in forced subscription mode');
+  delete process.env.ROUGE_LLM_PROVIDER;
+}
+
+// Restore
+if (SAVED_OVERRIDE !== undefined) process.env.ROUGE_LLM_PROVIDER = SAVED_OVERRIDE;
+
+console.log('\n' + '='.repeat(50));
+console.log(`Results: ${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);
+console.log('All tests passed.\n');


### PR DESCRIPTION
## Summary

Phase A of the LLM provider support plan (`docs/plans/2026-04-16-llm-provider-support.md`). Pure plumbing — no UI.

- Wires the Claude Code subprocess to any of four auth paths: **subscription** (default), **api**, **bedrock**, **vertex**.
- New `llm` integration group in the keychain for API / Bedrock / Vertex creds.
- New `authMode` field on `state.json` (per-spec, defaults to subscription).
- `ROUGE_LLM_PROVIDER` env var override for CI / power users.
- Doctor now reports the active mode + every provider with creds configured, instead of an opaque "valid".

Critical detail: subscription mode explicitly **scrubs** any inherited `ANTHROPIC_API_KEY` / `CLAUDE_CODE_USE_BEDROCK` / `CLAUDE_CODE_USE_VERTEX` from the child env. A leftover shell var could otherwise silently bill the user's API account instead of using their Claude Pro/Max subscription.

Phase B (dropdown + setup wizard step) and Phase C (token-first cost) land in follow-up PRs. v0.4.0 npm release is gated on Phase B.

## Test plan

- [x] `npm test` — 285 node tests + 183 legacy assertions, all green
- [x] `npm run docs:check` — green (CLI reference regenerated; `llm` now shown in integrations list)
- [x] New `tests/auth-mode.test.js` — 30 assertions: mode precedence, env scrubbing per mode, keychain → child-env mapping for each provider
- [ ] Manual: run an existing subscription-mode build end-to-end once CI is green, confirm "Auth mode: subscription" appears in phase log and subprocess still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)