### PR TITLE
feat(#103 PR a): tool-surface audit + vendor manifest contract

### DIFF
--- a/docs/contributing/adding-a-vendor.md
+++ b/docs/contributing/adding-a-vendor.md
@@ -1,0 +1,103 @@
+# Adding a vendor to The Rouge
+
+A vendor is any cloud provider Rouge orchestrates on the user's behalf: Vercel, Supabase, Cloudflare, GitHub, Fly, Neon, etc. Vendors are loaded by convention — drop one directory into `library/vendors/` and the launcher picks it up at startup.
+
+## Contract
+
+Every vendor is one directory containing exactly two files:
+
+```
+library/vendors/<name>/
+  manifest.yaml   # declarative configuration
+  handler.js     # intent implementations + ownership verification
+```
+
+`<name>` must be lowercase kebab-case (e.g. `fly`, `cloudflare-workers`) and must equal the `name` field in `manifest.yaml`.
+
+## `manifest.yaml`
+
+Validated against `schemas/vendor-manifest.json` at launcher startup. Invalid manifests abort boot — fail loud, not mid-build.
+
+Required fields: `name`, `version`, `intents`, `ownership_fence`. Typical structure:
+
+```yaml
+name: fly
+version: 1
+description: Fly.io app deploys via flyctl
+
+deny_patterns:
+  - "Bash(flyctl *)"
+  - "Bash(fly *)"
+
+intents:
+  - name: deploy-staging
+    handler: deployStaging
+    description: Deploy the staging app via the Fly Machines API
+  - name: deploy-production
+    handler: deployProduction
+  - name: rollback-production
+    handler: rollbackProduction
+
+ownership_fence:
+  manifest_field: fly_app_id
+  verify: verifyOwnership
+  pre_foundation_snapshot: listExistingApps
+
+escalations:
+  - infrastructure-ownership-ambiguity
+  - vendor-auth-expired
+```
+
+## `handler.js`
+
+Exports the functions named in the manifest. Handlers are called by `processInfraAction()` in `src/launcher/rouge-loop.js` after a phase writes `pending-action.json`.
+
+```js
+// library/vendors/fly/handler.js
+
+export async function deployStaging(action, context) {
+  // action: the parsed pending-action.json body
+  // context: { projectDir, manifest, state, logger }
+  // Return: { success: true, details: {...} } or { success: false, error: "..." }
+}
+
+export async function verifyOwnership(expectedId, liveResource) {
+  // Called before every infra callback fires.
+  // Return: { matches: true } or { matches: false, reason: "..." }
+}
+
+export async function listExistingApps(context) {
+  // Optional. Populates state.json:existing_external_resources before foundation.
+  // Return: array of { id, name, created_at } for resources already in the user's account.
+}
+```
+
+## Rules
+
+- **Never shell out to the vendor CLI from a prompt.** The `deny_patterns` you declare are enforced against every Claude subprocess. If the handler needs to call `flyctl`, call it from `handler.js` (launcher-side) — not from a phase prompt.
+- **Never allow force-push or destructive defaults.** If your vendor has destructive operations (drop, destroy, purge), require a second confirmation via the escalation contract.
+- **Ownership fence is mandatory.** Every vendor must declare `ownership_fence`. The launcher refuses to dispatch any intent for a vendor whose `verifyOwnership` returns `matches: false`. This is the mechanism that prevents the #103 class of incident.
+- **Secrets.** Never read secrets from `process.env` directly in `handler.js`. Use `src/launcher/secrets.js` — it enforces the keychain backend and audit log.
+
+## Testing
+
+Every vendor must ship with `test/vendors/<name>.test.js` covering:
+
+1. Schema validation of the manifest.
+2. Each declared intent handler called with a valid action — asserts `success: true`.
+3. Each handler called with an invalid action (missing field, wrong type) — asserts graceful failure, not throw.
+4. `verifyOwnership` — positive and negative cases.
+5. `pre_foundation_snapshot` if declared — mock the provider API, assert snapshot shape matches `schemas/state.json` `existing_external_resources` field.
+
+The launcher test harness exposes `mockVendorContext()` — use it. See `test/vendors/_template.test.js`.
+
+## Checklist before opening a PR
+
+- [ ] `manifest.yaml` validates against `schemas/vendor-manifest.json`
+- [ ] Every declared intent has a matching export in `handler.js`
+- [ ] `verifyOwnership` export exists and is wired to `ownership_fence.verify`
+- [ ] `deny_patterns` cover the vendor's CLI (including `npx <cli>` form if applicable)
+- [ ] No secrets read directly from `process.env`
+- [ ] Tests cover intents, ownership, and snapshot (if declared)
+- [ ] `docs/design/phase-tool-surface.md` updated if the vendor adds new Rouge-core patterns (rare)
+- [ ] PR description lists every intent introduced and links the escalation classifications

--- a/docs/design/phase-tool-surface.md
+++ b/docs/design/phase-tool-surface.md
@@ -1,0 +1,70 @@
+# Phase Tool Surface Audit
+
+Audit of every `bash` block in `src/prompts/**` as of #103 PR (a). Categorizes each command into: **allow** (Rouge-core whitelist), **route-to-intent** (must go through `INFRA_ACTION_HANDLERS`), or **deny** (must not appear in prompts at all).
+
+## Allow — Rouge-core whitelist
+
+These patterns are used by multiple phases and are safe to grant directly. They go into `.claude/settings.json` under `permissions.allow`.
+
+| Pattern | Used by |
+|---|---|
+| `Bash(git status)` | 01-building, 00-foundation-building |
+| `Bash(git log *)` | 01-building, 00-foundation-building |
+| `Bash(git diff *)` | 02c-code-review |
+| `Bash(git add *)` | 02a, 02c, 02d, 02e, 02f, 10, 00-foundation-evaluating |
+| `Bash(git commit *)` | 02a, 02c, 02d, 02e, 02f, 10, 00-foundation-evaluating |
+| `Bash(npm test *)` | final-validation-gate |
+| `Bash(npm audit *)` | 02c-code-review |
+| `Bash(npx eslint *)` | 02c-code-review |
+| `Bash(npx jscpd *)` | 02c-code-review |
+| `Bash(npx madge *)` | 02c-code-review |
+| `Bash(npx knip *)` | 02c-code-review |
+| `Bash(npx @sentry/cli *)` | final-validation-gate |
+| `Bash(mkdir -p *)` | 02d, 02f, 10, seeding/02 |
+| `Bash(find *)` | 02c-code-review |
+| `Bash(jq *)`, `Bash(test *)`, `Bash(xargs *)`, `Bash(wc *)`, `Bash(sort *)`, `Bash(head *)`, `Bash(grep *)` | shell utilities used across walk/evaluation phases |
+| `Bash(openspec *)` | seeding/04-spec, 05-change-spec-generation |
+| `Bash(src/*.sh *)` | 02-evaluation-orchestrator (rouge-diff-scope.sh, review-readiness.sh) |
+| `Bash($B *)` | 02d, 02f, 10, final-gate, seeding/02 (gstack browse binary, path from `$ROUGE_BROWSE_BIN`) |
+
+## Route-to-intent — removed from prompts
+
+These were in prompts but must not be executed by Claude directly. They are handled by the launcher via `pending-action.json` → `INFRA_ACTION_HANDLERS`.
+
+| Previous command | Replaced by intent |
+|---|---|
+| `npx wrangler versions deploy …` (07-ship-promote rollback) | `rollback-production` (vendor-dispatched) |
+| `vercel rollback` (07-ship-promote) | `rollback-production` |
+| `vercel deploy`, `vercel link`, `vercel env …` | `deploy-staging`, `deploy-production`, `env-set` (already shipped in Layer 4 Phase 1) |
+| `supabase db push`, `supabase functions deploy` | `db-migrate` (already shipped) |
+| `supabase projects create` | `provision-database` (to be added in PR (b)) |
+| `gh repo create` | `provision-repo` (to be added in PR (b)) |
+| `git push …` | `git-push` (already shipped, never allows `force: true`) |
+
+## Deny — must never appear in prompts
+
+Added to `.claude/settings.json` `permissions.deny` so a Claude subprocess is refused if it tries.
+
+| Pattern | Rationale |
+|---|---|
+| `Bash(vercel *)` | Provider CLI — must route via intent |
+| `Bash(supabase *)` | Provider CLI — must route via intent |
+| `Bash(gh *)` | GitHub CLI — must route via intent |
+| `Bash(wrangler *)`, `Bash(npx wrangler *)` | Cloudflare CLI — must route via intent |
+| `Bash(flyctl *)`, `Bash(aws *)`, `Bash(gcloud *)`, `Bash(heroku *)` | Vendor CLIs not yet supported — escalate |
+| `Bash(git push *)` | Push only via `git-push` intent (enforces no-force) |
+| `Bash(rm -rf *)` | Never destructive mass delete from a prompt |
+| `Bash(curl *)`, `Bash(wget *)` | Network fetch only via `web-fetch` intent |
+
+Deny takes precedence over allow per Claude Code permission semantics.
+
+## Footguns noted
+
+- **`$B` expansion.** The browse binary path is stored in `$ROUGE_BROWSE_BIN`. Allow pattern `Bash($B *)` only matches the literal string `$B *`, not the expanded path. PR (b) must either (a) resolve the binary path at spawn time and whitelist the resolved path, or (b) rename the prompt convention to always invoke by absolute path and whitelist `Bash(*/browse *)`. Tracked for PR (b).
+- **`eval $(src/rouge-diff-scope.sh main)`** in 02-evaluation-orchestrator. `eval` is a classic footgun. Out of scope for PR (a); noted for a follow-up to replace with `source <(…)` or variable assignment.
+- **Compound commands.** Prompts use `&&`, `||`, `|` extensively. Claude Code splits these and matches each leg against the allowlist independently. Every leg must be in the allow list or the whole command is denied. Audit above lists each leg separately.
+- **`npx` is not stripped.** `Bash(npx:*)` would be far too broad. Each `npx <tool>` is whitelisted by specific tool name.
+
+## Vendor extensibility
+
+Vendor-specific allow/deny patterns live in `library/vendors/<vendor>/manifest.yaml` and are merged into the launcher-constructed `--allowedTools` at spawn time. See `docs/contributing/adding-a-vendor.md` and `schemas/vendor-manifest.json`. The Rouge-core allow/deny in this document is vendor-agnostic.

--- a/library/vendors/README.md
+++ b/library/vendors/README.md
@@ -1,0 +1,9 @@
+# Vendors
+
+Each subdirectory here is one infrastructure vendor Rouge can orchestrate — Vercel, Supabase, Cloudflare, GitHub, Fly, etc.
+
+The launcher auto-discovers every `library/vendors/<name>/manifest.yaml` at startup, validates it against `schemas/vendor-manifest.json`, and wires the declared intents into `INFRA_ACTION_HANDLERS` + the declared `deny_patterns` into the spawn-time `--allowedTools` list.
+
+**To add a vendor:** read `docs/contributing/adding-a-vendor.md`. One manifest, one handler, one test file. No edits to `rouge-loop.js`, prompts, or `.claude/settings.json`.
+
+**Existing vendor support** currently lives inline in `src/launcher/rouge-loop.js` (Layer 4 Phase 1 shipped `deploy-staging`, `deploy-production`, `db-migrate`, `db-seed`, `git-push`, `git-tag`). Migration of those into per-vendor manifests happens in PR (b) of #103.

--- a/schemas/vendor-manifest.json
+++ b/schemas/vendor-manifest.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://the-rouge.dev/schemas/vendor-manifest.json",
+  "title": "Vendor Manifest",
+  "description": "Declarative contract for an infrastructure vendor (Vercel, Supabase, Cloudflare, Fly, etc.). The launcher auto-discovers every library/vendors/<name>/manifest.yaml at startup, validates against this schema, and wires the declared intents into INFRA_ACTION_HANDLERS plus the declared deny_patterns into --allowedTools.",
+  "type": "object",
+  "required": ["name", "version", "intents", "ownership_fence"],
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9-]*$",
+      "description": "Vendor slug. Must match the containing directory name (library/vendors/<name>/)."
+    },
+    "version": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Manifest schema version this file targets. Current: 1."
+    },
+    "description": {
+      "type": "string",
+      "description": "One-line human summary of what the vendor is and what Rouge uses it for."
+    },
+    "allow_patterns": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": [],
+      "description": "Bash patterns the vendor explicitly grants to Claude subprocesses. Usually empty — vendors should route through intents, not grant shell access. Use sparingly; anything here widens the attack surface."
+    },
+    "deny_patterns": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": [],
+      "description": "Bash patterns that must be denied whenever this vendor is loaded. E.g. ['Bash(vercel *)', 'Bash(npx vercel *)']."
+    },
+    "intents": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["name", "handler"],
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Intent action name registered into INFRA_ACTION_HANDLERS. E.g. 'deploy-staging', 'rollback-production', 'provision-database'."
+          },
+          "handler": {
+            "type": "string",
+            "description": "Name of the exported function in handler.js. Receives (action, context) and returns { success, details }."
+          },
+          "description": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ownership_fence": {
+      "type": "object",
+      "required": ["manifest_field", "verify"],
+      "additionalProperties": false,
+      "properties": {
+        "manifest_field": {
+          "type": "string",
+          "description": "Field in the project's infrastructure_manifest.json that stores the vendor-side identifier (e.g. vercel_project_id, supabase_project_ref). Deploy-blocking compares this against the live resource before any infra callback fires."
+        },
+        "verify": {
+          "type": "string",
+          "description": "Name of the exported verifyOwnership function in handler.js. Given (expectedId, liveResource) returns { matches: boolean, reason?: string }."
+        },
+        "pre_foundation_snapshot": {
+          "type": "string",
+          "description": "Optional. Name of a handler.js export that lists pre-existing resources in the user's account. The launcher calls this before foundation starts to populate state.json:existing_external_resources, which gates ambiguous adoptions."
+        }
+      }
+    },
+    "escalations": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": [],
+      "description": "Escalation classifications this vendor can raise (e.g. 'infrastructure-ownership-ambiguity', 'vendor-auth-expired'). Used by the escalation-response contract (#101)."
+    }
+  }
+}

