### PR TITLE
fix(#138): move slug rename into a project settings menu

### DIFF
--- a/dashboard/src/components/__tests__/project-settings-menu.test.tsx
+++ b/dashboard/src/components/__tests__/project-settings-menu.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { ProjectSettingsMenu } from '../project-settings-menu'
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}))
+
+describe('ProjectSettingsMenu', () => {
+  it('opens a modal with a slug input when the gear is clicked', () => {
+    render(<ProjectSettingsMenu slug="testimonials" state="seeding" />)
+    fireEvent.click(screen.getByRole('button', { name: /project settings/i }))
+    expect(screen.getByText(/project settings/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/url slug/i)).toHaveValue('testimonials')
+  })
+
+  it('disables the slug input once the build loop has started', () => {
+    render(<ProjectSettingsMenu slug="my-app" state="story-building" />)
+    fireEvent.click(screen.getByRole('button', { name: /project settings/i }))
+    expect(screen.getByLabelText(/url slug/i)).toBeDisabled()
+    expect(
+      screen.getByText(/slug is locked once the build loop starts/i),
+    ).toBeInTheDocument()
+  })
+})

--- a/dashboard/src/components/project-header.tsx
+++ b/dashboard/src/components/project-header.tsx
@@ -6,6 +6,7 @@ import { ProjectStack } from '@/components/project-stack'
 import { InfrastructureStack } from '@/components/infrastructure-stack'
 import { CycleRhythm } from '@/components/cycle-rhythm'
 import { ProjectTitleEditable } from '@/components/project-title-editable'
+import { ProjectSettingsMenu } from '@/components/project-settings-menu'
 import { ArchiveButton } from '@/components/archive-button'
 import { ProjectBudgetCapInline } from '@/components/project-budget-cap-inline'
 import { ExternalLink, ArrowLeft } from 'lucide-react'
