### PR TITLE
fix(#139): inline New spec CTA in Specs empty state

### DIFF
--- a/dashboard/src/components/__tests__/specs-table.test.tsx
+++ b/dashboard/src/components/__tests__/specs-table.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { SpecsTable } from '../specs-table'
+
+vi.mock('next/link', () => ({
+  default: ({ children, href, ...props }: React.PropsWithChildren<{ href: string }>) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
+vi.mock('@/lib/bridge-client', () => ({
+  isBridgeEnabled: () => true,
+  createBridgeProject: vi.fn(),
+}))
+
+describe('SpecsTable empty state', () => {
+  it('renders a New spec CTA inside the empty state', () => {
+    render(<SpecsTable specs={[]} />)
+    expect(screen.getByText(/no specs yet/i)).toBeInTheDocument()
+    // The NewProjectButton renders a button labelled "New spec"
+    expect(screen.getByRole('button', { name: /new spec/i })).toBeInTheDocument()
+  })
+})

--- a/dashboard/src/components/specs-table.tsx
+++ b/dashboard/src/components/specs-table.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import type { ProjectSummary } from '@/lib/types'
 import { SpecDepthPill, depthForProject } from './spec-depth-pill'
+import { NewProjectButton } from './new-project-button'
 
 type SortKey = 'touched' | 'depth' | 'name' | 'cost'
 
@@ -146,8 +147,11 @@ export function SpecsTable({ specs }: { specs: ProjectSummary[] }) {
 
   if (specs.length === 0) {
     return (
-      <div className="rounded-lg border border-dashed border-border bg-muted/20 p-8 text-center text-sm text-muted-foreground">
-        No specs yet. Click <strong>+ New Project</strong> to start one.
+      <div className="rounded-lg border border-dashed border-border bg-muted/20 p-10 text-center">
+        <p className="text-sm text-muted-foreground">No specs yet.</p>
+        <div className="mt-4 inline-flex">
+          <NewProjectButton />
+        </div>
       </div>
     )
   }


### PR DESCRIPTION
Closes #139.

## Summary
- Empty-state card now renders the existing `NewProjectButton` inline so the CTA sits where the eye lands, instead of pointing at the top-right chrome.
- Once one or more specs exist the empty state disappears and only the top-right button remains — no duplication.

## Test plan
- [x] New component test asserts the empty-state renders a `New spec` button
- [x] Full dashboard suite: 222 tests pass