### PR TITLE
fix(#137): auto-slugify placeholder projects when display name is set

### DIFF
--- a/dashboard/src/app/api/__tests__/routes.test.ts
+++ b/dashboard/src/app/api/__tests__/routes.test.ts
@@ -3,8 +3,9 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
+import { existsSync } from 'node:fs'
 import { GET as getProjects } from '../projects/route'
-import { GET as getProjectByName } from '../projects/[name]/route'
+import { GET as getProjectByName, PATCH as patchProjectByName } from '../projects/[name]/route'
 import { GET as getSpec } from '../projects/[name]/spec/route'
 import { GET as getBuildLog } from '../projects/[name]/build-log/route'
 import { GET as getBuildStatus } from '../projects/[name]/build-status/route'
@@ -91,6 +92,113 @@ describe('GET /api/projects/[name]', () => {
       params: makeParams({ name: 'nope' }),
     })
     expect(response.status).toBe(404)
+  })
+})
+
+describe('PATCH /api/projects/[name] — auto-slugify placeholder projects', () => {
+  beforeEach(() => {
+    rmSync(PROJECTS_ROOT, { recursive: true, force: true })
+    mkdirSync(PROJECTS_ROOT, { recursive: true })
+  })
+
+  it('renames untitled-* slug to match new displayName', async () => {
+    writeProject('untitled-mo0c46fx', {
+      project: 'Untitled',
+      current_state: 'seeding',
+    })
+    const response = await patchProjectByName(
+      new Request('http://localhost', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ displayName: 'Testimonials' }),
+      }),
+      { params: makeParams({ name: 'untitled-mo0c46fx' }) },
+    )
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    expect(data.slugChanged).toBe(true)
+    expect(data.slug).toBe('testimonials')
+    expect(existsSync(join(PROJECTS_ROOT, 'testimonials'))).toBe(true)
+    expect(existsSync(join(PROJECTS_ROOT, 'untitled-mo0c46fx'))).toBe(false)
+  })
+
+  it('does NOT rename a non-placeholder slug when displayName changes', async () => {
+    writeProject('testimonials', {
+      project: 'Testimonials',
+      current_state: 'seeding',
+    })
+    const response = await patchProjectByName(
+      new Request('http://localhost', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ displayName: 'Customer Stories' }),
+      }),
+      { params: makeParams({ name: 'testimonials' }) },
+    )
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    expect(data.slugChanged).toBe(false)
+    expect(data.slug).toBe('testimonials')
+  })
+
+  it('refuses auto-rename once the build loop has started', async () => {
+    writeProject('untitled-abc', {
+      project: 'Untitled',
+      current_state: 'story-building',
+    })
+    const response = await patchProjectByName(
+      new Request('http://localhost', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ displayName: 'Testimonials' }),
+      }),
+      { params: makeParams({ name: 'untitled-abc' }) },
+    )
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    // Display name updated, but slug preserved because the build started.
+    expect(data.slugChanged).toBe(false)
+    expect(data.slug).toBe('untitled-abc')
+  })
+
+  it('honours an explicit slug override sent alongside displayName', async () => {
+    writeProject('untitled-def', {
+      project: 'Untitled',
+      current_state: 'seeding',
+    })
+    const response = await patchProjectByName(
+      new Request('http://localhost', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ displayName: 'Testimonials', slug: 'reviews' }),
+      }),
+      { params: makeParams({ name: 'untitled-def' }) },
+    )
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    expect(data.slug).toBe('reviews')
+  })
+
+  it('falls back to -2 suffix when the derived slug collides', async () => {
+    writeProject('testimonials', {
+      project: 'Testimonials',
+      current_state: 'seeding',
+    })
+    writeProject('untitled-ghi', {
+      project: 'Untitled',
+      current_state: 'seeding',
+    })
+    const response = await patchProjectByName(
+      new Request('http://localhost', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ displayName: 'Testimonials' }),
+      }),
+      { params: makeParams({ name: 'untitled-ghi' }) },
+    )
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    expect(data.slug).toBe('testimonials-2')
   })
 })
 

