### PR TITLE
fix(#143): move projects out of the repo tree

### DIFF
--- a/dashboard/rouge-dashboard.config.json
+++ b/dashboard/rouge-dashboard.config.json
@@ -1,5 +1,4 @@
 {
-  "projects_root": "../projects",
   "rouge_cli": "../src/launcher/rouge-cli.js",
   "orchestrator_prompt": "../src/prompts/seeding/00-swarm-orchestrator.md",
   "bridge_port": 3002

--- a/dashboard/src/bridge/__tests__/activity-reader.test.ts
+++ b/dashboard/src/bridge/__tests__/activity-reader.test.ts
@@ -1,39 +1,45 @@
-import { resolve } from 'path'
 import { describe, it, expect } from 'vitest'
 import { readProjectActivity } from '../activity-reader'
+import { homedir } from 'os'
+import { existsSync } from 'fs'
 import { join } from 'path'
 
-const PROJECTS_ROOT = resolve(__dirname, '../../../../projects')
+// These tests exercise the reader against the real mtgordle project —
+// migrated out of the repo in #143. If the user hasn't run the migration,
+// skip gracefully so a fresh clone doesn't fail.
+const PROJECTS_ROOT = join(homedir(), '.rouge', 'projects')
+const MTGORDLE = join(PROJECTS_ROOT, 'mtgordle')
+const withMtgordle = existsSync(MTGORDLE) ? it : it.skip
 
 describe('readProjectActivity', () => {
-  it('reads checkpoints and produces critical events for mtgordle', () => {
-    const events = readProjectActivity(join(PROJECTS_ROOT, 'mtgordle'))
+  withMtgordle('reads checkpoints and produces critical events for mtgordle', () => {
+    const events = readProjectActivity(MTGORDLE)
     expect(events.length).toBeGreaterThan(0)
     expect(events.length).toBeLessThan(100) // Critical filter should dramatically reduce from 455
   })
 
-  it('includes phase transitions', () => {
-    const events = readProjectActivity(join(PROJECTS_ROOT, 'mtgordle'))
+  withMtgordle('includes phase transitions', () => {
+    const events = readProjectActivity(MTGORDLE)
     const transitions = events.filter((e) => e.type === 'phase-transition')
     expect(transitions.length).toBeGreaterThan(0)
   })
 
-  it('includes deploys from cycle_context', () => {
-    const events = readProjectActivity(join(PROJECTS_ROOT, 'mtgordle'))
+  withMtgordle('includes deploys from cycle_context', () => {
+    const events = readProjectActivity(MTGORDLE)
     const deploys = events.filter((e) => e.type === 'deploy')
     expect(deploys.length).toBeGreaterThan(0)
     expect(String(deploys[0].metadata?.url)).toContain('vercel.app')
   })
 
-  it('events are sorted newest first', () => {
-    const events = readProjectActivity(join(PROJECTS_ROOT, 'mtgordle'))
+  withMtgordle('events are sorted newest first', () => {
+    const events = readProjectActivity(MTGORDLE)
     for (let i = 1; i < events.length; i++) {
       expect(events[i - 1].timestamp >= events[i].timestamp).toBe(true)
     }
   })
 
-  it('verbose mode returns all checkpoint entries', () => {
-    const events = readProjectActivity(join(PROJECTS_ROOT, 'mtgordle'), { verbose: true })
+  withMtgordle('verbose mode returns all checkpoint entries', () => {
+    const events = readProjectActivity(MTGORDLE, { verbose: true })
     expect(events.length).toBeGreaterThan(400) // mtgordle has 455+ checkpoints
   })
 

--- a/dashboard/src/bridge/__tests__/platform-reader.test.ts
+++ b/dashboard/src/bridge/__tests__/platform-reader.test.ts
@@ -1,23 +1,29 @@
-import { resolve } from 'path'
 import { describe, it, expect } from 'vitest'
 import { readPlatformData } from '../platform-reader'
+import { homedir } from 'os'
+import { existsSync } from 'fs'
+import { join } from 'path'
 
-const PROJECTS_ROOT = resolve(__dirname, '../../../../projects')
+// Exercises the reader against the real projects dir (migrated out of
+// the repo in #143). Skip gracefully if the user hasn't run the
+// migration so a fresh clone doesn't fail.
+const PROJECTS_ROOT = join(homedir(), '.rouge', 'projects')
+const withProjects = existsSync(join(PROJECTS_ROOT, 'mtgordle')) ? it : it.skip
 
 describe('readPlatformData', () => {
-  it('aggregates providers across all projects', () => {
+  withProjects('aggregates providers across all projects', () => {
     const data = readPlatformData(PROJECTS_ROOT)
     expect(data.quotas).toHaveLength(5)
     expect(data.totalProjects).toBeGreaterThan(0)
   })
 
-  it('includes mtgordle under vercel', () => {
+  withProjects('includes mtgordle under vercel', () => {
     const data = readPlatformData(PROJECTS_ROOT)
     const vercel = data.quotas.find((q) => q.provider === 'vercel')
     expect(vercel?.projects.some((p) => p.slug === 'mtgordle')).toBe(true)
   })
 
-  it('project status is active or paused (not complete)', () => {
+  withProjects('project status is active or paused (not complete)', () => {
     const data = readPlatformData(PROJECTS_ROOT)
     const vercel = data.quotas.find((q) => q.provider === 'vercel')
     const mtg = vercel?.projects.find((p) => p.slug === 'mtgordle')
@@ -25,7 +31,7 @@ describe('readPlatformData', () => {
     expect(['active', 'paused']).toContain(mtg?.status)
   })
 
-  it('includes posthog as a provider', () => {
+  withProjects('includes posthog as a provider', () => {
     const data = readPlatformData(PROJECTS_ROOT)
     const posthog = data.quotas.find((q) => q.provider === 'posthog')
     expect(posthog).toBeDefined()

--- a/dashboard/src/bridge/__tests__/scanner.test.ts
+++ b/dashboard/src/bridge/__tests__/scanner.test.ts
@@ -1,66 +1,101 @@
-import { resolve } from 'path'
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { scanProjects } from '../scanner'
 
-const PROJECTS_ROOT = resolve(__dirname, '../../../../projects')
+// Tests use a fixture directory so they don't depend on the user's live
+// projects. (Previously this suite pointed at `<repo>/projects/` which
+// only worked because example projects happened to live inside the repo —
+// broken by #143 which moved them to ~/.rouge/projects.)
+
+let PROJECTS_ROOT: string
+
+function writeProject(slug: string, state: Record<string, unknown>, cycleContext?: Record<string, unknown>) {
+  const dir = join(PROJECTS_ROOT, slug)
+  mkdirSync(join(dir, '.rouge'), { recursive: true })
+  writeFileSync(join(dir, '.rouge', 'state.json'), JSON.stringify(state, null, 2))
+  if (cycleContext) {
+    writeFileSync(join(dir, 'cycle_context.json'), JSON.stringify(cycleContext, null, 2))
+  }
+}
+
+beforeEach(() => {
+  PROJECTS_ROOT = mkdtempSync(join(tmpdir(), 'rouge-scanner-test-'))
+})
+
+afterEach(() => {
+  rmSync(PROJECTS_ROOT, { recursive: true, force: true })
+})
 
 describe('scanProjects', () => {
   it('finds projects with state.json', () => {
+    writeProject('alpha', { project: 'alpha', current_state: 'building', milestones: [] })
+    writeProject('beta', { project: 'beta', current_state: 'complete', milestones: [] })
     const projects = scanProjects(PROJECTS_ROOT)
-    expect(projects.length).toBeGreaterThan(0)
+    expect(projects.length).toBe(2)
   })
 
-  it('includes mtgordle as a V3 project', () => {
-    const projects = scanProjects(PROJECTS_ROOT)
-    const mtg = projects.find(p => p.slug === 'mtgordle')
-    expect(mtg).toBeDefined()
-    expect(mtg!.schemaVersion).toBe('v3')
-    expect(mtg!.state).toBeDefined()
+  it('detects V3 schema from milestones[]', () => {
+    writeProject('v3-proj', {
+      project: 'v3-proj',
+      current_state: 'story-building',
+      milestones: [{ name: 'm1', status: 'pending' }],
+    })
+    const p = scanProjects(PROJECTS_ROOT).find(p => p.slug === 'v3-proj')
+    expect(p?.schemaVersion).toBe('v3')
   })
 
-  it('includes countdowntimer as a V2 project', () => {
-    const projects = scanProjects(PROJECTS_ROOT)
-    const timer = projects.find(p => p.slug === 'countdowntimer')
-    expect(timer).toBeDefined()
-    expect(timer!.schemaVersion).toBe('v2')
+  it('detects V2 schema from feature_areas[]', () => {
+    writeProject('v2-proj', {
+      project: 'v2-proj',
+      current_state: 'building',
+      feature_areas: [{ name: 'f1', status: 'pending' }],
+    })
+    const p = scanProjects(PROJECTS_ROOT).find(p => p.slug === 'v2-proj')
+    expect(p?.schemaVersion).toBe('v2')
   })
 
   it('excludes directories without state.json', () => {
-    const projects = scanProjects(PROJECTS_ROOT)
-    const slugs = projects.map(p => p.slug)
-    // fleet-manager has no state.json
-    expect(slugs).not.toContain('fleet-manager')
+    writeProject('has-state', { project: 'has-state', current_state: 'building' })
+    mkdirSync(join(PROJECTS_ROOT, 'no-state'))
+    const slugs = scanProjects(PROJECTS_ROOT).map(p => p.slug)
+    expect(slugs).toContain('has-state')
+    expect(slugs).not.toContain('no-state')
   })
 
   describe('provider detection', () => {
-    it('detects vercel for mtgordle', () => {
-      const projects = scanProjects(PROJECTS_ROOT)
-      const mtg = projects.find(p => p.slug === 'mtgordle')
-      expect(mtg!.providers).toContain('vercel')
+    it('detects vercel from staging_url', () => {
+      writeProject(
+        'vercel-proj',
+        { project: 'vercel-proj', current_state: 'complete' },
+        { infrastructure: { staging_url: 'https://vercel-proj.vercel.app' } },
+      )
+      const p = scanProjects(PROJECTS_ROOT).find(p => p.slug === 'vercel-proj')
+      expect(p?.providers).toContain('vercel')
+      expect(p?.deploymentUrl).toContain('vercel.app')
     })
 
     it('does not include supabase when supabase_ref is null', () => {
-      const projects = scanProjects(PROJECTS_ROOT)
-      const mtg = projects.find(p => p.slug === 'mtgordle')
-      expect(mtg!.providers).not.toContain('supabase')
-    })
-
-    it('includes deployment URL when available', () => {
-      const projects = scanProjects(PROJECTS_ROOT)
-      const mtg = projects.find(p => p.slug === 'mtgordle')
-      expect(mtg!.deploymentUrl).toContain('vercel.app')
+      writeProject(
+        'no-supabase',
+        { project: 'no-supabase', current_state: 'complete' },
+        { infrastructure: { staging_url: 'https://x.vercel.app', supabase_ref: null } },
+      )
+      const p = scanProjects(PROJECTS_ROOT).find(p => p.slug === 'no-supabase')
+      expect(p?.providers).not.toContain('supabase')
     })
 
     it('handles projects without cycle_context.json', () => {
-      const projects = scanProjects(PROJECTS_ROOT)
-      const timer = projects.find(p => p.slug === 'countdowntimer')
-      expect(timer!.providers).toBeInstanceOf(Array)
+      writeProject('no-ctx', { project: 'no-ctx', current_state: 'seeding' })
+      const p = scanProjects(PROJECTS_ROOT).find(p => p.slug === 'no-ctx')
+      expect(p?.providers).toBeInstanceOf(Array)
     })
   })
 
   it('returns normalized BridgeProjectSummary', () => {
-    const projects = scanProjects(PROJECTS_ROOT)
-    const first = projects[0]
+    writeProject('shape-check', { project: 'shape-check', current_state: 'ready', milestones: [] })
+    const first = scanProjects(PROJECTS_ROOT)[0]
     expect(first).toHaveProperty('name')
     expect(first).toHaveProperty('slug')
     expect(first).toHaveProperty('state')

--- a/dashboard/src/bridge/__tests__/spec-reader.test.ts
+++ b/dashboard/src/bridge/__tests__/spec-reader.test.ts
@@ -1,13 +1,18 @@
-import { resolve } from 'path'
 import { describe, it, expect } from 'vitest'
 import { readProjectSpec } from '../spec-reader'
+import { homedir } from 'os'
+import { existsSync } from 'fs'
 import { join } from 'path'
 
-const PROJECTS_ROOT = resolve(__dirname, '../../../../projects')
+// Exercises the reader against the real mtgordle project (migrated out
+// of the repo in #143). Skip gracefully if the user hasn't run the
+// migration so a fresh clone doesn't fail.
+const MTGORDLE = join(homedir(), '.rouge', 'projects', 'mtgordle')
+const withMtgordle = existsSync(MTGORDLE) ? it : it.skip
 
 describe('readProjectSpec', () => {
-  it('reads vision and milestones for mtgordle', () => {
-    const spec = readProjectSpec(join(PROJECTS_ROOT, 'mtgordle'))
+  withMtgordle('reads vision and milestones for mtgordle', () => {
+    const spec = readProjectSpec(MTGORDLE)
     expect(spec.hasVision).toBe(true)
     expect(spec.hasMilestones).toBe(true)
     expect(spec.vision?.name).toBeDefined()

--- a/src/launcher/migrate-projects-out-of-repo.js
+++ b/src/launcher/migrate-projects-out-of-repo.js
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+/**
+ * One-shot migration: move every project directory out of the Rouge
+ * repo tree and into `~/.rouge/projects/<slug>`.
+ *
+ * Motivation (#143): spawned phase agents run with `cwd = projectDir`
+ * and Claude Code auto-loads every `CLAUDE.md` walking up. When
+ * projects lived inside the Rouge repo, the ancestor walk picked up
+ * Rouge's own developer CLAUDE.md and the agent started behaving like
+ * a Rouge contributor instead of the product-building role it was
+ * given. Moving projects to `~/.rouge/projects/` removes the ancestor
+ * entirely.
+ *
+ * Safe to run repeatedly:
+ *   - skips projects already at the destination
+ *   - refuses to move if the destination exists with different contents
+ *     (conflict — resolve manually)
+ *
+ * Usage:
+ *   node src/launcher/migrate-projects-out-of-repo.js [source] [dest]
+ *
+ * Default source: `<repo>/projects`.
+ * Default dest:   `$ROUGE_PROJECTS_DIR` or `~/.rouge/projects`.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+function resolveDefaultSource() {
+  return path.join(path.resolve(__dirname, '../..'), 'projects');
+}
+
+function resolveDefaultDest() {
+  if (process.env.ROUGE_PROJECTS_DIR) return process.env.ROUGE_PROJECTS_DIR;
+  const home = process.env.HOME || process.env.USERPROFILE || '/tmp';
+  return path.join(home, '.rouge', 'projects');
+}
+
+function isDirEmpty(dir) {
+  try {
+    return fs.readdirSync(dir).length === 0;
+  } catch {
+    return true;
+  }
+}
+
+function migrateProject(srcDir, destDir) {
+  const hasSrc = fs.existsSync(srcDir);
+  const hasDest = fs.existsSync(destDir);
+
+  if (!hasSrc && !hasDest) return { status: 'missing' };
+  if (!hasSrc && hasDest) return { status: 'already-migrated' };
+
+  if (hasSrc && hasDest) {
+    // Harmless duplicate if the destination is a leftover empty dir.
+    if (isDirEmpty(destDir)) {
+      fs.rmdirSync(destDir);
+    } else {
+      return {
+        status: 'conflict',
+        detail: `both ${srcDir} and ${destDir} exist with content — resolve manually`,
+      };
+    }
+  }
+
+  fs.mkdirSync(path.dirname(destDir), { recursive: true });
+  fs.renameSync(srcDir, destDir);
+  return { status: 'migrated' };
+}
+
+function main() {
+  const source = path.resolve(process.argv[2] || resolveDefaultSource());
+  const dest = path.resolve(process.argv[3] || resolveDefaultDest());
+
+  if (!fs.existsSync(source)) {
+    console.log(`Source does not exist, nothing to migrate: ${source}`);
+    return;
+  }
+
+  console.log(`Migrating projects:`);
+  console.log(`  from: ${source}`);
+  console.log(`    to: ${dest}`);
+  console.log('');
+
+  fs.mkdirSync(dest, { recursive: true });
+
+  const entries = fs.readdirSync(source, { withFileTypes: true })
+    .filter(e => e.isDirectory());
+
+  let migrated = 0;
+  let already = 0;
+  let conflicts = 0;
+
+  for (const entry of entries) {
+    const srcDir = path.join(source, entry.name);
+    const destDir = path.join(dest, entry.name);
+    const result = migrateProject(srcDir, destDir);
+    switch (result.status) {
+      case 'migrated':
+        console.log(`  migrated: ${entry.name}`);
+        migrated++;
+        break;
+      case 'already-migrated':
+        console.log(`  already migrated: ${entry.name}`);
+        already++;
+        break;
+      case 'conflict':
+        console.error(`  CONFLICT: ${entry.name} — ${result.detail}`);
+        conflicts++;
+        break;
+    }
+  }
+
+  // Drop the now-empty source dir so it stops showing up in `git status`.
+  if (migrated > 0 && isDirEmpty(source)) {
+    fs.rmdirSync(source);
+    console.log(`  removed empty source: ${source}`);
+  }
+
+  console.log('');
+  console.log(`Summary: ${migrated} migrated, ${already} already, ${conflicts} conflicts`);
+
+  if (conflicts > 0) process.exit(2);
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { migrateProject };

--- a/src/launcher/provision-infrastructure.js
+++ b/src/launcher/provision-infrastructure.js
@@ -194,7 +194,8 @@ function provisionSupabase(projectDir, projectName) {
     // Slot rotation: find a project NOT actively managed by Rouge to pause.
     // Rouge-managed projects have a state.json in PROJECTS_DIR/<name>/ with state != complete.
     // Non-Rouge projects (manual, other tools) are always eligible to pause.
-    const PROJECTS_DIR = process.env.ROUGE_PROJECTS_DIR || path.join(ROUGE_ROOT, 'projects');
+    const PROJECTS_DIR = process.env.ROUGE_PROJECTS_DIR ||
+      path.join(process.env.HOME || process.env.USERPROFILE || '/tmp', '.rouge', 'projects');
 
     const isActiveRougeProject = (supabaseName) => {
       // Check all Rouge project dirs for a matching supabase ref

--- a/src/launcher/rouge-cli.js
+++ b/src/launcher/rouge-cli.js
@@ -19,14 +19,12 @@ const fs = require('fs');
 
 const ROUGE_ROOT = path.resolve(__dirname, '../..');
 
-// Detect if installed globally (npm install -g) vs cloned from source.
-// Global: ROUGE_ROOT is inside node_modules — don't store projects there.
-// Source: ROUGE_ROOT is the repo — projects/ is the natural home.
+// Projects always live under ~/.rouge/projects so spawned phase agents
+// (cwd = project dir) don't inherit Rouge's own CLAUDE.md via ancestor
+// lookup — see #143 for the leak that motivated moving them out of the
+// repo tree.
 function resolveProjectsDir() {
   if (process.env.ROUGE_PROJECTS_DIR) return process.env.ROUGE_PROJECTS_DIR;
-  const repoProjects = path.join(ROUGE_ROOT, 'projects');
-  if (fs.existsSync(path.join(ROUGE_ROOT, '.git'))) return repoProjects;
-  // Global install — use ~/.rouge/projects/
   const home = process.env.HOME || process.env.USERPROFILE || '/tmp';
   return path.join(home, '.rouge', 'projects');
 }

--- a/src/launcher/rouge-loop.js
+++ b/src/launcher/rouge-loop.js
@@ -32,10 +32,17 @@ const { statePath, statePathForWrite, hasStateFile } = require('./state-path.js'
 
 const ROUGE_ROOT = path.resolve(__dirname, '../..');
 
-// Detect global npm install vs cloned from source
+// Resolve the projects directory.
+//
+// Always lives OUTSIDE the Rouge repo tree (#143). Spawned phase agents
+// run with cwd set to a project dir, and Claude Code auto-loads every
+// `CLAUDE.md` walking up — so anything inside the Rouge repo picks up
+// Rouge's own developer instructions and the agent starts behaving like
+// a Rouge contributor instead of the product-building role it was given.
+// Storing projects under ~/.rouge/projects puts a clean filesystem
+// boundary between the meta-system and the products it builds.
 function resolveProjectsDir() {
   if (process.env.ROUGE_PROJECTS_DIR) return process.env.ROUGE_PROJECTS_DIR;
-  if (fs.existsSync(path.join(ROUGE_ROOT, '.git'))) return path.join(ROUGE_ROOT, 'projects');
   const home = process.env.HOME || process.env.USERPROFILE || '/tmp';
   return path.join(home, '.rouge', 'projects');
 }

--- a/src/slack/bot.js
+++ b/src/slack/bot.js
@@ -12,7 +12,10 @@ const app = new App({
   socketMode: true,
 });
 
-const PROJECTS_DIR = process.env.ROUGE_PROJECTS_DIR || path.join(__dirname, '../../projects');
+// Projects live outside the repo tree (#143) so spawned phase agents
+// don't auto-load Rouge's own CLAUDE.md as ancestor context.
+const PROJECTS_DIR = process.env.ROUGE_PROJECTS_DIR ||
+  path.join(process.env.HOME || process.env.USERPROFILE || '/tmp', '.rouge', 'projects');
 const KNOWN_COMMANDS = ['status', 'start', 'pause', 'resume', 'new', 'seed', 'ship', 'feedback', 'help'];
 
 function readState(projectName) {

--- a/test/launcher/migrate-projects-out-of-repo.test.js
+++ b/test/launcher/migrate-projects-out-of-repo.test.js
@@ -1,0 +1,92 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { migrateProject } = require('../../src/launcher/migrate-projects-out-of-repo.js');
+
+function mkdtemp() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'rouge-migrate-proj-'));
+}
+
+test('moves the project directory from source to destination', () => {
+  const root = mkdtemp();
+  try {
+    const src = path.join(root, 'src', 'alpha');
+    const dst = path.join(root, 'dst', 'alpha');
+    fs.mkdirSync(src, { recursive: true });
+    fs.writeFileSync(path.join(src, 'state.json'), '{"current_state":"seeding"}');
+
+    const result = migrateProject(src, dst);
+    assert.strictEqual(result.status, 'migrated');
+    assert.ok(fs.existsSync(path.join(dst, 'state.json')));
+    assert.ok(!fs.existsSync(src));
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('reports already-migrated when destination exists and source is gone', () => {
+  const root = mkdtemp();
+  try {
+    const src = path.join(root, 'src', 'alpha');
+    const dst = path.join(root, 'dst', 'alpha');
+    fs.mkdirSync(dst, { recursive: true });
+    fs.writeFileSync(path.join(dst, 'state.json'), '{}');
+
+    const result = migrateProject(src, dst);
+    assert.strictEqual(result.status, 'already-migrated');
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('flags conflict when both source and destination have content', () => {
+  const root = mkdtemp();
+  try {
+    const src = path.join(root, 'src', 'alpha');
+    const dst = path.join(root, 'dst', 'alpha');
+    fs.mkdirSync(src, { recursive: true });
+    fs.mkdirSync(dst, { recursive: true });
+    fs.writeFileSync(path.join(src, 'state.json'), '{"v":1}');
+    fs.writeFileSync(path.join(dst, 'state.json'), '{"v":2}');
+
+    const result = migrateProject(src, dst);
+    assert.strictEqual(result.status, 'conflict');
+    // Both sides remain untouched for manual resolution.
+    assert.ok(fs.existsSync(path.join(src, 'state.json')));
+    assert.ok(fs.existsSync(path.join(dst, 'state.json')));
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('cleans up an empty destination dir before moving source over it', () => {
+  const root = mkdtemp();
+  try {
+    const src = path.join(root, 'src', 'alpha');
+    const dst = path.join(root, 'dst', 'alpha');
+    fs.mkdirSync(src, { recursive: true });
+    fs.writeFileSync(path.join(src, 'state.json'), '{"v":1}');
+    fs.mkdirSync(dst, { recursive: true }); // empty placeholder
+
+    const result = migrateProject(src, dst);
+    assert.strictEqual(result.status, 'migrated');
+    assert.ok(fs.existsSync(path.join(dst, 'state.json')));
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('no-op when the source does not exist', () => {
+  const root = mkdtemp();
+  try {
+    const src = path.join(root, 'src', 'missing');
+    const dst = path.join(root, 'dst', 'missing');
+    const result = migrateProject(src, dst);
+    assert.strictEqual(result.status, 'missing');
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Closes #143.

## Why

Spawned phase agents ran with `cwd` set to a project dir. Claude Code auto-loads every `CLAUDE.md` walking up from cwd, so the brainstormer was inheriting Rouge's own developer instructions from the repo root and behaving like a Rouge contributor ("do you want to run this through the Rouge loop") instead of a product brainstormer.

Hiding `state.json` under `.rouge/` (#135) closed one channel. The `CLAUDE.md` chain is structural: any project inside the repo gets it. Only fix is moving projects out of the repo tree.

## What

- `resolveProjectsDir` (launcher, cli, slack bot, provisioning) now always defaults to `~/.rouge/projects`. `ROUGE_PROJECTS_DIR` still wins.
- `dashboard/rouge-dashboard.config.json` drops `projects_root`, letting `loadServerConfig` fall through to the `~/.rouge/projects` default.
- New `src/launcher/migrate-projects-out-of-repo.js` (idempotent, unit-tested). Ran against the 9 live projects; empty source dir removed.
- scanner/activity-reader/platform-reader/spec-reader tests that previously pointed at `<repo>/projects` now use either fixtures (scanner) or skip-if-not-migrated (the others), so a fresh clone doesn't fail.

## Test plan
- [x] `npm test`: 320 launcher tests pass
- [x] `cd dashboard && npm test`: 223 tests pass
- [x] Migration ran idempotently against live projects (9 moved, then 0 on re-run)
- [ ] Manual: restart dashboard, create a new spec, confirm the brainstormer stays in role