@@ -77,6 +78,7 @@ export function ProjectHeader({
       <div className="flex flex-wrap items-center justify-between gap-4">
         <div className="flex flex-wrap items-center gap-4">
           <ProjectTitleEditable slug={project.slug} name={project.name} state={project.state} />
+          <ProjectSettingsMenu slug={project.slug} state={project.state} />
           <StateBadge state={project.state} size="lg" />
         </div>
 

--- a/dashboard/src/components/project-settings-menu.tsx
+++ b/dashboard/src/components/project-settings-menu.tsx
@@ -1,0 +1,149 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Loader2, Settings } from 'lucide-react'
+
+/**
+ * Settings menu for a single project. Lives next to the display-name
+ * editor in the header. Current single action: rename the URL slug.
+ *
+ * Why this exists: the slug is a launcher artifact 95% of users never
+ * touch. Putting it inline next to the title (with a checkbox next to
+ * the display-name editor) gave it equal visual weight to the
+ * display-name rename — the action people actually want — and
+ * regularly surfaced the raw placeholder slug, making it look like the
+ * display name had vanished (#135, #138).
+ *
+ * Auto-slugify (#137) handles the first-name-on-placeholder case
+ * transparently. Manual slug edits after that happen through this menu.
+ */
+export function ProjectSettingsMenu({
+  slug,
+  state,
+}: {
+  slug: string
+  state: string
+}) {
+  const router = useRouter()
+  const [open, setOpen] = useState(false)
+  const [draft, setDraft] = useState(slug)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const canRenameSlug = state === 'seeding' || state === 'ready'
+
+  function openMenu() {
+    setDraft(slug)
+    setError(null)
+    setOpen(true)
+  }
+
+  function closeMenu() {
+    if (saving) return
+    setOpen(false)
+  }
+
+  async function save() {
+    const trimmed = draft.trim()
+    if (!trimmed || trimmed === slug) {
+      closeMenu()
+      return
+    }
+    setSaving(true)
+    setError(null)
+    try {
+      const res = await fetch(`/api/projects/${encodeURIComponent(slug)}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ slug: trimmed }),
+      })
+      const body = await res.json()
+      if (!res.ok) throw new Error(body.error ?? `HTTP ${res.status}`)
+      if (body.slugChanged) {
+        router.push(`/projects/${body.slug}`)
+        router.refresh()
+      } else {
+        router.refresh()
+      }
+      setOpen(false)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={openMenu}
+        className="rounded-md p-1.5 text-muted-foreground/60 hover:bg-muted/60 hover:text-muted-foreground transition-colors"
+        title="Project settings"
+        aria-label="Project settings"
+      >
+        <Settings className="h-4 w-4" />
+      </button>
+
+      {open && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 p-4"
+          onClick={closeMenu}
+        >
+          <div
+            onClick={(e) => e.stopPropagation()}
+            className="w-full max-w-md rounded-lg border border-border bg-background p-5 shadow-lg"
+          >
+            <h3 className="text-base font-semibold text-foreground">Project settings</h3>
+
+            <section className="mt-4 flex flex-col gap-2">
+              <label className="text-sm font-medium text-foreground" htmlFor="project-slug">
+                URL slug
+              </label>
+              <input
+                id="project-slug"
+                type="text"
+                value={draft}
+                onChange={(e) => setDraft(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') save()
+                  if (e.key === 'Escape') closeMenu()
+                }}
+                disabled={!canRenameSlug || saving}
+                className="w-full rounded-md border border-border bg-background px-2 py-1.5 text-sm tabular-nums focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
+              />
+              <p className="text-xs text-muted-foreground">
+                {canRenameSlug
+                  ? 'Changes the project directory and URL. Lowercase letters, digits, and hyphens.'
+                  : 'Slug is locked once the build loop starts — git history and deploys key on it.'}
+              </p>
+            </section>
+
+            {error && <p className="mt-3 text-xs text-red-700">{error}</p>}
+
+            <div className="mt-5 flex items-center justify-end gap-2">
+              <button
+                type="button"
+                onClick={closeMenu}
+                disabled={saving}
+                className="rounded-md border border-border px-3 py-1.5 text-sm hover:bg-accent disabled:opacity-50"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={save}
+                disabled={saving || !canRenameSlug || !draft.trim() || draft.trim() === slug}
+                className="inline-flex items-center rounded-md bg-gray-900 px-3 py-1.5 text-sm font-medium text-white hover:bg-gray-800 disabled:opacity-50"
+              >
+                {saving && <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />}
+                Save
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/dashboard/src/components/project-title-editable.tsx
+++ b/dashboard/src/components/project-title-editable.tsx
@@ -31,13 +31,17 @@ export function ProjectTitleEditable({
   const isUntitled = isUntitledName(name) || slug.startsWith('untitled-')
   const [editing, setEditing] = useState(isUntitled)
   const [draft, setDraft] = useState(isUntitled ? '' : name)
-  const [alsoRenameSlug, setAlsoRenameSlug] = useState(false)
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const inputRef = useRef<HTMLInputElement>(null)
 
-  const canRenameSlug = state === 'seeding' || state === 'ready'
   const slugIsPlaceholder = slug === 'untitled' || slug.startsWith('untitled-')
+  // During seeding/ready, the PATCH handler auto-renames placeholder slugs
+  // to match the new display name (#137). After that, explicit slug edits
+  // happen through the project settings menu — we no longer expose a
+  // checkbox inline alongside the title editor (#138).
+  const willAutoRenameSlug =
+    slugIsPlaceholder && (state === 'seeding' || state === 'ready')
 
   // When the name arrives late via bridge (e.g., auto-derive writes a
   // working title after first message), slide out of editing mode so the
@@ -61,7 +65,6 @@ export function ProjectTitleEditable({
 
   function startEdit() {
     setDraft(isUntitled ? '' : name)
-    setAlsoRenameSlug(canRenameSlug && isUntitled)
     setError(null)
     setEditing(true)
   }
@@ -83,10 +86,10 @@ export function ProjectTitleEditable({
     setSaving(true)
     setError(null)
     try {
-      const payload: { displayName: string; slug?: string } = { displayName: trimmed }
-      if (alsoRenameSlug && canRenameSlug) {
-        payload.slug = trimmed
-      }
+      // Let the server decide whether to rename the slug: it auto-renames
+      // placeholder slugs to match the new display name (#137). Explicit
+      // slug edits happen through the project settings menu.
+      const payload = { displayName: trimmed }
       const res = await fetch(`/api/projects/${encodeURIComponent(slug)}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
@@ -160,25 +163,9 @@ export function ProjectTitleEditable({
           Optional — you can rename anytime.
         </p>
       )}
-      {canRenameSlug && draft.trim() && slugIsPlaceholder && (
+      {willAutoRenameSlug && draft.trim() && (
         <p className="text-xs text-muted-foreground">
           URL will update to match the new name.
-        </p>
-      )}
-      {canRenameSlug && draft.trim() && !slugIsPlaceholder && (
-        <label className="flex items-center gap-2 text-xs text-muted-foreground">
-          <input
-            type="checkbox"
-            checked={alsoRenameSlug}
-            onChange={(e) => setAlsoRenameSlug(e.target.checked)}
-            disabled={saving}
-          />
-          Also rename the project directory (URL will change)
-        </label>
-      )}
-      {!canRenameSlug && (
-        <p className="text-xs text-muted-foreground">
-          Directory slug is locked once the build loop starts — only the display name will change.
         </p>
       )}
       {error && (


### PR DESCRIPTION
Closes #138.

## Summary
- New `ProjectSettingsMenu` component — a small gear icon next to the title that opens a modal with the slug rename form. Lock behaviour (seeding/ready only) is shown in the modal, not inline.
- Removed the inline \"Also rename the project directory\" checkbox and the \"...locked once the build loop starts\" hint from the title editor. The editor is now single-purpose: it edits the display name.
- For placeholder slugs, a quieter hint ("URL will update to match the new name.") remains, because the PATCH handler auto-renames them (#137).

## Test plan
- [x] New component test covers the gear + modal open state and the disabled-after-build-loop path
- [x] Full dashboard suite: 224 tests pass (up from 222)