--- a/dashboard/src/app/api/projects/[name]/route.ts
+++ b/dashboard/src/app/api/projects/[name]/route.ts
@@ -3,6 +3,7 @@ import { existsSync, readFileSync, renameSync, rmSync, writeFileSync } from "nod
 import { join } from "node:path";
 import { loadServerConfig } from "@/lib/server-config";
 import { statePath } from "@/bridge/state-path";
+import { isPlaceholderSlug, slugify, uniqueSlug } from "@/bridge/slug";
 import {
   mergeSeedingProgress,
   readCheckpointSummary,
@@ -16,10 +17,6 @@ export const dynamic = "force-dynamic";
 const SLUG_RENAMEABLE_STATES = new Set([
   "seeding", "ready",
 ]);
-
-function slugify(v: string): string {
-  return v.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 64);
-}
 
 export async function GET(
   _request: Request,
@@ -78,6 +75,26 @@ export async function PATCH(
   const currentState = state.current_state ?? state.state ?? "unknown";
 
   let slugChanged: string | null = null;
+
+  // Auto-slugify when promoting a placeholder-slugged project. If the
+  // client is setting a real display name on a project whose URL is still
+  // `untitled-*`, derive the URL from the new name so it doesn't silently
+  // keep the placeholder (#137). Caller can still opt out by sending an
+  // explicit body.slug (including the current slug, to keep it).
+  if (
+    body.displayName !== undefined &&
+    body.slug === undefined &&
+    isPlaceholderSlug(name) &&
+    SLUG_RENAMEABLE_STATES.has(currentState)
+  ) {
+    const derived = slugify(body.displayName);
+    if (derived && /^[a-z][a-z0-9-]*$/.test(derived)) {
+      const unique = uniqueSlug(derived, projectsRoot, name);
+      if (unique && unique !== name) {
+        body.slug = unique;
+      }
+    }
+  }
 
   // Slug rename (filesystem mv)
   if (body.slug && body.slug !== name) {

--- a/dashboard/src/bridge/__tests__/slug.test.ts
+++ b/dashboard/src/bridge/__tests__/slug.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, mkdirSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { slugify, isPlaceholderSlug, uniqueSlug } from '../slug'
+
+describe('slugify', () => {
+  it('lowercases and replaces non-alphanumerics with hyphens', () => {
+    expect(slugify('Customer Stories')).toBe('customer-stories')
+  })
+
+  it('trims leading and trailing hyphens', () => {
+    expect(slugify('  Hello World!  ')).toBe('hello-world')
+  })
+
+  it('caps length at 64 chars', () => {
+    const long = 'a'.repeat(100)
+    expect(slugify(long).length).toBe(64)
+  })
+
+  it('produces empty string for non-alphanumeric input', () => {
+    expect(slugify('!!!')).toBe('')
+  })
+})
+
+describe('isPlaceholderSlug', () => {
+  it('recognises the bare placeholder', () => {
+    expect(isPlaceholderSlug('untitled')).toBe(true)
+  })
+
+  it('recognises timestamped placeholders', () => {
+    expect(isPlaceholderSlug('untitled-mo0c46fx')).toBe(true)
+  })
+
+  it('rejects real slugs', () => {
+    expect(isPlaceholderSlug('testimonials')).toBe(false)
+    expect(isPlaceholderSlug('customer-stories')).toBe(false)
+  })
+
+  it('does not false-positive on slugs that merely contain "untitled"', () => {
+    expect(isPlaceholderSlug('not-untitled')).toBe(false)
+  })
+})
+
+describe('uniqueSlug', () => {
+  let projectsRoot: string
+
+  beforeEach(() => {
+    projectsRoot = mkdtempSync(join(tmpdir(), 'rouge-slug-test-'))
+  })
+
+  afterEach(() => {
+    rmSync(projectsRoot, { recursive: true, force: true })
+  })
+
+  it('returns the desired slug when nothing collides', () => {
+    expect(uniqueSlug('testimonials', projectsRoot)).toBe('testimonials')
+  })
+
+  it('appends -2 on first collision', () => {
+    mkdirSync(join(projectsRoot, 'testimonials'))
+    expect(uniqueSlug('testimonials', projectsRoot)).toBe('testimonials-2')
+  })
+
+  it('skips further collisions', () => {
+    mkdirSync(join(projectsRoot, 'testimonials'))
+    mkdirSync(join(projectsRoot, 'testimonials-2'))
+    expect(uniqueSlug('testimonials', projectsRoot)).toBe('testimonials-3')
+  })
+
+  it('treats reservedSelf as free (lets the project keep its own slug)', () => {
+    mkdirSync(join(projectsRoot, 'testimonials'))
+    expect(uniqueSlug('testimonials', projectsRoot, 'testimonials')).toBe('testimonials')
+  })
+})

--- a/dashboard/src/bridge/slug.ts
+++ b/dashboard/src/bridge/slug.ts
@@ -1,0 +1,47 @@
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * Project-slug helpers.
+ *
+ * A project's slug is the URL-safe directory name under `projects/<slug>`.
+ * Brand-new projects get a placeholder slug (`untitled-<base36-ts>`) so the
+ * user can start chatting before naming. Once they name the product, the
+ * slug should follow — otherwise the "Rename Project URL" UI surfaces the
+ * placeholder and the display name appears to vanish (#135, #137).
+ */
+
+const PLACEHOLDER_PREFIX = 'untitled-'
+
+export function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 64)
+}
+
+export function isPlaceholderSlug(slug: string): boolean {
+  return slug === 'untitled' || slug.startsWith(PLACEHOLDER_PREFIX)
+}
+
+/**
+ * Returns the desired slug, or `<desired>-2`, `<desired>-3`, ... if earlier
+ * names are already taken. Returns null if even 100 variants collide
+ * (defensive — should never happen in practice).
+ */
+export function uniqueSlug(
+  desired: string,
+  projectsRoot: string,
+  reservedSelf?: string,
+): string | null {
+  const isFree = (candidate: string) =>
+    candidate === reservedSelf || !existsSync(join(projectsRoot, candidate))
+
+  if (isFree(desired)) return desired
+  for (let i = 2; i < 100; i++) {
+    const candidate = `${desired}-${i}`
+    if (isFree(candidate)) return candidate
+  }
+  return null
+}

--- a/dashboard/src/components/project-title-editable.tsx
+++ b/dashboard/src/components/project-title-editable.tsx
@@ -37,6 +37,7 @@ export function ProjectTitleEditable({
   const inputRef = useRef<HTMLInputElement>(null)
 
   const canRenameSlug = state === 'seeding' || state === 'ready'
+  const slugIsPlaceholder = slug === 'untitled' || slug.startsWith('untitled-')
 
   // When the name arrives late via bridge (e.g., auto-derive writes a
   // working title after first message), slide out of editing mode so the
@@ -159,7 +160,12 @@ export function ProjectTitleEditable({
           Optional — you can rename anytime.
         </p>
       )}
-      {canRenameSlug && draft.trim() && (
+      {canRenameSlug && draft.trim() && slugIsPlaceholder && (
+        <p className="text-xs text-muted-foreground">
+          URL will update to match the new name.
+        </p>
+      )}
+      {canRenameSlug && draft.trim() && !slugIsPlaceholder && (
         <label className="flex items-center gap-2 text-xs text-muted-foreground">
           <input
             type="checkbox"


### PR DESCRIPTION
Closes #137.

## Summary
- PATCH `/api/projects/[name]` now auto-renames `untitled-*` slugs to match a newly-set `displayName`, so the project URL follows the name instead of preserving the placeholder. Scoped to states where slug rename is already safe (`seeding`, `ready`).
- Collisions fall back to `slug-2`, `slug-3`, ...
- Client UI: hide the now-redundant "Also rename URL" checkbox when the slug is a placeholder; show a quieter inline hint instead.
- `derive-title.ts` still only writes the display name — renaming the directory from a fire-and-forget job could 404 an in-flight seed request. Users who let auto-title name their project can clean up the URL later via the inline editor, which now does the right thing.

## Test plan
- [x] `npm test` in `dashboard/`: 221 tests pass (up from 204)
- [x] Unit tests for slugify / isPlaceholderSlug / uniqueSlug (12 cases)
- [x] Integration tests on the PATCH handler: auto-rename happy path, non-placeholder preservation, build-state refusal, explicit slug override, collision fallback (5 cases)
- [ ] Manual: create a new spec, type "Testimonials" in the inline title editor, watch the URL become `/projects/testimonials`