### PR TITLE
polish: wire Platform totals, drop confidence placeholder, disclose catalogue

### DIFF
--- a/dashboard/src/app/catalogue/page.tsx
+++ b/dashboard/src/app/catalogue/page.tsx
@@ -1,5 +1,6 @@
 import { catalogue } from '@/data/catalogue'
 import { CatalogueTabs } from '@/components/catalogue-tabs'
+import { Beaker } from 'lucide-react'
 
 export default function CataloguePage() {
   return (
@@ -13,9 +14,32 @@ export default function CataloguePage() {
           {catalogue.length}
         </span>
       </div>
-      <p className="mb-6 text-sm text-muted-foreground">
+      <p className="mb-4 text-sm text-muted-foreground">
         Available technologies, services, and integration patterns.
       </p>
+
+      {/* Static-data disclosure. The catalogue ships as a curated seed
+          taxonomy so Rouge has a shared vocabulary on day one. Wiring each
+          entry to live per-project usage (which builds actually depend on
+          Supabase, how the Cloudflare slot is filled, etc.) is a
+          contribution opportunity — see CONTRIBUTING.md. */}
+      <div className="mb-6 flex items-start gap-3 rounded-lg border border-violet-200 bg-violet-50 px-4 py-3 text-sm text-violet-900">
+        <Beaker className="mt-0.5 h-4 w-4 shrink-0 text-violet-600" />
+        <div>
+          <p className="font-medium">Seed taxonomy — not yet live state.</p>
+          <p className="mt-0.5 text-xs text-violet-800">
+            The catalogue ships with a curated starter set so every Rouge
+            install speaks the same vocabulary on day one. Turning it into
+            live project inventory — which builds actually use which
+            entries, quota headroom per integration, real-time status — is
+            an open contribution. See
+            {' '}
+            <a className="underline underline-offset-2" href="https://github.com/gregario/the-rouge/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener noreferrer">
+              CONTRIBUTING.md
+            </a>.
+          </p>
+        </div>
+      </div>
 
       {/* Catalogue browser */}
       <CatalogueTabs entities={catalogue} />

--- a/dashboard/src/app/platform/page.tsx
+++ b/dashboard/src/app/platform/page.tsx
@@ -1,5 +1,4 @@
 import { fetchBridgePlatform, isBridgeEnabled } from '@/lib/bridge-client'
-import { platform } from '@/data/platform'
 import { ProviderSlotCard } from '@/components/provider-slot-card'
 import { LiveRefresh } from '@/components/live-refresh'
 
@@ -22,11 +21,13 @@ interface PlatformData {
     limit?: number
   }>
   totalProjects: number
+  totalSpendUsd: number
+  totalCapUsd: number
 }
 
 async function getData(): Promise<{ data?: PlatformData; error?: string }> {
   if (!isBridgeEnabled()) {
-    return { data: { quotas: [], totalProjects: 0 } }
+    return { data: { quotas: [], totalProjects: 0, totalSpendUsd: 0, totalCapUsd: 0 } }
   }
   try {
     const data = await fetchBridgePlatform()
@@ -59,20 +60,25 @@ export default async function PlatformPage() {
       {data && (
         <>
           <div className="mb-8 grid grid-cols-2 gap-4 sm:grid-cols-4">
-            <div className="rounded-lg border border-gray-200 bg-gray-50 px-6 py-5">
+            <div className="rounded-lg border border-gray-200 bg-gray-50 px-6 py-5" title="Sum of cumulative_cost_usd across all non-archived projects">
               <p className="text-xs font-medium uppercase tracking-wider text-gray-400">
-                Monthly Spend
+                Total Spend
               </p>
               <p className="mt-1 text-3xl font-bold tabular-nums text-gray-900">
-                ${platform.totalMonthlySpend.toFixed(0)}
+                ${data.totalSpendUsd.toFixed(2)}
               </p>
             </div>
-            <div className="rounded-lg border border-gray-200 bg-gray-50 px-6 py-5">
+            <div className="rounded-lg border border-gray-200 bg-gray-50 px-6 py-5" title="Sum of per-project budget caps minus total spend">
               <p className="text-xs font-medium uppercase tracking-wider text-gray-400">
                 Budget Remaining
               </p>
-              <p className="mt-1 text-3xl font-bold tabular-nums text-green-600">
-                ${platform.budgetRemaining.toFixed(0)}
+              <p className={`mt-1 text-3xl font-bold tabular-nums ${
+                data.totalCapUsd - data.totalSpendUsd < 0 ? 'text-red-600' : 'text-green-600'
+              }`}>
+                ${(data.totalCapUsd - data.totalSpendUsd).toFixed(2)}
+              </p>
+              <p className="mt-1 text-[10px] text-muted-foreground tabular-nums">
+                of ${data.totalCapUsd.toFixed(0)} capped
               </p>
             </div>
             <div className="rounded-lg border border-gray-200 bg-gray-50 px-6 py-5">

--- a/dashboard/src/bridge/platform-reader.ts
+++ b/dashboard/src/bridge/platform-reader.ts
@@ -19,6 +19,12 @@ export interface ProviderQuota {
 export interface PlatformData {
   quotas: ProviderQuota[]
   totalProjects: number
+  // Aggregated spend figures across all non-archived projects. Cap total is
+  // the sum of per-project budget_cap_usd (falling back to globalDefault for
+  // projects that predate per-project caps). Spend total sums
+  // state.costs.cumulative_cost_usd, same field as the project cards.
+  totalSpendUsd: number
+  totalCapUsd: number
 }
 
 // Provider limits (free tier / common defaults — display only, not enforced)
@@ -30,6 +36,25 @@ const DEFAULT_LIMITS: Record<string, number> = {
   posthog: 20,
 }
 
+// Read rouge.config.json's global default cap. Projects that predate
+// per-project caps still fall back to this at enforcement time, so we mirror
+// that in aggregation.
+function readGlobalDefaultCap(projectsRoot: string): number {
+  const candidates = [
+    join(projectsRoot, '..', 'rouge.config.json'),
+    join(process.cwd(), 'rouge.config.json'),
+  ]
+  for (const p of candidates) {
+    try {
+      if (existsSync(p)) {
+        const cfg = JSON.parse(readFileSync(p, 'utf-8')) as { budget_cap_usd?: number }
+        if (typeof cfg.budget_cap_usd === 'number') return cfg.budget_cap_usd
+      }
+    } catch { /* next */ }
+  }
+  return 100
+}
+
 export function readPlatformData(projectsRoot: string): PlatformData {
   const entries = readdirSync(projectsRoot)
   const providerMap: Record<string, ProviderProject[]> = {
@@ -39,6 +64,9 @@ export function readPlatformData(projectsRoot: string): PlatformData {
     sentry: [],
     posthog: [],
   }
+  const globalDefaultCap = readGlobalDefaultCap(projectsRoot)
+  let totalSpendUsd = 0
+  let totalCapUsd = 0
 
   for (const entry of entries) {
     const projectDir = join(projectsRoot, entry)
@@ -79,6 +107,16 @@ export function readPlatformData(projectsRoot: string): PlatformData {
     // Only `waiting-for-human` maps to paused; everything else is active.
     const status: 'active' | 'paused' =
       currentState === 'waiting-for-human' ? 'paused' : 'active'
+
+    // Archived projects don't count toward spend or cap totals — they're
+     // parked, not active budget. Mirrors the homepage filter.
+    if (state.archived !== true) {
+      const costs = (state.costs as { cumulative_cost_usd?: number } | undefined) ?? {}
+      const spend = typeof costs.cumulative_cost_usd === 'number' ? costs.cumulative_cost_usd : 0
+      const cap = typeof state.budget_cap_usd === 'number' ? (state.budget_cap_usd as number) : globalDefaultCap
+      totalSpendUsd += spend
+      totalCapUsd += cap
+    }
 
     const project: ProviderProject = { slug: entry, name, deployUrl, status }
 
@@ -141,5 +179,10 @@ export function readPlatformData(projectsRoot: string): PlatformData {
     }
   }).length
 
-  return { quotas, totalProjects }
+  return {
+    quotas,
+    totalProjects,
+    totalSpendUsd,
+    totalCapUsd,
+  }
 }

--- a/dashboard/src/components/metrics-sidebar.tsx
+++ b/dashboard/src/components/metrics-sidebar.tsx
@@ -1,7 +1,6 @@
 import type { ProjectDetail } from '@/lib/types'
 import { Card, CardContent } from '@/components/ui/card'
 import { StateBadge } from '@/components/state-badge'
-import { Sparkline } from '@/components/sparkline'
 import { cn } from '@/lib/utils'
 import { ExternalLink } from 'lucide-react'
 
@@ -28,8 +27,6 @@ export function MetricsSidebar({ project }: { project: ProjectDetail }) {
     project.cost.budgetCap > 0
       ? (project.cost.totalSpend / project.cost.budgetCap) * 100
       : 0
-  const confidenceData = project.confidenceHistory.map((p) => p.value)
-
   return (
     <div className="flex flex-col gap-3" data-testid="metrics-sidebar">
       {/* Health */}
@@ -49,21 +46,6 @@ export function MetricsSidebar({ project }: { project: ProjectDetail }) {
               className={cn('h-full rounded-full transition-all', healthBg(project.health))}
               style={{ width: `${Math.min(project.health, 100)}%` }}
             />
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* Confidence */}
-      <Card size="sm">
-        <CardContent>
-          <div className="flex items-center justify-between">
-            <span className="text-xs text-muted-foreground">Confidence</span>
-            <span className="text-lg font-bold tabular-nums text-foreground">
-              {Math.round(project.confidence * 100)}%
-            </span>
-          </div>
-          <div className="mt-1">
-            <Sparkline data={confidenceData} width={200} height={28} className="w-full" />
           </div>
         </CardContent>
       </Card>

--- a/dashboard/src/components/project-card.tsx
+++ b/dashboard/src/components/project-card.tsx
@@ -42,7 +42,7 @@ function ProgressRing({ progress, hasEscalation, size = 48 }: { progress: number
           strokeDasharray={circumference} strokeDashoffset={circumference - filled}
         />
       </svg>
-      <span className={cn('absolute text-sm font-bold tabular-nums', progressColor(progress, hasEscalation))}>
+      <span className={cn('absolute text-[11px] font-bold tabular-nums', progressColor(progress, hasEscalation))}>
         {progress}%
       </span>
     </div>


### PR DESCRIPTION
Pre-release cleanup of the visible mock data you spotted.

## Platform page

- **Monthly Spend** (\$75 hardcoded) → **Total Spend**, now sums \`state.costs.cumulative_cost_usd\` across every non-archived project.
- **Budget Remaining** (\$185 hardcoded) → now computed as \`totalCapUsd − totalSpendUsd\`, red when negative, with a subscript showing the cap total. Cap total sums per-project \`budget_cap_usd\` (fallback to the \`rouge.config.json\` default for legacy projects).
- Archived projects excluded so parked work doesn't distort the remaining figure.

Matches the semantics you proposed: the numbers now add up in the expected direction — money actually spent, and what's left before any project hits its cap.

## Project detail

Dropped the Confidence card from MetricsSidebar. \`project.confidence\` was a \`0.75\` placeholder in \`bridge-mapper.ts\` with a \"Rouge doesn't surface this yet\" comment — showing it misled users into thinking the number meant something.

## Catalogue

Added a prominent disclosure above the browser:

> **Seed taxonomy — not yet live state.**
> The catalogue ships with a curated starter set so every Rouge install speaks the same vocabulary on day one. Turning it into live project inventory — which builds actually use which entries, quota headroom per integration, real-time status — is an open contribution. See CONTRIBUTING.md.

Framed as a deliberate design choice (shared vocabulary from day one) rather than an apology for missing data, with a clear contribution path.

## Cards

Progress ring percentage text dropped from \`text-sm\` to \`text-[11px]\` so \"100%\" fits inside the 48px ring cleanly.

## Test plan

- [x] \`npx tsc --noEmit\` — clean
- [x] Dashboard vitest — 196/196
- [ ] Manual: load \`/platform\`, confirm Total Spend matches the sum shown on project cards; Budget Remaining equals (sum of caps - sum of spend).
- [ ] Manual: load a project, confirm Confidence card is gone from the sidebar.
- [ ] Manual: load \`/catalogue\`, confirm the violet \"seed taxonomy\" banner renders above the tabs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)