--- a/src/prompts/loop/07-ship-promote.md
+++ b/src/prompts/loop/07-ship-promote.md
@@ -184,17 +184,17 @@ On successful promotion, update `cycle_context.json`:
 
 ### Step 7.5 — Rollback Plan
 
-If post-deploy verification fails (production URL returns errors, key user flows broken), execute the platform-appropriate rollback. Read `infrastructure_manifest.json` for the deployment target:
+If post-deploy verification fails (production URL returns errors, key user flows broken), request a rollback via the intent callback protocol. Do not run provider CLIs directly — the launcher executes the rollback on your behalf using the vendor handler registered in `library/vendors/<vendor>/handler.js`.
 
-**Cloudflare Workers:**
-```bash
-npx wrangler versions list --name <worker-name>
-npx wrangler versions deploy <previous-version-id>@100% --name <worker-name> --yes
+Write `pending-action.json`:
+```json
+{
+  "action": "rollback-production",
+  "reason": "<one-line why verification failed>"
+}
 ```
 
-**Vercel:** Use the Vercel dashboard or `vercel rollback` to revert to the previous production deployment.
-
-**Other platforms:** Read the rollback procedure from the integration catalogue. If no rollback procedure exists, ESCALATE.
+The launcher reads `infrastructure_manifest.json` to determine the vendor, dispatches to the vendor handler, and writes the result to `action-result.json`. If no vendor handler exists for the target, the launcher escalates automatically.
 
 On any rollback:
 1. Log the failure in `cycle_context.json` under `ship_error` with the rollback details.


### PR DESCRIPTION
## Summary

Prerequisite PR for Layer 4 Phase 2 of #103. No runtime behavior change — sets up the audit, prompt canonicalization, and vendor-manifest extensibility contract that PR (b) builds on.

- **docs/design/phase-tool-surface.md** — audit of every `bash` block across `src/prompts/**`. Categorized allow / route-to-intent / deny. Footguns noted (compound-command splitting, `$B` expansion, `eval` in 02-evaluation-orchestrator).
- **src/prompts/loop/07-ship-promote.md** — last direct `npx wrangler versions deploy` rewritten as a `rollback-production` intent via `pending-action.json`, matching the Layer 4 Phase 1 callback pattern.
- **schemas/vendor-manifest.json + docs/contributing/adding-a-vendor.md + library/vendors/README.md** — declarative vendor-manifest contract. Contributors add a vendor (Fly, Neon, etc.) by dropping one directory into `library/vendors/`. Launcher will auto-discover in PR (b) and wire into `--allowedTools` + `INFRA_ACTION_HANDLERS`. Ownership fence is mandatory.

## Deferred to PR (b)

The `.claude/settings.json` permissions baseline was intentionally left out. Reasons:

1. `settings.json` is project-scoped — it affects interactive developer sessions in this repo, not just the Rouge subprocess. Denying `gh *`, `git push *`, `curl *` there would break human workflows.
2. Deny-rule behavior under `--dangerously-skip-permissions` (which the autonomous loop uses today) is not empirically verified. If the dangerous flag bypasses deny, the baseline is theater.

PR (b) will pass `--allowedTools`/`--disallowedTools` per-spawn via CLI flags, scoped to the subprocess only, after an empirical test confirms denial behavior in `-p` mode.

## Test plan

- [x] `npm test` — 285 pass, 0 fail
- [x] Manual read-through of the audit doc against prompt source
- [ ] PR (b): empirical test of `claude -p` denial behavior with/without `--dangerously-skip-permissions`
- [ ] PR (b): shadow-mode run across 2–3 product builds to validate allowlist completeness

Refs #103. Unblocks PR (b) (spawn-site plumbing + `ROUGE_TOOL_ENFORCEMENT` flag + shadow-mode log parser) and PR (d) (ownership fence in `infrastructure_manifest.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)