### PR TITLE
budget: per-project cap with $100 default + promote-to-build confirm

### DIFF
--- a/dashboard/src/app/api/projects/[name]/route.ts
+++ b/dashboard/src/app/api/projects/[name]/route.ts
@@ -70,6 +70,7 @@ export async function PATCH(
     displayName?: string;
     slug?: string;
     archived?: boolean;
+    budgetCap?: number;
   };
 
   const state = JSON.parse(readFileSync(stateFile, "utf-8"));
@@ -131,9 +132,20 @@ export async function PATCH(
     state.project = trimmed;
   }
 
-  // Persist state.json once — covers archive toggle, display-name update,
-  // or both in the same request.
-  if (body.displayName !== undefined || body.archived !== undefined) {
+  // Per-project budget cap
+  if (body.budgetCap !== undefined) {
+    const n = Number(body.budgetCap);
+    if (!Number.isFinite(n) || n < 0) {
+      return NextResponse.json({ error: "budgetCap must be a non-negative number" }, { status: 400 });
+    }
+    state.budget_cap_usd = n;
+    // Clear prior alerts so raising the cap doesn't leave stale 80% flags.
+    delete state._cost_alert_80;
+    delete state._cost_alert_50;
+  }
+
+  // Single write — covers display-name, archive toggle, budget cap, or any combo.
+  if (body.displayName !== undefined || body.archived !== undefined || body.budgetCap !== undefined) {
     const targetDir = slugChanged ? join(projectsRoot, slugChanged) : projectDir;
     writeFileSync(join(targetDir, "state.json"), JSON.stringify(state, null, 2) + "\n");
   }

--- a/dashboard/src/app/api/projects/route.ts
+++ b/dashboard/src/app/api/projects/route.ts
@@ -1,10 +1,28 @@
 import { NextResponse } from "next/server";
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
 import { scanProjects } from "@/bridge/scanner";
 import { writeSeedingState } from "@/bridge/seeding-state";
 import { startSeedingSession } from "@/bridge/seed-handler";
 import { loadServerConfig } from "@/lib/server-config";
+
+// Pull the global default cap from rouge.config.json. Falls back to 100
+// if the file isn't found (matches the live default).
+function readDefaultBudgetCap(): number {
+  const candidates = [
+    join(process.cwd(), "rouge.config.json"),
+    resolve(__dirname, "../../../../../../rouge.config.json"),
+  ];
+  for (const p of candidates) {
+    try {
+      if (existsSync(p)) {
+        const cfg = JSON.parse(readFileSync(p, "utf-8")) as { budget_cap_usd?: number };
+        if (typeof cfg.budget_cap_usd === "number") return cfg.budget_cap_usd;
+      }
+    } catch { /* next candidate */ }
+  }
+  return 100;
+}
 
 export const dynamic = "force-dynamic";
 
@@ -42,6 +60,10 @@ export async function POST(request: Request) {
     project: slug,
     name,
     current_state: "seeding",
+    // Per-project cap copied from the global default at creation. Users
+    // can override this from the project page or promote-to-build
+    // confirmation.
+    budget_cap_usd: readDefaultBudgetCap(),
     milestones: [],
     escalations: [],
     seedingProgress: {

--- a/dashboard/src/app/api/system/budget/route.ts
+++ b/dashboard/src/app/api/system/budget/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { assertLoopback } from "@/lib/localhost-guard";
+import { loadServerConfig } from "@/lib/server-config";
 import { existsSync, readFileSync, writeFileSync, readdirSync, statSync } from "node:fs";
 import path from "node:path";
 
@@ -17,12 +18,11 @@ function resolveRougeConfigPath(): string | null {
   return null;
 }
 
-function projectsRoot(): string {
-  return process.env.ROUGE_PROJECTS_DIR ?? path.join(process.env.HOME ?? "/tmp", ".rouge", "projects");
-}
-
 function readTotalSpend(): { total: number; byProject: Record<string, number> } {
-  const root = projectsRoot();
+  // Use the shared server config — the old handcoded `~/.rouge/projects`
+  // fallback didn't match where the launcher actually writes projects
+  // when run from a cloned repo, which broke the spend sum silently.
+  const root = loadServerConfig().projectsRoot;
   const byProject: Record<string, number> = {};
   let total = 0;
   if (!existsSync(root)) return { total, byProject };
@@ -53,7 +53,7 @@ export async function GET() {
 
   const cfgPath = resolveRougeConfigPath();
   const cfg = cfgPath ? JSON.parse(readFileSync(cfgPath, "utf-8")) as { budget_cap_usd?: number } : {};
-  const cap = Number(cfg.budget_cap_usd ?? 50);
+  const cap = Number(cfg.budget_cap_usd ?? 100);
   const spend = readTotalSpend();
   return NextResponse.json({ cap, spend, configPath: cfgPath });
 }

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -7,7 +7,6 @@ import { ProjectCard } from '@/components/project-card'
 import { TopBar } from '@/components/top-bar'
 import { LiveRefresh } from '@/components/live-refresh'
 import { NewProjectButton } from '@/components/new-project-button'
-import { BudgetPanel } from '@/components/budget-panel'
 import { SpecsTable } from '@/components/specs-table'
 import { Archive } from 'lucide-react'
 import Link from 'next/link'
@@ -36,7 +35,8 @@ function mapBridgeProjects(data: Record<string, unknown>[]): ProjectSummary[] {
       progress: Number(p.progress ?? 0),
       confidence: 0.75,
       cost: {
-        totalSpend: Number(p.costUsd ?? 0), budgetCap: 500,
+        totalSpend: Number(p.costUsd ?? 0),
+        budgetCap: typeof p.budgetCapUsd === 'number' ? p.budgetCapUsd : 100,
         breakdown: { llmTokens: 0, deploys: 0, other: 0 },
         lastUpdated: new Date().toISOString(),
       },
@@ -155,10 +155,7 @@ export default async function Home() {
       )}
       <div className="flex flex-wrap items-start justify-between gap-6">
         <TopBar />
-        <div className="flex flex-wrap items-start gap-6">
-          <BudgetPanel />
-          <NewProjectButton />
-        </div>
+        <NewProjectButton />
       </div>
       {archivedCount > 0 && (
         <div className="mt-4 flex justify-end">

--- a/dashboard/src/bridge/scanner.ts
+++ b/dashboard/src/bridge/scanner.ts
@@ -256,6 +256,7 @@ function normalizeProject(
     currentStory: (raw.current_story as string) || undefined,
     escalation,
     costUsd: lastCheckpoint.costUsd,
+    budgetCapUsd: typeof raw.budget_cap_usd === 'number' ? (raw.budget_cap_usd as number) : undefined,
     lastCheckpointAt: lastCheckpoint.timestamp,
     hasStateFile: true,
     providers,

--- a/dashboard/src/bridge/types.ts
+++ b/dashboard/src/bridge/types.ts
@@ -83,6 +83,7 @@ export interface BridgeProjectSummary {
   currentStory?: string
   escalation?: { tier: number; summary: string }
   costUsd?: number
+  budgetCapUsd?: number
   lastCheckpointAt?: string
   hasStateFile: boolean
   providers: string[]

--- a/dashboard/src/components/project-budget-cap-inline.tsx
+++ b/dashboard/src/components/project-budget-cap-inline.tsx
@@ -1,0 +1,121 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Check, Loader2, Pencil, X } from 'lucide-react'
+
+/**
+ * Inline-editable per-project budget cap. Shown next to the spend figure
+ * in the project header. Writes `budget_cap_usd` on state.json via
+ * PATCH /api/projects/[slug] — the launcher reads it on the next phase
+ * and enforces accordingly.
+ *
+ * Displayed bare (no icon) to keep the header quiet. Click the cap number
+ * to edit.
+ */
+export function ProjectBudgetCapInline({
+  slug,
+  cap,
+  totalSpend,
+}: {
+  slug: string
+  cap: number
+  totalSpend: number
+}) {
+  const router = useRouter()
+  const [editing, setEditing] = useState(false)
+  const [draft, setDraft] = useState(String(cap))
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function save() {
+    const n = Number(draft)
+    if (!Number.isFinite(n) || n < 0) {
+      setError('Cap must be a non-negative number')
+      return
+    }
+    if (n === cap) {
+      setEditing(false)
+      return
+    }
+    setSaving(true)
+    setError(null)
+    try {
+      const res = await fetch(`/api/projects/${encodeURIComponent(slug)}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ budgetCap: n }),
+      })
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}))
+        throw new Error(body.error ?? `HTTP ${res.status}`)
+      }
+      setEditing(false)
+      router.refresh()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (editing) {
+    return (
+      <div className="flex flex-col items-end gap-0.5">
+        <div className="flex items-center gap-1 text-sm">
+          <span className="tabular-nums text-gray-900">${totalSpend.toFixed(2)}</span>
+          <span className="text-muted-foreground">/</span>
+          <span className="text-muted-foreground">$</span>
+          <input
+            type="number" min="0" step="10" autoFocus
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') save()
+              if (e.key === 'Escape') { setEditing(false); setDraft(String(cap)); setError(null) }
+            }}
+            disabled={saving}
+            className="w-16 rounded-md border border-border bg-background px-1.5 py-0.5 text-sm tabular-nums focus:outline-none focus:ring-2 focus:ring-ring"
+          />
+          <button
+            type="button"
+            onClick={save}
+            disabled={saving}
+            className="rounded-md border border-border p-1 hover:bg-accent"
+            title="Save (Enter)"
+          >
+            {saving ? <Loader2 className="h-3 w-3 animate-spin" /> : <Check className="h-3 w-3 text-green-600" />}
+          </button>
+          <button
+            type="button"
+            onClick={() => { setEditing(false); setDraft(String(cap)); setError(null) }}
+            disabled={saving}
+            className="rounded-md border border-border p-1 hover:bg-accent"
+            title="Cancel (Esc)"
+          >
+            <X className="h-3 w-3 text-muted-foreground" />
+          </button>
+        </div>
+        <span className="text-[10px] text-muted-foreground">Build Cost · cap</span>
+        {error && <span className="text-[10px] text-red-700">{error}</span>}
+      </div>
+    )
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => setEditing(true)}
+      title="Edit cap"
+      className="group flex flex-col items-end gap-0.5 rounded-md -mx-1 px-1 py-0.5 hover:bg-muted/60 transition-colors"
+    >
+      <span className="inline-flex items-center gap-1 text-sm font-semibold tabular-nums text-gray-900">
+        ${totalSpend.toFixed(2)}
+        <span className="text-muted-foreground font-normal">/</span>
+        <span className="text-muted-foreground tabular-nums">${cap.toFixed(0)}</span>
+        <Pencil className="h-3 w-3 text-muted-foreground/60 group-hover:text-muted-foreground transition-colors" />
+      </span>
+      <span className="text-[10px] text-muted-foreground">Build Cost · cap</span>
+    </button>
+  )
+}

--- a/dashboard/src/components/project-header.tsx
+++ b/dashboard/src/components/project-header.tsx
@@ -7,6 +7,7 @@ import { InfrastructureStack } from '@/components/infrastructure-stack'
 import { CycleRhythm } from '@/components/cycle-rhythm'
 import { ProjectTitleEditable } from '@/components/project-title-editable'
 import { ArchiveButton } from '@/components/archive-button'
+import { ProjectBudgetCapInline } from '@/components/project-budget-cap-inline'
 import { ExternalLink, ArrowLeft } from 'lucide-react'
 import Link from 'next/link'
 import { cn } from '@/lib/utils'
@@ -42,13 +43,6 @@ function HealthRingSmall({ health }: { health: number }) {
       </span>
     </div>
   )
-}
-
-function formatCost(project: ProjectDetail): string {
-  if (project.state === 'complete') {
-    return `Build Cost: $${project.cost.totalSpend.toFixed(2)}`
-  }
-  return `$${project.cost.totalSpend.toFixed(2)} / $${project.cost.budgetCap.toFixed(0)}`
 }
 
 export function ProjectHeader({
@@ -93,12 +87,20 @@ export function ProjectHeader({
             lastPhase={project.lastPhase}
             checkpointCount={project.checkpointCount}
           />
-          <div className="flex flex-col items-center gap-0.5" title="Build cost">
-            <span className="text-sm font-semibold tabular-nums text-gray-900">
-              {formatCost(project)}
-            </span>
-            <span className="text-[10px] text-muted-foreground">Build Cost</span>
-          </div>
+          {project.state === 'complete' ? (
+            <div className="flex flex-col items-center gap-0.5" title="Build cost">
+              <span className="text-sm font-semibold tabular-nums text-gray-900">
+                ${project.cost.totalSpend.toFixed(2)}
+              </span>
+              <span className="text-[10px] text-muted-foreground">Build Cost</span>
+            </div>
+          ) : (
+            <ProjectBudgetCapInline
+              slug={project.slug}
+              cap={project.cost.budgetCap}
+              totalSpend={project.cost.totalSpend}
+            />
+          )}
         </div>
       </div>
 

--- a/dashboard/src/components/setup/defaults-step.tsx
+++ b/dashboard/src/components/setup/defaults-step.tsx
@@ -1,0 +1,122 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Check, Loader2, Save } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Help } from '@/components/ui/help'
+
+/**
+ * Configures the per-project defaults Rouge writes into state.json at
+ * project creation. Today there's one knob — `budget_cap_usd` — but the
+ * step exists so future defaults (LLM provider, etc.) have a home that
+ * isn't buried in a config file.
+ */
+export function DefaultsStep({ onReady }: { onReady: (ready: boolean) => void }) {
+  const [cap, setCap] = useState<number | null>(null)
+  const [draft, setDraft] = useState<string>('')
+  const [saving, setSaving] = useState(false)
+  const [savedBanner, setSavedBanner] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    // Step is always ready — defaults already exist, user may just skim.
+    onReady(true)
+    fetch('/api/system/budget')
+      .then((r) => r.json())
+      .then((d) => {
+        if (typeof d.cap === 'number') {
+          setCap(d.cap)
+          setDraft(String(d.cap))
+        }
+      })
+      .catch((err) => setError(err instanceof Error ? err.message : String(err)))
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  async function save() {
+    const n = Number(draft)
+    if (!Number.isFinite(n) || n < 0) {
+      setError('Cap must be a non-negative number')
+      return
+    }
+    setSaving(true)
+    setError(null)
+    try {
+      const res = await fetch('/api/system/budget', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ cap: n }),
+      })
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}))
+        throw new Error(body.error ?? `HTTP ${res.status}`)
+      }
+      setCap(n)
+      setSavedBanner(`Default cap updated to $${n}. Applies to new projects only — existing projects keep their current cap.`)
+      setTimeout(() => setSavedBanner(null), 4000)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const dirty = cap !== null && Number(draft) !== cap && draft.trim() !== ''
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="text-xl font-semibold text-foreground">New-project defaults</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Settings copied into every new project&apos;s <code>state.json</code> when it&apos;s
+          created. You can change any of these per-project later without touching this step.
+        </p>
+        <Help className="mt-2">
+          <p><strong>Budget cap.</strong> The launcher pauses a build and escalates when cumulative spend passes this value. Per-project — every project has its own, started from this default.</p>
+          <p><strong>Why $100?</strong> A realistic foundation + a few milestones + QA on a small product lands in the $30–80 range. $100 gives most builds enough room without one runaway wiping out a weekend&apos;s budget.</p>
+          <p><strong>Existing projects aren&apos;t touched.</strong> Changing this only affects projects created after the save.</p>
+        </Help>
+      </div>
+
+      {error && (
+        <div className="rounded-md border border-red-300 bg-red-50 p-3 text-sm text-red-800">
+          <strong>Error:</strong> {error}
+        </div>
+      )}
+
+      {savedBanner && (
+        <div className="rounded-md border border-green-300 bg-green-50 p-3 text-sm text-green-800">
+          <Check className="inline h-4 w-4 mr-1" /> {savedBanner}
+        </div>
+      )}
+
+      <div className="rounded-lg border border-border bg-card p-4 space-y-3">
+        <div className="space-y-1.5">
+          <label className="text-sm font-medium text-foreground" htmlFor="default-budget-cap">
+            Default budget cap (USD)
+          </label>
+          <div className="flex items-center gap-2">
+            <span className="text-muted-foreground">$</span>
+            <input
+              id="default-budget-cap"
+              type="number" min="0" step="10"
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter') save() }}
+              disabled={saving || cap === null}
+              placeholder={cap === null ? 'Loading…' : undefined}
+              className="w-32 rounded-md border border-border bg-background px-3 py-1.5 text-sm tabular-nums focus:outline-none focus:ring-2 focus:ring-ring"
+            />
+            <Button size="sm" onClick={save} disabled={saving || !dirty}>
+              {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
+              <span className="ml-2">Save default</span>
+            </Button>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Applied to every new project at creation. Tweak per-project from the project page or the &ldquo;Build this&rdquo; confirmation.
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/dashboard/src/components/setup/setup-wizard.tsx
+++ b/dashboard/src/components/setup/setup-wizard.tsx
@@ -9,9 +9,10 @@ import { DoctorStep } from './doctor-step'
 import { SecretsStep } from './secrets-step'
 import { SlackStep } from './slack-step'
 import { DaemonStep } from './daemon-step'
+import { DefaultsStep } from './defaults-step'
 import { FinishStep } from './finish-step'
 
-type StepId = 'prereqs' | 'secrets' | 'slack' | 'daemon' | 'finish'
+type StepId = 'prereqs' | 'secrets' | 'slack' | 'daemon' | 'defaults' | 'finish'
 
 interface Step {
   id: StepId
@@ -24,13 +25,14 @@ const steps: Step[] = [
   { id: 'secrets', label: 'Integrations (optional)' },
   { id: 'slack', label: 'Slack (optional)' },
   { id: 'daemon', label: 'Background daemon' },
+  { id: 'defaults', label: 'Defaults' },
   { id: 'finish', label: 'Finish' },
 ]
 
 export function SetupWizard() {
   const [activeIdx, setActiveIdx] = useState(0)
   const [readyMap, setReadyMap] = useState<Record<StepId, boolean>>({
-    prereqs: false, secrets: false, slack: false, daemon: false, finish: false,
+    prereqs: false, secrets: false, slack: false, daemon: false, defaults: false, finish: false,
   })
 
   const active = steps[activeIdx]
@@ -114,6 +116,7 @@ export function SetupWizard() {
         {active.id === 'secrets' && <SecretsStep onReady={(r) => markReady('secrets', r)} />}
         {active.id === 'slack' && <SlackStep onReady={(r) => markReady('slack', r)} />}
         {active.id === 'daemon' && <DaemonStep onReady={(r) => markReady('daemon', r)} />}
+        {active.id === 'defaults' && <DefaultsStep onReady={(r) => markReady('defaults', r)} />}
         {active.id === 'finish' && <FinishStep onReady={(r) => markReady('finish', r)} />}
       </div>
 

--- a/dashboard/src/components/specs-table.tsx
+++ b/dashboard/src/components/specs-table.tsx
@@ -34,6 +34,8 @@ export function SpecsTable({ specs }: { specs: ProjectSummary[] }) {
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>('desc')
   const [promoting, setPromoting] = useState<string | null>(null)
   const [deleting, setDeleting] = useState<string | null>(null)
+  const [confirmSlug, setConfirmSlug] = useState<string | null>(null)
+  const [confirmCap, setConfirmCap] = useState<string>('')
   const [error, setError] = useState<string | null>(null)
 
   const filtered = useMemo(() => {
@@ -89,7 +91,6 @@ export function SpecsTable({ specs }: { specs: ProjectSummary[] }) {
         const body = await res.json().catch(() => ({}))
         throw new Error(body.error ?? `HTTP ${res.status}`)
       }
-      // Optimistic reload — page is RSC so a full refresh is fine.
       window.location.reload()
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err))
@@ -97,21 +98,46 @@ export function SpecsTable({ specs }: { specs: ProjectSummary[] }) {
     }
   }
 
-  async function promote(slug: string) {
-    setPromoting(slug)
+  function openPromoteConfirm(slug: string, currentCap: number) {
+    setConfirmSlug(slug)
+    setConfirmCap(String(currentCap))
+    setError(null)
+  }
+
+  async function confirmPromote() {
+    if (!confirmSlug) return
+    const capN = Number(confirmCap)
+    if (!Number.isFinite(capN) || capN < 0) {
+      setError('Cap must be a non-negative number')
+      return
+    }
+    const spec = specs.find((s) => s.slug === confirmSlug)
+    const currentCap = spec?.cost.budgetCap ?? 100
+    setPromoting(confirmSlug)
     setError(null)
     try {
-      // "Promotion" = starting the build loop. A spec in the `ready` state
-      // has everything it needs; /start kicks off the Karpathy Loop and
-      // the project moves into `foundation` (building).
-      const res = await fetch(`/api/projects/${encodeURIComponent(slug)}/start`, {
+      // Persist cap change first (cheap) before starting the build.
+      if (capN !== currentCap) {
+        const patchRes = await fetch(`/api/projects/${encodeURIComponent(confirmSlug)}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ budgetCap: capN }),
+        })
+        if (!patchRes.ok) {
+          const body = await patchRes.json().catch(() => ({}))
+          throw new Error(body.error ?? `HTTP ${patchRes.status}`)
+        }
+      }
+      // "Promotion" = starting the build loop. A spec in `ready` has
+      // everything it needs; /start kicks off the Karpathy Loop and the
+      // project moves into `foundation` (building).
+      const res = await fetch(`/api/projects/${encodeURIComponent(confirmSlug)}/start`, {
         method: 'POST',
       })
       if (!res.ok) {
         const body = await res.json().catch(() => ({}))
         throw new Error(body.error ?? `HTTP ${res.status}`)
       }
-      // The project moves out of Specs and into Building on next render.
       window.location.reload()
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err))
@@ -226,7 +252,7 @@ export function SpecsTable({ specs }: { specs: ProjectSummary[] }) {
                   {isReady ? (
                     <Button
                       size="sm"
-                      onClick={() => promote(p.slug)}
+                      onClick={() => openPromoteConfirm(p.slug, p.cost.budgetCap)}
                       disabled={isPromoting}
                       className="h-7"
                     >
@@ -265,6 +291,63 @@ export function SpecsTable({ specs }: { specs: ProjectSummary[] }) {
           </div>
         )}
       </div>
+
+      {/* Promote-to-build confirmation */}
+      {confirmSlug && (() => {
+        const spec = specs.find((s) => s.slug === confirmSlug)
+        if (!spec) return null
+        const isPromoting = promoting === confirmSlug
+        return (
+          <div
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 p-4"
+            onClick={() => !isPromoting && setConfirmSlug(null)}
+          >
+            <div
+              onClick={(e) => e.stopPropagation()}
+              className="w-full max-w-md rounded-lg border border-border bg-background p-5 shadow-lg"
+            >
+              <h3 className="text-base font-semibold text-foreground">
+                Build <span className="italic">{spec.name}</span>?
+              </h3>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Starts the build loop. Rouge will pause and escalate if spend exceeds the cap below.
+              </p>
+              <label className="mt-4 flex items-center gap-2 text-sm">
+                <span className="w-24 text-muted-foreground">Budget cap</span>
+                <span className="text-muted-foreground">$</span>
+                <input
+                  type="number" min="0" step="10"
+                  value={confirmCap}
+                  onChange={(e) => setConfirmCap(e.target.value)}
+                  disabled={isPromoting}
+                  className="flex-1 rounded-md border border-border bg-background px-2 py-1 text-sm tabular-nums focus:outline-none focus:ring-2 focus:ring-ring"
+                  autoFocus
+                />
+              </label>
+              <p className="mt-1 ml-26 text-[11px] text-muted-foreground">
+                Change the default for future projects in <Link href="/setup" className="underline">Setup</Link>.
+              </p>
+              {error && (
+                <p className="mt-3 text-xs text-red-700">{error}</p>
+              )}
+              <div className="mt-4 flex items-center justify-end gap-2">
+                <button
+                  type="button"
+                  onClick={() => setConfirmSlug(null)}
+                  disabled={isPromoting}
+                  className="rounded-md border border-border px-3 py-1.5 text-sm hover:bg-accent disabled:opacity-50"
+                >
+                  Cancel
+                </button>
+                <Button onClick={confirmPromote} disabled={isPromoting}>
+                  {isPromoting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Rocket className="h-4 w-4" />}
+                  <span className="ml-1.5">Start build</span>
+                </Button>
+              </div>
+            </div>
+          </div>
+        )
+      })()}
     </div>
   )
 }

--- a/dashboard/src/lib/bridge-mapper.ts
+++ b/dashboard/src/lib/bridge-mapper.ts
@@ -74,11 +74,13 @@ interface RougeState {
   }
   // Checkpoint summary from latest checkpoint (added by bridge)
   costUsd?: number | null
+  budgetCapUsd?: number | null
   lastCheckpointAt?: string | null
   lastPhase?: string | null
   checkpointCount?: number
   archived?: boolean
   archivedAt?: string
+  budget_cap_usd?: number
 }
 
 function mapSeedingProgress(raw: RougeState['seedingProgress']): SeedingProgress | undefined {
@@ -247,7 +249,10 @@ export function mapRougeStateToProjectDetail(raw: unknown, slug: string): Projec
     cost: {
       // Real cumulative cost from latest checkpoint, or 0 if no checkpoints yet
       totalSpend: state.costUsd ?? 0,
-      budgetCap: 500, // see rouge.config.json — raised from $50 to $500
+      // Per-project cap from state.json, falls back for ancient projects that
+      // predate per-project caps. The launcher's effective cap is now always
+      // state.budget_cap_usd ?? rouge.config.json.budget_cap_usd.
+      budgetCap: state.budget_cap_usd ?? state.budgetCapUsd ?? 100,
       breakdown: { llmTokens: 0, deploys: 0, other: 0 },
       lastUpdated: now,
     },

--- a/rouge.config.json
+++ b/rouge.config.json
@@ -9,7 +9,7 @@
     ],
     "custom_pre_hooks": []
   },
-  "budget_cap_usd": 50,
+  "budget_cap_usd": 100,
   "spin_detection": {
     "zero_delta_threshold": 3,
     "time_stall_minutes": 30,

--- a/schemas/state.json
+++ b/schemas/state.json
@@ -52,6 +52,11 @@
         "capabilities_activated": { "type": "array", "items": { "type": "string", "enum": ["foundation-cycle", "dependency-ordering", "parallel-building", "integration-pass", "integration-escalation", "foundation-evaluation"] } }
       }
     },
+    "budget_cap_usd": {
+      "type": "number",
+      "minimum": 0,
+      "description": "Per-project spend cap in USD. Overrides rouge.config.json's global default. Launcher pauses the loop when cumulative spend exceeds this."
+    },
     "authMode": {
       "type": "string",
       "enum": ["subscription", "api", "bedrock", "vertex"],

--- a/src/launcher/rouge-loop.js
+++ b/src/launcher/rouge-loop.js
@@ -1414,15 +1414,19 @@ async function runPhase(projectDir) {
   const checkpointsFile = path.join(projectDir, 'checkpoints.jsonl');
   const configFile = path.join(ROUGE_ROOT, 'rouge.config.json');
   const config = readJson(configFile) || {};
-  if (config.budget_cap_usd && checkBudgetCap(state, config.budget_cap_usd)) {
-    log(`[${projectName}] Budget cap reached ($${state.costs?.cumulative_cost_usd?.toFixed(2)} / $${config.budget_cap_usd}) — escalating`);
+  // Per-project cap (set at creation or via dashboard) overrides the
+  // global default. Keeps runaway-build protection but lets a user raise
+  // the cap on a specific build without changing the global default.
+  const effectiveCap = state.budget_cap_usd ?? config.budget_cap_usd;
+  if (effectiveCap && checkBudgetCap(state, effectiveCap)) {
+    log(`[${projectName}] Budget cap reached ($${state.costs?.cumulative_cost_usd?.toFixed(2)} / $${effectiveCap}) — escalating`);
     state.current_state = 'escalation';
     if (!state.escalations) state.escalations = [];
     state.escalations.push({
       id: `esc-budget-cap-${Date.now()}`,
       tier: 2,
       classification: 'budget-exceeded',
-      summary: `Budget cap reached: $${state.costs?.cumulative_cost_usd?.toFixed(2)} / $${config.budget_cap_usd}`,
+      summary: `Budget cap reached: $${state.costs?.cumulative_cost_usd?.toFixed(2)} / $${effectiveCap}`,
       story_id: null,
       status: 'pending',
       created_at: new Date().toISOString(),
@@ -1801,15 +1805,16 @@ async function runPhase(projectDir) {
         writeJson(stateFile, state);
         log(`[${projectName}] Cost: ~${state.costs.phase_cost_usd.toFixed(2)} USD this phase, ~${state.costs.cumulative_cost_usd.toFixed(2)} USD cumulative`);
 
-        // V3: Cost milestone notifications
-        if (config.budget_cap_usd) {
-          const pct = Math.round((state.costs.cumulative_cost_usd / config.budget_cap_usd) * 100);
+        // V3: Cost milestone notifications (per-project cap wins over global)
+        const alertCap = state.budget_cap_usd ?? config.budget_cap_usd;
+        if (alertCap) {
+          const pct = Math.round((state.costs.cumulative_cost_usd / alertCap) * 100);
           if (pct >= 80 && !state._cost_alert_80) {
             state._cost_alert_80 = true;
-            notifyRich('cost-alert', { project: projectName, currentUsd: state.costs.cumulative_cost_usd, budgetUsd: config.budget_cap_usd, percentage: 80 });
+            notifyRich('cost-alert', { project: projectName, currentUsd: state.costs.cumulative_cost_usd, budgetUsd: alertCap, percentage: 80 });
           } else if (pct >= 50 && !state._cost_alert_50) {
             state._cost_alert_50 = true;
-            notifyRich('cost-alert', { project: projectName, currentUsd: state.costs.cumulative_cost_usd, budgetUsd: config.budget_cap_usd, percentage: 50 });
+            notifyRich('cost-alert', { project: projectName, currentUsd: state.costs.cumulative_cost_usd, budgetUsd: alertCap, percentage: 50 });
           }
           writeJson(stateFile, state);
         }


### PR DESCRIPTION
## Summary

Rethinks how the budget cap works. Before: single \`budget_cap_usd\` in \`rouge.config.json\`, applied per-project, with a confusing top-strip that compared global spend to that per-project number. After: real per-project caps, sensible default, and the global widget goes away.

### Launcher
- \`rouge-loop.js\` reads \`state.budget_cap_usd\` as a per-project override, falls back to \`config.budget_cap_usd\`. Escalation summary + 50/80% cost alerts use the effective cap.
- Default bumped 50 → 100 in \`rouge.config.json\`. $50 was a safety valve sized below a realistic build; $100 fits most small products.
- \`schemas/state.json\` gets optional \`budget_cap_usd\`.

### Dashboard
- Project creation copies the global default into the new project's \`state.json\`.
- Project header shows **"$SPEND / $CAP · Build Cost · cap"** inline, click-to-edit.
- **Specs table "Build this" now opens a confirm modal** with an inline cap editor before starting the loop. Setting moment lives where spend actually begins.
- Homepage top-strip BudgetPanel removed — the apples-to-oranges comparison is gone.
- New \`/setup\` step **"Defaults"** — edits the global default cap via the existing \`PUT /api/system/budget\`.

### Bug fixed along the way
\`/api/system/budget\` was reading spend from \`~/.rouge/projects\` even when the launcher ran from a cloned repo with projects at \`\$ROUGE_ROOT/projects\`. That's why the top-strip read \$0.00 while individual cards showed real dollars. Now uses \`loadServerConfig()\`.

## Test plan

- [x] \`npm test\` (dashboard) — 196/196
- [x] \`npm test\` (root) — 285/285
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run docs:check\` — clean
- [ ] **Manual UI verification needed**:
  - New spec → open state.json → confirm \`budget_cap_usd: 100\`
  - Project header shows editable cap, click to change, save, reload — sticks
  - Specs table "Build this" on a \`ready\` spec — modal opens with cap, tweak, start
  - Setup page new "Defaults" step — edit global default, create another new spec, confirm it picks up the new default

🤖 Generated with [Claude Code](https://claude.com/claude-code)