### PR TITLE
fix(#135): hide state.json from agent cwd via .rouge/ dotdir

### DIFF
--- a/dashboard/src/app/api/projects/[name]/pause/route.ts
+++ b/dashboard/src/app/api/projects/[name]/pause/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { loadServerConfig } from "@/lib/server-config";
+import { statePath } from "@/bridge/state-path";
 
 export const dynamic = "force-dynamic";
 
@@ -11,7 +12,7 @@ export async function POST(
 ) {
   const { name } = await params;
   const { projectsRoot } = loadServerConfig();
-  const stateFile = join(projectsRoot, name, "state.json");
+  const stateFile = statePath(join(projectsRoot, name));
   if (!existsSync(stateFile)) {
     return NextResponse.json({ error: "Project not found" }, { status: 404 });
   }

--- a/dashboard/src/app/api/projects/[name]/resolve-escalation/route.ts
+++ b/dashboard/src/app/api/projects/[name]/resolve-escalation/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { loadServerConfig } from "@/lib/server-config";
+import { statePath } from "@/bridge/state-path";
 
 export const dynamic = "force-dynamic";
 
@@ -18,7 +19,7 @@ export async function POST(
 ) {
   const { name } = await params;
   const { projectsRoot } = loadServerConfig();
-  const stateFile = join(projectsRoot, name, "state.json");
+  const stateFile = statePath(join(projectsRoot, name));
   if (!existsSync(stateFile)) {
     return NextResponse.json({ error: "Project not found" }, { status: 404 });
   }

--- a/dashboard/src/app/api/projects/[name]/route.ts
+++ b/dashboard/src/app/api/projects/[name]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { existsSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { loadServerConfig } from "@/lib/server-config";
+import { statePath } from "@/bridge/state-path";
 import {
   mergeSeedingProgress,
   readCheckpointSummary,
@@ -27,7 +28,7 @@ export async function GET(
   const { name } = await params;
   const { projectsRoot } = loadServerConfig();
   const projectDir = join(projectsRoot, name);
-  const stateFile = join(projectDir, "state.json");
+  const stateFile = statePath(projectDir);
 
   if (!existsSync(stateFile)) {
     return NextResponse.json({ error: "Project not found" }, { status: 404 });
@@ -60,7 +61,7 @@ export async function PATCH(
   const { name } = await params;
   const { projectsRoot } = loadServerConfig();
   const projectDir = join(projectsRoot, name);
-  const stateFile = join(projectDir, "state.json");
+  const stateFile = statePath(projectDir);
 
   if (!existsSync(stateFile)) {
     return NextResponse.json({ error: "Project not found" }, { status: 404 });
@@ -147,7 +148,7 @@ export async function PATCH(
   // Single write — covers display-name, archive toggle, budget cap, or any combo.
   if (body.displayName !== undefined || body.archived !== undefined || body.budgetCap !== undefined) {
     const targetDir = slugChanged ? join(projectsRoot, slugChanged) : projectDir;
-    writeFileSync(join(targetDir, "state.json"), JSON.stringify(state, null, 2) + "\n");
+    writeFileSync(statePath(targetDir), JSON.stringify(state, null, 2) + "\n");
   }
 
   return NextResponse.json({
@@ -169,7 +170,7 @@ export async function DELETE(
   const { name } = await params;
   const { projectsRoot } = loadServerConfig();
   const projectDir = join(projectsRoot, name);
-  const stateFile = join(projectDir, "state.json");
+  const stateFile = statePath(projectDir);
 
   if (!existsSync(stateFile)) {
     return NextResponse.json({ error: "Project not found" }, { status: 404 });

--- a/dashboard/src/app/api/projects/route.ts
+++ b/dashboard/src/app/api/projects/route.ts
@@ -4,6 +4,7 @@ import { join, resolve } from "node:path";
 import { scanProjects } from "@/bridge/scanner";
 import { writeSeedingState } from "@/bridge/seeding-state";
 import { startSeedingSession } from "@/bridge/seed-handler";
+import { statePathForWrite } from "@/bridge/state-path";
 import { loadServerConfig } from "@/lib/server-config";
 
 // Pull the global default cap from rouge.config.json. Falls back to 100
@@ -83,7 +84,7 @@ export async function POST(request: Request) {
     createdAt: new Date().toISOString(),
   };
   writeFileSync(
-    join(projectDir, "state.json"),
+    statePathForWrite(projectDir),
     JSON.stringify(initialState, null, 2),
   );
   writeSeedingState(projectDir, {

--- a/dashboard/src/app/api/system/budget/route.ts
+++ b/dashboard/src/app/api/system/budget/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { assertLoopback } from "@/lib/localhost-guard";
 import { loadServerConfig } from "@/lib/server-config";
+import { statePath } from "@/bridge/state-path";
 import { existsSync, readFileSync, writeFileSync, readdirSync, statSync } from "node:fs";
 import path from "node:path";
 
@@ -31,10 +32,10 @@ function readTotalSpend(): { total: number; byProject: Record<string, number> } 
       const dir = path.join(root, name);
       if (!statSync(dir).isDirectory()) continue;
       // Rouge writes cumulative spend into state.json.costs.cumulative_cost_usd
-      const statePath = path.join(dir, "state.json");
-      if (!existsSync(statePath)) continue;
+      const stateFile = statePath(dir);
+      if (!existsSync(stateFile)) continue;
       try {
-        const state = JSON.parse(readFileSync(statePath, "utf-8")) as { costs?: { cumulative_cost_usd?: number } };
+        const state = JSON.parse(readFileSync(stateFile, "utf-8")) as { costs?: { cumulative_cost_usd?: number } };
         const n = Number(state.costs?.cumulative_cost_usd ?? 0);
         if (n > 0) {
           byProject[name] = n;

--- a/dashboard/src/bridge/__tests__/state-path.test.ts
+++ b/dashboard/src/bridge/__tests__/state-path.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { statePath, statePathForWrite, hasStateFile, ROUGE_DIR, STATE_FILE } from '../state-path'
+
+let dir: string
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'rouge-state-path-'))
+})
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+describe('statePath', () => {
+  it('prefers .rouge/state.json when it exists', () => {
+    mkdirSync(join(dir, ROUGE_DIR))
+    writeFileSync(join(dir, ROUGE_DIR, STATE_FILE), '{}')
+    writeFileSync(join(dir, STATE_FILE), '{}')
+    expect(statePath(dir)).toBe(join(dir, ROUGE_DIR, STATE_FILE))
+  })
+
+  it('falls back to legacy state.json when .rouge/state.json is missing', () => {
+    writeFileSync(join(dir, STATE_FILE), '{}')
+    expect(statePath(dir)).toBe(join(dir, STATE_FILE))
+  })
+
+  it('returns the new path when neither exists (for writes-into-nothing callers)', () => {
+    expect(statePath(dir)).toBe(join(dir, ROUGE_DIR, STATE_FILE))
+  })
+})
+
+describe('statePathForWrite', () => {
+  it('always returns the .rouge/state.json path', () => {
+    writeFileSync(join(dir, STATE_FILE), '{}')
+    expect(statePathForWrite(dir)).toBe(join(dir, ROUGE_DIR, STATE_FILE))
+  })
+
+  it('creates .rouge/ if missing', () => {
+    expect(existsSync(join(dir, ROUGE_DIR))).toBe(false)
+    statePathForWrite(dir)
+    expect(existsSync(join(dir, ROUGE_DIR))).toBe(true)
+  })
+})
+
+describe('hasStateFile', () => {
+  it('is true when .rouge/state.json exists', () => {
+    mkdirSync(join(dir, ROUGE_DIR))
+    writeFileSync(join(dir, ROUGE_DIR, STATE_FILE), '{}')
+    expect(hasStateFile(dir)).toBe(true)
+  })
+
+  it('is true when only legacy state.json exists', () => {
+    writeFileSync(join(dir, STATE_FILE), '{}')
+    expect(hasStateFile(dir)).toBe(true)
+  })
+
+  it('is false when neither exists', () => {
+    expect(hasStateFile(dir)).toBe(false)
+  })
+})

--- a/dashboard/src/bridge/build-runner.ts
+++ b/dashboard/src/bridge/build-runner.ts
@@ -1,6 +1,7 @@
 import { spawn } from 'child_process'
 import { readFileSync, writeFileSync, existsSync, unlinkSync, openSync } from 'fs'
 import { join } from 'path'
+import { statePath as resolveStatePath } from './state-path'
 
 const PID_FILE = '.build-pid'
 
@@ -70,7 +71,7 @@ export function startBuild(
   // 'story-building' if foundation is already complete). The Rouge loop
   // skips projects in 'ready' state — it's waiting for a human trigger.
   // This matches what the Slack bot does in its `start` command.
-  const statePath = join(projectDir, 'state.json')
+  const statePath = resolveStatePath(projectDir)
   if (existsSync(statePath)) {
     try {
       const state = JSON.parse(readFileSync(statePath, 'utf-8'))

--- a/dashboard/src/bridge/derive-title.ts
+++ b/dashboard/src/bridge/derive-title.ts
@@ -1,7 +1,7 @@
 import { readFileSync, writeFileSync, existsSync } from 'fs'
-import { join } from 'path'
 import { runClaude } from './claude-runner'
 import { readChatLog } from './chat-reader'
+import { statePath } from './state-path'
 
 /**
  * One-shot working-title derivation. Called after the first user message
@@ -55,7 +55,7 @@ ${firstUserMessage.slice(0, 2000)}`
 }
 
 function readCurrentName(projectDir: string): string {
-  const file = join(projectDir, 'state.json')
+  const file = statePath(projectDir)
   if (!existsSync(file)) return ''
   try {
     const raw = JSON.parse(readFileSync(file, 'utf-8')) as { name?: string; project?: string }
@@ -66,7 +66,7 @@ function readCurrentName(projectDir: string): string {
 }
 
 function writeName(projectDir: string, title: string): void {
-  const file = join(projectDir, 'state.json')
+  const file = statePath(projectDir)
   if (!existsSync(file)) return
   const raw = JSON.parse(readFileSync(file, 'utf-8'))
   raw.name = title

--- a/dashboard/src/bridge/platform-reader.ts
+++ b/dashboard/src/bridge/platform-reader.ts
@@ -1,5 +1,6 @@
 import { readFileSync, existsSync, readdirSync, statSync } from 'fs'
 import { join } from 'path'
+import { statePath, hasStateFile } from './state-path'
 
 export interface ProviderProject {
   slug: string
@@ -76,13 +77,13 @@ export function readPlatformData(projectsRoot: string): PlatformData {
       continue
     }
 
-    const statePath = join(projectDir, 'state.json')
+    const stateFile = statePath(projectDir)
     const contextPath = join(projectDir, 'cycle_context.json')
-    if (!existsSync(statePath)) continue
+    if (!existsSync(stateFile)) continue
 
     let state: Record<string, unknown> = {}
     try {
-      state = JSON.parse(readFileSync(statePath, 'utf-8'))
+      state = JSON.parse(readFileSync(stateFile, 'utf-8'))
     } catch {
       // ignore
     }
@@ -172,7 +173,7 @@ export function readPlatformData(projectsRoot: string): PlatformData {
     try {
       return (
         statSync(join(projectsRoot, e)).isDirectory() &&
-        existsSync(join(projectsRoot, e, 'state.json'))
+        hasStateFile(join(projectsRoot, e))
       )
     } catch {
       return false

--- a/dashboard/src/bridge/scanner.ts
+++ b/dashboard/src/bridge/scanner.ts
@@ -2,6 +2,7 @@ import { readdirSync, readFileSync, existsSync, statSync } from 'fs'
 import { join } from 'path'
 import type { BridgeProjectSummary } from './types'
 import { readChatLog } from './chat-reader'
+import { statePath } from './state-path'
 
 /**
  * Scan a Rouge projects directory and return normalized summaries
@@ -19,7 +20,7 @@ export function scanProjects(projectsRoot: string): BridgeProjectSummary[] {
       continue
     }
 
-    const stateFile = join(dir, 'state.json')
+    const stateFile = statePath(dir)
     if (!existsSync(stateFile)) continue
 
     try {

--- a/dashboard/src/bridge/seeding-finalize.ts
+++ b/dashboard/src/bridge/seeding-finalize.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync, writeFileSync, readdirSync } from 'fs'
 import { join } from 'path'
+import { statePath as resolveStatePath } from './state-path'
 
 export interface FinalizeResult {
   ok: boolean
@@ -30,7 +31,7 @@ export function finalizeSeeding(projectDir: string): FinalizeResult {
   }
 
   // Transition state.json to ready
-  const statePath = join(projectDir, 'state.json')
+  const statePath = resolveStatePath(projectDir)
   if (existsSync(statePath)) {
     const state = JSON.parse(readFileSync(statePath, 'utf-8'))
     state.current_state = 'ready'

--- a/dashboard/src/bridge/seeding-state.ts
+++ b/dashboard/src/bridge/seeding-state.ts
@@ -1,6 +1,7 @@
 import { readFileSync, writeFileSync, existsSync } from 'fs'
 import { join } from 'path'
 import { DISCIPLINE_SEQUENCE, type SeedingSessionState } from './types'
+import { statePath } from './state-path'
 
 const STATE_FILE = 'seeding-state.json'
 
@@ -59,10 +60,10 @@ function nextDiscipline(complete: string[]): string {
 }
 
 function updateStateJsonDiscipline(projectDir: string, discipline: string): void {
-  const statePath = join(projectDir, 'state.json')
-  if (!existsSync(statePath)) return
+  const stateFile = statePath(projectDir)
+  if (!existsSync(stateFile)) return
   try {
-    const rawState = JSON.parse(readFileSync(statePath, 'utf-8'))
+    const rawState = JSON.parse(readFileSync(stateFile, 'utf-8'))
     if (!rawState.seedingProgress?.disciplines) return
 
     const disciplines = rawState.seedingProgress.disciplines as Array<{ discipline: string; status: string }>
@@ -77,7 +78,7 @@ function updateStateJsonDiscipline(projectDir: string, discipline: string): void
     const current = DISCIPLINE_SEQUENCE.find(d => !complete.includes(d)) ?? DISCIPLINE_SEQUENCE[DISCIPLINE_SEQUENCE.length - 1]
     rawState.seedingProgress.currentDiscipline = current
 
-    writeFileSync(statePath, JSON.stringify(rawState, null, 2))
+    writeFileSync(stateFile, JSON.stringify(rawState, null, 2))
   } catch {
     // If state.json is malformed, skip
   }

--- a/dashboard/src/bridge/state-path.ts
+++ b/dashboard/src/bridge/state-path.ts
@@ -1,0 +1,26 @@
+import { existsSync, mkdirSync } from 'node:fs'
+import { join } from 'node:path'
+
+export const ROUGE_DIR = '.rouge'
+export const STATE_FILE = 'state.json'
+
+export function statePath(projectDir: string): string {
+  const newPath = join(projectDir, ROUGE_DIR, STATE_FILE)
+  if (existsSync(newPath)) return newPath
+  const oldPath = join(projectDir, STATE_FILE)
+  if (existsSync(oldPath)) return oldPath
+  return newPath
+}
+
+export function statePathForWrite(projectDir: string): string {
+  const dir = join(projectDir, ROUGE_DIR)
+  mkdirSync(dir, { recursive: true })
+  return join(dir, STATE_FILE)
+}
+
+export function hasStateFile(projectDir: string): boolean {
+  return (
+    existsSync(join(projectDir, ROUGE_DIR, STATE_FILE)) ||
+    existsSync(join(projectDir, STATE_FILE))
+  )
+}

--- a/dashboard/src/bridge/watcher.ts
+++ b/dashboard/src/bridge/watcher.ts
@@ -3,6 +3,7 @@ import { watch, readFileSync, readdirSync, existsSync, statSync } from 'fs'
 import { join, basename } from 'path'
 import type { FSWatcher } from 'fs'
 import type { BridgeEvent } from './types'
+import { statePath } from './state-path'
 
 /**
  * Watches Rouge project directories for state.json changes.
@@ -90,7 +91,7 @@ export class ProjectWatcher extends EventEmitter {
   }
 
   private initProject(projectDir: string): void {
-    const stateFile = join(projectDir, 'state.json')
+    const stateFile = statePath(projectDir)
     if (!existsSync(stateFile)) return
 
     // Cache initial state
@@ -105,12 +106,11 @@ export class ProjectWatcher extends EventEmitter {
   }
 
   private discoverProject(projectDir: string): void {
-    const stateFile = join(projectDir, 'state.json')
-
     // Check periodically for state.json (it may arrive slightly after the dir)
     const checkForState = (attempts: number) => {
       if (attempts <= 0) return
 
+      const stateFile = statePath(projectDir)
       if (existsSync(stateFile)) {
         try {
           const content = readFileSync(stateFile, 'utf-8')
@@ -139,7 +139,7 @@ export class ProjectWatcher extends EventEmitter {
   }
 
   private watchProject(projectDir: string): void {
-    const stateFile = join(projectDir, 'state.json')
+    const stateFile = statePath(projectDir)
     const projectName = basename(projectDir)
 
     try {
@@ -156,7 +156,7 @@ export class ProjectWatcher extends EventEmitter {
   }
 
   private handleStateChange(projectDir: string, projectName: string): void {
-    const stateFile = join(projectDir, 'state.json')
+    const stateFile = statePath(projectDir)
 
     let content: string
     try {

--- a/src/launcher/estimate-cost.js
+++ b/src/launcher/estimate-cost.js
@@ -15,6 +15,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { statePath } = require('./state-path.js');
 
 const PROJECT_DIR = process.argv[2];
 const ACTUAL_MODE = process.argv.includes('--actual');
@@ -243,7 +244,7 @@ if (ACTUAL_MODE) {
 }
 
 const ctx = readJson(path.join(PROJECT_DIR, 'cycle_context.json'));
-const state = readJson(path.join(PROJECT_DIR, 'state.json'));
+const state = readJson(statePath(PROJECT_DIR));
 
 if (!ctx && !state) {
   console.error('No cycle_context.json or state.json found');

--- a/src/launcher/learn-from-project.js
+++ b/src/launcher/learn-from-project.js
@@ -18,6 +18,7 @@ const fs = require('fs');
 const path = require('path');
 
 const { getLogDir } = require('./logger.js');
+const { statePath } = require('./state-path.js');
 
 const ROUGE_ROOT = path.resolve(__dirname, '../..');
 const PERSONAL_DIR = path.join(ROUGE_ROOT, 'library', 'personal');
@@ -41,7 +42,7 @@ if (!PROJECT_DIR) {
 
 const projectName = path.basename(PROJECT_DIR);
 const ctx = readJson(path.join(PROJECT_DIR, 'cycle_context.json'));
-const state = readJson(path.join(PROJECT_DIR, 'state.json'));
+const state = readJson(statePath(PROJECT_DIR));
 
 if (!ctx || !state) {
   console.error('No cycle_context.json or state.json found');

--- a/src/launcher/migrate-state-to-rouge-dir.js
+++ b/src/launcher/migrate-state-to-rouge-dir.js
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+/**
+ * One-shot migration: move each project's legacy `state.json` into `.rouge/state.json`.
+ *
+ * Motivation (issue #135): with state.json sitting in the project root, any
+ * phase agent spawned with cwd = projectDir auto-ingested the file and
+ * started narrating Rouge's pipeline back at the user instead of doing its
+ * assigned role. Moving state under a `.rouge/` dotdir keeps it out of the
+ * agent's working-directory listing.
+ *
+ * Safe to run repeatedly:
+ *   - skips projects already migrated (`.rouge/state.json` exists)
+ *   - skips directories with no `state.json` at all
+ *   - aborts if both locations exist but the contents differ (conflict)
+ *
+ * Usage: node src/launcher/migrate-state-to-rouge-dir.js [projects-dir]
+ *
+ * Default projects dir: `$ROUGE_PROJECTS_DIR` or `<repo>/projects`.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const { ROUGE_DIR, STATE_FILE } = require('./state-path.js');
+
+function resolveProjectsDir(arg) {
+  if (arg) return path.resolve(arg);
+  if (process.env.ROUGE_PROJECTS_DIR) return process.env.ROUGE_PROJECTS_DIR;
+  return path.join(path.resolve(__dirname, '../..'), 'projects');
+}
+
+function migrateProject(projectDir) {
+  const legacyPath = path.join(projectDir, STATE_FILE);
+  const newDir = path.join(projectDir, ROUGE_DIR);
+  const newPath = path.join(newDir, STATE_FILE);
+
+  const hasLegacy = fs.existsSync(legacyPath);
+  const hasNew = fs.existsSync(newPath);
+
+  if (!hasLegacy && !hasNew) return { status: 'no-state', projectDir };
+  if (!hasLegacy && hasNew) return { status: 'already-migrated', projectDir };
+
+  if (hasLegacy && hasNew) {
+    const legacy = fs.readFileSync(legacyPath, 'utf8');
+    const current = fs.readFileSync(newPath, 'utf8');
+    if (legacy === current) {
+      fs.unlinkSync(legacyPath);
+      return { status: 'cleaned-stale-legacy', projectDir };
+    }
+    return { status: 'conflict', projectDir, detail: 'both files exist with different content — resolve manually' };
+  }
+
+  fs.mkdirSync(newDir, { recursive: true });
+  fs.renameSync(legacyPath, newPath);
+  return { status: 'migrated', projectDir };
+}
+
+function main() {
+  const projectsDir = resolveProjectsDir(process.argv[2]);
+  if (!fs.existsSync(projectsDir)) {
+    console.error(`Projects dir not found: ${projectsDir}`);
+    process.exit(1);
+  }
+
+  const entries = fs.readdirSync(projectsDir, { withFileTypes: true })
+    .filter(e => e.isDirectory())
+    .map(e => path.join(projectsDir, e.name));
+
+  const results = entries.map(migrateProject);
+
+  let migrated = 0;
+  let already = 0;
+  let noState = 0;
+  let conflicts = 0;
+  let cleanedStale = 0;
+
+  for (const r of results) {
+    const label = path.basename(r.projectDir);
+    switch (r.status) {
+      case 'migrated':
+        console.log(`  migrated: ${label}`);
+        migrated++;
+        break;
+      case 'already-migrated':
+        console.log(`  already migrated: ${label}`);
+        already++;
+        break;
+      case 'cleaned-stale-legacy':
+        console.log(`  cleaned stale legacy: ${label}`);
+        cleanedStale++;
+        break;
+      case 'no-state':
+        console.log(`  no state.json: ${label}`);
+        noState++;
+        break;
+      case 'conflict':
+        console.error(`  CONFLICT: ${label} — ${r.detail}`);
+        conflicts++;
+        break;
+    }
+  }
+
+  console.log('');
+  console.log(`Summary: ${migrated} migrated, ${already} already, ${cleanedStale} cleaned, ${noState} no-state, ${conflicts} conflicts`);
+
+  if (conflicts > 0) process.exit(2);
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { migrateProject };

--- a/src/launcher/provision-infrastructure.js
+++ b/src/launcher/provision-infrastructure.js
@@ -10,6 +10,7 @@ const { execSync, execFileSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 const { log: logLine } = require('./logger.js');
+const { statePath, hasStateFile } = require('./state-path.js');
 
 function readJson(filePath) {
   try { return JSON.parse(fs.readFileSync(filePath, 'utf8')); } catch { return null; }
@@ -199,11 +200,12 @@ function provisionSupabase(projectDir, projectName) {
       // Check all Rouge project dirs for a matching supabase ref
       if (!fs.existsSync(PROJECTS_DIR)) return false;
       const rougeDirs = fs.readdirSync(PROJECTS_DIR).filter(d =>
-        fs.existsSync(path.join(PROJECTS_DIR, d, 'state.json'))
+        hasStateFile(path.join(PROJECTS_DIR, d))
       );
       for (const dir of rougeDirs) {
-        const ctx = readJson(path.join(PROJECTS_DIR, dir, 'cycle_context.json'));
-        const state = readJson(path.join(PROJECTS_DIR, dir, 'state.json'));
+        const projectDir = path.join(PROJECTS_DIR, dir);
+        const ctx = readJson(path.join(projectDir, 'cycle_context.json'));
+        const state = readJson(statePath(projectDir));
         if (ctx?.supabase?.project_ref && state?.current_state !== 'complete') {
           // This Rouge project is actively using a Supabase slot
           if (supabaseName.includes(dir) || dir.includes(supabaseName)) return true;

--- a/src/launcher/rouge-cli.js
+++ b/src/launcher/rouge-cli.js
@@ -160,6 +160,7 @@ const {
   INTEGRATION_KEYS,
 } = require('./secrets.js');
 const { buildClaudeEnv } = require('./auth-mode.js');
+const { statePath: resolveStatePath } = require('./state-path.js');
 
 // ---------------------------------------------------------------------------
 // Interactive input helper
@@ -541,7 +542,7 @@ function cmdSeed(name) {
 
   const promptContent = fs.readFileSync(promptFile, 'utf8');
   // Route seeding through the same provider the project will use for build.
-  const statePath = path.join(projectPath, 'state.json');
+  const statePath = resolveStatePath(projectPath);
   let state = null;
   try { state = JSON.parse(fs.readFileSync(statePath, 'utf8')); } catch {}
   const { env: claudeEnv } = buildClaudeEnv({ state });
@@ -735,7 +736,7 @@ async function cmdUninstall() {
 }
 
 function printProjectStatus(name, projectPath) {
-  const statePath = path.join(projectPath, 'state.json');
+  const statePath = resolveStatePath(projectPath);
   if (!fs.existsSync(statePath)) {
     console.log(`  ${name.padEnd(22)} ${'not seeded'.padEnd(22)}`);
     return;

--- a/src/launcher/rouge-loop.js
+++ b/src/launcher/rouge-loop.js
@@ -17,6 +17,7 @@ const { injectPreamble } = require('./preamble-injector.js');
 const { getMilestoneTagName } = require('./branch-strategy.js');
 const { getModelForPhase } = require('./model-selection.js');
 const { buildClaudeEnv } = require('./auth-mode.js');
+const { statePath, statePathForWrite, hasStateFile } = require('./state-path.js');
 
 // Load .env from Rouge root (for ROUGE_SLACK_WEBHOOK, etc.)
 {
@@ -174,11 +175,13 @@ function snapshotState(projectDir, phase) {
   const snapshotDir = path.join(projectDir, '.snapshots', `${Date.now()}-${phase}`);
   try {
     fs.mkdirSync(snapshotDir, { recursive: true });
-    for (const file of ['state.json', 'cycle_context.json']) {
-      const src = path.join(projectDir, file);
-      if (fs.existsSync(src)) {
-        fs.copyFileSync(src, path.join(snapshotDir, file));
-      }
+    const stateSrc = statePath(projectDir);
+    if (fs.existsSync(stateSrc)) {
+      fs.copyFileSync(stateSrc, path.join(snapshotDir, 'state.json'));
+    }
+    const ctxSrc = path.join(projectDir, 'cycle_context.json');
+    if (fs.existsSync(ctxSrc)) {
+      fs.copyFileSync(ctxSrc, path.join(snapshotDir, 'cycle_context.json'));
     }
     // Keep only last 20 snapshots to prevent disk bloat
     const snapshots = fs.readdirSync(path.join(projectDir, '.snapshots')).sort();
@@ -506,7 +509,7 @@ function processInfraAction(projectDir, state) {
 
 async function advanceState(projectDir) {
   const projectName = path.basename(projectDir);
-  const stateFile = path.join(projectDir, 'state.json');
+  const stateFile = statePath(projectDir);
   const contextFile = path.join(projectDir, 'cycle_context.json');
   const checkpointsFile = path.join(projectDir, 'checkpoints.jsonl');
   const state = readJson(stateFile);
@@ -1380,7 +1383,7 @@ async function runPhase(projectDir) {
     log(`[${projectName}] V2 → V3 state migration complete`);
   }
 
-  const stateFile = path.join(projectDir, 'state.json');
+  const stateFile = statePath(projectDir);
   const contextFile = path.join(projectDir, 'cycle_context.json');
   const state = readJson(stateFile);
   if (!state) return { success: true }; // no state file = skip
@@ -1909,7 +1912,7 @@ function checkBriefing() {
   fs.unlinkSync(triggerFile);
 
   const projects = listProjects().map(name => {
-    const state = readJson(path.join(PROJECTS_DIR, name, 'state.json'));
+    const state = readJson(statePath(path.join(PROJECTS_DIR, name)));
     return { name, state: state?.current_state || '?', cycle: state?.cycle_number || 0 };
   });
 
@@ -1921,7 +1924,7 @@ function checkBriefing() {
 function listProjects() {
   if (!fs.existsSync(PROJECTS_DIR)) return [];
   return fs.readdirSync(PROJECTS_DIR).filter(d =>
-    fs.existsSync(path.join(PROJECTS_DIR, d, 'state.json'))
+    hasStateFile(path.join(PROJECTS_DIR, d))
   );
 }
 
@@ -1966,7 +1969,7 @@ async function main() {
           // Parse reset time from phase log — sleep until actual reset instead of short retry loops
           let backoff = 60000 * (retries + 1); // fallback: escalating backoff
           try {
-            const phaseState = readJson(path.join(projectDir, 'state.json'));
+            const phaseState = readJson(statePath(projectDir));
             const logFile = path.join(LOG_DIR, `${projectName}-${phaseState?.current_state || 'unknown'}.log`);
             const logContent = fs.readFileSync(logFile, 'utf8').slice(-2000);
             const resetMatch = logContent.match(/resets?\s+(?:at\s+)?(\d{1,2}(?::\d{2})?\s*(?:am|pm))/i);
@@ -1991,7 +1994,7 @@ async function main() {
 
         if (retries >= MAX_RETRIES) {
           log(`[${projectName}] Max retries reached. Transitioning to waiting-for-human.`);
-          const stateFile = path.join(projectDir, 'state.json');
+          const stateFile = statePath(projectDir);
           const contextFile = path.join(projectDir, 'cycle_context.json');
           const state = readJson(stateFile);
           const ctx = readJson(contextFile);

--- a/src/launcher/state-migration.js
+++ b/src/launcher/state-migration.js
@@ -7,9 +7,10 @@
 const fs = require('fs');
 const path = require('path');
 const { writeCheckpoint } = require('./checkpoint.js');
+const { statePath } = require('./state-path.js');
 
 function migrateV2StateToV3(projectDir) {
-  const stateFile = path.join(projectDir, 'state.json');
+  const stateFile = statePath(projectDir);
   const ledgerFile = path.join(projectDir, 'task_ledger.json');
   const checkpointsFile = path.join(projectDir, 'checkpoints.jsonl');
 

--- a/src/launcher/state-path.js
+++ b/src/launcher/state-path.js
@@ -1,0 +1,46 @@
+/**
+ * Resolves the path to a project's state.json.
+ *
+ * State lives at `.rouge/state.json` inside each project. The dotdir keeps
+ * it out of the agent's working-directory listing so phase prompts don't
+ * auto-ingest it and start narrating Rouge's pipeline back at the user
+ * (issue #135).
+ *
+ * Reads fall back to the legacy `state.json` at project root so unmigrated
+ * projects keep working until the migration script runs.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROUGE_DIR = '.rouge';
+const STATE_FILE = 'state.json';
+
+function statePath(projectDir) {
+  const newPath = path.join(projectDir, ROUGE_DIR, STATE_FILE);
+  if (fs.existsSync(newPath)) return newPath;
+  const oldPath = path.join(projectDir, STATE_FILE);
+  if (fs.existsSync(oldPath)) return oldPath;
+  return newPath;
+}
+
+function statePathForWrite(projectDir) {
+  const dir = path.join(projectDir, ROUGE_DIR);
+  fs.mkdirSync(dir, { recursive: true });
+  return path.join(dir, STATE_FILE);
+}
+
+function hasStateFile(projectDir) {
+  return (
+    fs.existsSync(path.join(projectDir, ROUGE_DIR, STATE_FILE)) ||
+    fs.existsSync(path.join(projectDir, STATE_FILE))
+  );
+}
+
+module.exports = {
+  statePath,
+  statePathForWrite,
+  hasStateFile,
+  ROUGE_DIR,
+  STATE_FILE,
+};

--- a/src/prompts/loop/00-foundation-building.md
+++ b/src/prompts/loop/00-foundation-building.md
@@ -16,7 +16,7 @@ These rules exist because foundation for `construction-coordinator` force-pushed
 
 4. **NEVER run `git push --force` or `git push --force-with-lease`.** If a push fails because the remote has diverged, the remote is showing you someone else's work — STOP and ESCALATE. Overwriting remote history is data loss. The force-push that destroyed mtgordle's history is exactly why this rule exists.
 
-5. **Verify ownership before every infrastructure operation.** If `infrastructure_manifest.json` or `state.json` records expected resource identifiers (Vercel project name, Supabase project ref, GitHub repo), verify the current linked resource matches before any write. If it does not match, ESCALATE.
+5. **Verify ownership before every infrastructure operation.** If `infrastructure_manifest.json` or `.rouge/state.json` records expected resource identifiers (Vercel project name, Supabase project ref, GitHub repo), verify the current linked resource matches before any write. If it does not match, ESCALATE.
 
 6. **When in doubt, ESCALATE, do not infer.** "Naming alignment is unambiguous" is NOT a valid rationale for adopting pre-existing infrastructure. If you cannot prove the resource was created by this project in this session, it belongs to someone else.
 

--- a/src/prompts/loop/01-building.md
+++ b/src/prompts/loop/01-building.md
@@ -16,7 +16,7 @@ These rules exist because foundation for `construction-coordinator` force-pushed
 
 4. **NEVER run `git push --force` or `git push --force-with-lease`.** If a push fails because the remote has diverged, the remote is showing you someone else's work — STOP and ESCALATE. Overwriting remote history is data loss. The force-push that destroyed mtgordle's history is exactly why this rule exists.
 
-5. **Verify ownership before every infrastructure operation.** If `infrastructure_manifest.json` or `state.json` records expected resource identifiers (Vercel project name, Supabase project ref, GitHub repo), verify the current linked resource matches before any write. If it does not match, ESCALATE.
+5. **Verify ownership before every infrastructure operation.** If `infrastructure_manifest.json` or `.rouge/state.json` records expected resource identifiers (Vercel project name, Supabase project ref, GitHub repo), verify the current linked resource matches before any write. If it does not match, ESCALATE.
 
 6. **When in doubt, ESCALATE, do not infer.** "Naming alignment is unambiguous" is NOT a valid rationale for adopting pre-existing infrastructure. If you cannot prove the resource was created by this project in this session, it belongs to someone else.
 
@@ -619,7 +619,7 @@ After committing all work and writing back to `cycle_context.json`:
 1. Run the full test suite one final time. All tests must pass. If any fail, fix them before exiting.
 2. Verify the staging deployment is accessible (if deployed). A quick sanity check — does the URL respond?
 3. Verify `cycle_context.json` is valid JSON and contains all required fields.
-4. Do NOT update `state.json`. The launcher manages state transitions.
+4. Do NOT update `.rouge/state.json`. The launcher manages state transitions.
 5. Do NOT create a PR. That happens in a later phase.
 6. Do NOT decide what happens next. Your job is to build and report. The Runner decides the next state.
 7. Exit.

--- a/src/prompts/loop/_preamble.md
+++ b/src/prompts/loop/_preamble.md
@@ -17,7 +17,7 @@ MODEL: {{model_name}}
 ### NEVER write
 - checkpoints.jsonl (launcher-only)
 - infrastructure_manifest.json (seeding-only)
-- state.json (V2 legacy — launcher manages this, prompts must not touch it)
+- .rouge/state.json (launcher-only — prompts must not touch it)
 
 ### Required output keys in cycle_context.json
 {{required_output_keys}}

--- a/src/prompts/seeding/00-swarm-orchestrator.md
+++ b/src/prompts/seeding/00-swarm-orchestrator.md
@@ -46,7 +46,7 @@ Never emit `[DISCIPLINE_COMPLETE: <name>]` based on summaries, plans, intentions
 
 **Pre-emission check.** Before writing `[DISCIPLINE_COMPLETE: <name>]`, verify the artifact(s) above exist on disk with full content. If you are tempted to say "here is a summary of the acceptance criteria" — instead, write the criteria to the file. If you are tempted to emit the marker and "flesh out the file later" — don't. Write the file now, then emit the marker.
 
-**SEEDING_COMPLETE pre-check.** Before presenting the SEED SUMMARY or writing `state.json` to `ready`, verify every discipline's expected artifact exists on disk with content beyond stubs. If any are missing or placeholder-only, do NOT declare seeding complete — return to the missing discipline and do the work properly.
+**SEEDING_COMPLETE pre-check.** Before presenting the SEED SUMMARY or writing `.rouge/state.json` to `ready`, verify every discipline's expected artifact exists on disk with content beyond stubs. If any are missing or placeholder-only, do NOT declare seeding complete — return to the missing discipline and do the work properly.
 
 **No false completion claims.** Never self-score a discipline as complete if the work is only in your head. Never invoke "background agents" or "async workers" to explain why an artifact isn't on disk yet (see Sequential execution below — there is only one worker, and it is you, and the work is done when the file exists with content).
 
@@ -149,7 +149,7 @@ There are no background agents, no async workers, and no parallel subprocesses. 
    - `seed_spec/` — milestones with stories, each story with acceptance criteria, PO checks, dependencies, affected entities/screens
    - `legal/` — T&Cs, privacy policy, cookie policy (if generated)
    - `marketing/` — landing page copy
-   - Set `state.json` to `ready` using the **V2 schema** (see `docs/design/state-schema-v2.md`):
+   - Set `.rouge/state.json` to `ready` using the **V2 schema** (see `docs/design/state-schema-v2.md`):
      - Write `milestones[]` with nested `stories[]` (NOT `feature_areas[]`)
      - Each story has: `id`, `name`, `status: "pending"`, `depends_on`, `affected_entities`, `affected_screens`
      - Each milestone has: `name`, `status: "pending"`, `stories[]`

--- a/src/slack/bot.js
+++ b/src/slack/bot.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const path = require('path');
 const { markdownToSlack } = require('./format');
 const blockKit = require('./block-kit');
+const { statePath: resolveStatePath, hasStateFile } = require('../launcher/state-path.js');
 
 const app = new App({
   token: process.env.SLACK_BOT_TOKEN,
@@ -15,13 +16,13 @@ const PROJECTS_DIR = process.env.ROUGE_PROJECTS_DIR || path.join(__dirname, '../
 const KNOWN_COMMANDS = ['status', 'start', 'pause', 'resume', 'new', 'seed', 'ship', 'feedback', 'help'];
 
 function readState(projectName) {
-  const statePath = path.join(PROJECTS_DIR, projectName, 'state.json');
+  const statePath = resolveStatePath(path.join(PROJECTS_DIR, projectName));
   if (!fs.existsSync(statePath)) return null;
   return JSON.parse(fs.readFileSync(statePath, 'utf8'));
 }
 
 function writeState(projectName, state) {
-  const statePath = path.join(PROJECTS_DIR, projectName, 'state.json');
+  const statePath = resolveStatePath(path.join(PROJECTS_DIR, projectName));
   state.timestamp = new Date().toISOString();
   const tmp = statePath + '.tmp';
   fs.writeFileSync(tmp, JSON.stringify(state, null, 2) + '\n');
@@ -31,10 +32,7 @@ function writeState(projectName, state) {
 function listProjects() {
   if (!fs.existsSync(PROJECTS_DIR)) return [];
   return fs.readdirSync(PROJECTS_DIR)
-    .filter(d => {
-      const p = path.join(PROJECTS_DIR, d, 'state.json');
-      return fs.existsSync(p);
-    });
+    .filter(d => hasStateFile(path.join(PROJECTS_DIR, d)));
 }
 
 function writeFeedback(projectName, text) {

--- a/test/launcher/migrate-state-to-rouge-dir.test.js
+++ b/test/launcher/migrate-state-to-rouge-dir.test.js
@@ -1,0 +1,78 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { migrateProject } = require('../../src/launcher/migrate-state-to-rouge-dir.js');
+const { ROUGE_DIR, STATE_FILE } = require('../../src/launcher/state-path.js');
+
+function mkdtemp() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'rouge-state-migrate-'));
+}
+
+test('migrates legacy state.json into .rouge/', () => {
+  const dir = mkdtemp();
+  try {
+    fs.writeFileSync(path.join(dir, STATE_FILE), '{"current_state":"seeding"}');
+    const result = migrateProject(dir);
+    assert.strictEqual(result.status, 'migrated');
+    assert.ok(fs.existsSync(path.join(dir, ROUGE_DIR, STATE_FILE)));
+    assert.ok(!fs.existsSync(path.join(dir, STATE_FILE)));
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('skips projects already migrated', () => {
+  const dir = mkdtemp();
+  try {
+    fs.mkdirSync(path.join(dir, ROUGE_DIR));
+    fs.writeFileSync(path.join(dir, ROUGE_DIR, STATE_FILE), '{}');
+    const result = migrateProject(dir);
+    assert.strictEqual(result.status, 'already-migrated');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('removes stale legacy file when contents match new', () => {
+  const dir = mkdtemp();
+  try {
+    const content = '{"current_state":"ready"}';
+    fs.mkdirSync(path.join(dir, ROUGE_DIR));
+    fs.writeFileSync(path.join(dir, ROUGE_DIR, STATE_FILE), content);
+    fs.writeFileSync(path.join(dir, STATE_FILE), content);
+    const result = migrateProject(dir);
+    assert.strictEqual(result.status, 'cleaned-stale-legacy');
+    assert.ok(!fs.existsSync(path.join(dir, STATE_FILE)));
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('flags conflict when both exist with different content', () => {
+  const dir = mkdtemp();
+  try {
+    fs.mkdirSync(path.join(dir, ROUGE_DIR));
+    fs.writeFileSync(path.join(dir, ROUGE_DIR, STATE_FILE), '{"current_state":"ready"}');
+    fs.writeFileSync(path.join(dir, STATE_FILE), '{"current_state":"seeding"}');
+    const result = migrateProject(dir);
+    assert.strictEqual(result.status, 'conflict');
+    // Both files must remain so operator can resolve manually.
+    assert.ok(fs.existsSync(path.join(dir, STATE_FILE)));
+    assert.ok(fs.existsSync(path.join(dir, ROUGE_DIR, STATE_FILE)));
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('no-op on directories without state.json', () => {
+  const dir = mkdtemp();
+  try {
+    const result = migrateProject(dir);
+    assert.strictEqual(result.status, 'no-state');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/test/launcher/state-path.test.js
+++ b/test/launcher/state-path.test.js
@@ -1,0 +1,74 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { statePath, statePathForWrite, hasStateFile, ROUGE_DIR, STATE_FILE } = require('../../src/launcher/state-path.js');
+
+function mkdtemp() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'rouge-state-path-'));
+}
+
+test('statePath prefers .rouge/state.json when both exist', () => {
+  const dir = mkdtemp();
+  try {
+    fs.mkdirSync(path.join(dir, ROUGE_DIR));
+    fs.writeFileSync(path.join(dir, ROUGE_DIR, STATE_FILE), '{}');
+    fs.writeFileSync(path.join(dir, STATE_FILE), '{}');
+    assert.strictEqual(statePath(dir), path.join(dir, ROUGE_DIR, STATE_FILE));
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('statePath falls back to legacy state.json when .rouge/state.json is missing', () => {
+  const dir = mkdtemp();
+  try {
+    fs.writeFileSync(path.join(dir, STATE_FILE), '{}');
+    assert.strictEqual(statePath(dir), path.join(dir, STATE_FILE));
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('statePath returns the new path when neither file exists', () => {
+  const dir = mkdtemp();
+  try {
+    assert.strictEqual(statePath(dir), path.join(dir, ROUGE_DIR, STATE_FILE));
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('statePathForWrite always returns .rouge/state.json and creates the dir', () => {
+  const dir = mkdtemp();
+  try {
+    assert.strictEqual(fs.existsSync(path.join(dir, ROUGE_DIR)), false);
+    const p = statePathForWrite(dir);
+    assert.strictEqual(p, path.join(dir, ROUGE_DIR, STATE_FILE));
+    assert.strictEqual(fs.existsSync(path.join(dir, ROUGE_DIR)), true);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('hasStateFile is true for new or legacy location', () => {
+  const newOnly = mkdtemp();
+  const legacyOnly = mkdtemp();
+  const empty = mkdtemp();
+  try {
+    fs.mkdirSync(path.join(newOnly, ROUGE_DIR));
+    fs.writeFileSync(path.join(newOnly, ROUGE_DIR, STATE_FILE), '{}');
+    assert.strictEqual(hasStateFile(newOnly), true);
+
+    fs.writeFileSync(path.join(legacyOnly, STATE_FILE), '{}');
+    assert.strictEqual(hasStateFile(legacyOnly), true);
+
+    assert.strictEqual(hasStateFile(empty), false);
+  } finally {
+    fs.rmSync(newOnly, { recursive: true, force: true });
+    fs.rmSync(legacyOnly, { recursive: true, force: true });
+    fs.rmSync(empty, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Closes #135.

## Summary
- Root cause: `claude -p` spawns with `cwd: projectDir`; `state.json` sits in that dir and Claude Code auto-ingests it, so the brainstorming agent narrates Rouge's pipeline back ("This is already registered as a Rouge project, state.json shows current_state: seeding...") instead of exploring the user's idea.
- Move project state to `.rouge/state.json`. Dotdir keeps it out of the agent's working-directory view. `cycle_context.json`, `task_ledger.json`, and `checkpoints.jsonl` stay put — they're intentional agent inputs or launcher-only metadata that don't trigger narration.
- Add `statePath` / `statePathForWrite` helpers in both launcher (JS) and dashboard (TS). Readers prefer `.rouge/state.json`, fall back to legacy `state.json` so unmigrated checkouts keep working. Writes always go to `.rouge/`.
- Seeding orchestrator prompt updated to write `.rouge/state.json`. Loop prompts touched only for path consistency in existing rule statements.
- One-shot migration script `src/launcher/migrate-state-to-rouge-dir.js` (idempotent, with unit tests). Already ran against the 8 live projects.

## Test plan
- [x] `npm test` → 295 launcher/root tests pass (up from 285 — new state-path + migration tests)
- [x] `cd dashboard && npm test` → 204 dashboard tests pass (up from 196)
- [x] `node src/launcher/migrate-state-to-rouge-dir.js` → migrated 8/9 projects, ran twice to confirm idempotency
- [x] Prompt contract validation passes
- [ ] Manual: create a new project via the dashboard and send a brainstorm message — verify the agent stays in role instead of narrating about state.json