### PR TITLE
fix: orchestrator init on first message (kill create-time race)

### DIFF
--- a/dashboard/src/app/api/projects/route.ts
+++ b/dashboard/src/app/api/projects/route.ts
@@ -3,7 +3,6 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { scanProjects } from "@/bridge/scanner";
 import { writeSeedingState } from "@/bridge/seeding-state";
-import { startSeedingSession } from "@/bridge/seed-handler";
 import { statePathForWrite } from "@/bridge/state-path";
 import { loadServerConfig } from "@/lib/server-config";
 
@@ -93,9 +92,16 @@ export async function POST(request: Request) {
     started_at: new Date().toISOString(),
   });
 
-  startSeedingSession(projectDir, name).catch((err) => {
-    console.error(`[seeding] Initial call failed for ${slug}:`, err);
-  });
-
+  // We used to fire `startSeedingSession` here as a fire-and-forget so
+  // Rouge would greet the user before they typed anything. That raced
+  // with the inline title editor: the orchestrator's `claude -p` takes
+  // 15–30s, during which the auto-slug rename (#137) moves the project
+  // directory out from under it and the background call dies with
+  // ENOENT on the stale path — no orchestrator context ever reaches
+  // Claude and the first real message gets a generic response.
+  //
+  // The init now runs inside `handleSeedMessage` on the first user
+  // message instead, so any rename has already happened by the time we
+  // resolve the prompt path.
   return NextResponse.json({ ok: true, slug });
 }

--- a/dashboard/src/bridge/seed-handler.ts
+++ b/dashboard/src/bridge/seed-handler.ts
@@ -92,9 +92,31 @@ export async function handleSeedMessage(
   // the conversation after seeding completes — to amend spec, add missing
   // artifacts, or clarify decisions. Claude remembers context via session_id.
 
+  // First message from the user: inline the orchestrator prompt so the
+  // agent enters the brainstorming discipline. Previously this ran from
+  // a fire-and-forget `startSeedingSession` at project creation, which
+  // raced with the auto-slug rename (#137) and ENOENT'd on the stale
+  // project directory — leaving the session bare-bones Opus.
+  let prompt = userText
+  if (state.session_id === null) {
+    try {
+      const orchestratorPrompt = readFileSync(ORCHESTRATOR_PROMPT_PATH, 'utf-8')
+      prompt = [
+        orchestratorPrompt,
+        '---',
+        'The user has described what they want to build. Begin the seeding swarm — enter BRAINSTORMING and explore their idea per the discipline\'s rules. Their first message is below.',
+        '---',
+        userText,
+      ].join('\n\n')
+    } catch (err) {
+      console.error('[seeding] orchestrator prompt unreadable:', err)
+      // Fall through with raw userText — better than 500'ing the chat.
+    }
+  }
+
   const result = await runClaude({
     projectDir,
-    prompt: userText,
+    prompt,
     sessionId: state.session_id,
   })
 


### PR DESCRIPTION
## Why the brainstorm is still generic

The earlier fix made the orchestrator prompt file loadable. But the dev-server log on the latest seeding attempt showed the next bug:

```
POST   /api/projects                                   → creates untitled-XXX/, fires startSeedingSession in background
PATCH  /api/projects/untitled-XXX                      → auto-slug rename (#137) → testimonials/
POST   /api/projects/testimonials/seed/message  30.6s  → user's first real message
```

...and:
```
[seeding] Initial call failed for untitled-XXX:
  Error: ENOENT: no such file or directory, open '.../untitled-XXX/seeding-state.json'
  at updateSessionId (seeding-state.ts:33)
```

The orchestrator's `claude -p` call takes 15–30s. During that window, the user types a real name in the inline title editor, auto-slug renames the directory, and when the background call tries to persist its session_id it hits ENOENT on the old path. Session dies silently. No orchestrator context ever enters any conversation. The user's first message gets raw Opus.

## Fix

Drop the fire-and-forget at project creation. Move the orchestrator-prompt injection into `handleSeedMessage` on the first user message (when `state.session_id === null`).

By then any auto-slug rename has already settled, there's no race, and the first Claude response enters the brainstorming discipline *responding to the user's actual input* rather than as a separate greeting.

Small UX change: no more "Starting the seeding swarm…" prelude before the user types — the first Rouge message is now the response to their first message, with the BRAINSTORMING framing attached.

## Test plan
- [x] `cd dashboard && npm test` → 223 tests pass
- [ ] Manual: restart dashboard, create spec, describe testimonials idea, first Rouge reply should open with the brainstorming discipline's voice (questions about user/pain/trigger, no unsolicited stack picks)