### PR TITLE
fix(#147): inject sub-discipline prompts and verify artifacts before accepting markers

### DIFF
--- a/dashboard/src/bridge/__tests__/discipline-artifacts.test.ts
+++ b/dashboard/src/bridge/__tests__/discipline-artifacts.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { verifyDisciplineArtifact } from '../discipline-artifacts'
+
+let PROJECT_DIR: string
+
+beforeEach(() => {
+  PROJECT_DIR = mkdtempSync(join(tmpdir(), 'rouge-artifact-'))
+})
+
+afterEach(() => {
+  rmSync(PROJECT_DIR, { recursive: true, force: true })
+})
+
+function writeFile(rel: string, body: string): void {
+  const full = join(PROJECT_DIR, rel)
+  mkdirSync(join(full, '..'), { recursive: true })
+  writeFileSync(full, body)
+}
+
+function writeDir(rel: string, files: Record<string, string>): void {
+  mkdirSync(join(PROJECT_DIR, rel), { recursive: true })
+  for (const [name, body] of Object.entries(files)) {
+    writeFileSync(join(PROJECT_DIR, rel, name), body)
+  }
+}
+
+const LONG_BODY = 'x'.repeat(1000)
+const TINY_BODY = 'x'.repeat(50)
+
+describe('verifyDisciplineArtifact', () => {
+  it('accepts brainstorming when seed_spec/brainstorming.md has real content', () => {
+    writeFile('seed_spec/brainstorming.md', LONG_BODY)
+    expect(verifyDisciplineArtifact(PROJECT_DIR, 'brainstorming').ok).toBe(true)
+  })
+
+  it('accepts brainstorming-design-doc.md as an alternate filename', () => {
+    writeFile('seed_spec/brainstorming-design-doc.md', LONG_BODY)
+    expect(verifyDisciplineArtifact(PROJECT_DIR, 'brainstorming').ok).toBe(true)
+  })
+
+  it('rejects brainstorming when the file exists but is a stub', () => {
+    writeFile('seed_spec/brainstorming.md', TINY_BODY)
+    const r = verifyDisciplineArtifact(PROJECT_DIR, 'brainstorming')
+    expect(r.ok).toBe(false)
+    expect(r.reason).toMatch(/no artifact found/i)
+  })
+
+  it('rejects brainstorming when no file exists', () => {
+    expect(verifyDisciplineArtifact(PROJECT_DIR, 'brainstorming').ok).toBe(false)
+  })
+
+  it('accepts competition via competition_brief.md', () => {
+    writeFile('seed_spec/competition_brief.md', LONG_BODY)
+    expect(verifyDisciplineArtifact(PROJECT_DIR, 'competition').ok).toBe(true)
+  })
+
+  it('accepts taste via seed_spec/taste_verdict.md', () => {
+    writeFile('seed_spec/taste_verdict.md', LONG_BODY)
+    expect(verifyDisciplineArtifact(PROJECT_DIR, 'taste').ok).toBe(true)
+  })
+
+  it('accepts spec via seed_spec/milestones.json', () => {
+    writeFile('seed_spec/milestones.json', LONG_BODY)
+    expect(verifyDisciplineArtifact(PROJECT_DIR, 'spec').ok).toBe(true)
+  })
+
+  it('accepts infrastructure via infrastructure_manifest.json', () => {
+    writeFile('infrastructure_manifest.json', LONG_BODY)
+    expect(verifyDisciplineArtifact(PROJECT_DIR, 'infrastructure').ok).toBe(true)
+  })
+
+  it('accepts design when design/ has at least one file', () => {
+    writeDir('design', { 'layout.yaml': 'hi' })
+    expect(verifyDisciplineArtifact(PROJECT_DIR, 'design').ok).toBe(true)
+  })
+
+  it('rejects design when design/ is empty', () => {
+    writeDir('design', {})
+    expect(verifyDisciplineArtifact(PROJECT_DIR, 'design').ok).toBe(false)
+  })
+
+  it('rejects design when design/ only contains dotfiles', () => {
+    writeDir('design', { '.DS_Store': '' })
+    expect(verifyDisciplineArtifact(PROJECT_DIR, 'design').ok).toBe(false)
+  })
+
+  it('accepts legal-privacy when legal/ has a file', () => {
+    writeDir('legal', { 'terms.md': 'hi' })
+    expect(verifyDisciplineArtifact(PROJECT_DIR, 'legal-privacy').ok).toBe(true)
+  })
+
+  it('accepts marketing when marketing/ has a file', () => {
+    writeDir('marketing', { 'landing.md': 'hi' })
+    expect(verifyDisciplineArtifact(PROJECT_DIR, 'marketing').ok).toBe(true)
+  })
+})

--- a/dashboard/src/bridge/__tests__/discipline-prompts.test.ts
+++ b/dashboard/src/bridge/__tests__/discipline-prompts.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  loadDisciplinePrompt,
+  resolveDisciplinePromptPath,
+} from '../discipline-prompts'
+
+// We point ROUGE_PROMPTS_DIR at a temp seed-prompts dir so the test
+// doesn't rely on the repo's real prompts or on any cwd heuristic.
+let PROMPTS_DIR: string
+let prevEnv: string | undefined
+
+beforeEach(() => {
+  PROMPTS_DIR = mkdtempSync(join(tmpdir(), 'rouge-prompts-'))
+  prevEnv = process.env.ROUGE_PROMPTS_DIR
+  process.env.ROUGE_PROMPTS_DIR = PROMPTS_DIR
+})
+
+afterEach(() => {
+  if (prevEnv === undefined) delete process.env.ROUGE_PROMPTS_DIR
+  else process.env.ROUGE_PROMPTS_DIR = prevEnv
+  rmSync(PROMPTS_DIR, { recursive: true, force: true })
+})
+
+function seed(filename: string, body: string): void {
+  mkdirSync(PROMPTS_DIR, { recursive: true })
+  writeFileSync(join(PROMPTS_DIR, filename), body)
+}
+
+describe('resolveDisciplinePromptPath', () => {
+  it('maps each discipline to its numbered sub-prompt filename', () => {
+    seed('01-brainstorming.md', 'x')
+    seed('02-competition.md', 'x')
+    seed('03-taste.md', 'x')
+    seed('04-spec.md', 'x')
+    seed('05-design.md', 'x')
+    seed('06-legal-privacy.md', 'x')
+    seed('07-marketing.md', 'x')
+    seed('08-infrastructure.md', 'x')
+
+    expect(resolveDisciplinePromptPath('brainstorming')).toContain('01-brainstorming.md')
+    expect(resolveDisciplinePromptPath('competition')).toContain('02-competition.md')
+    expect(resolveDisciplinePromptPath('taste')).toContain('03-taste.md')
+    expect(resolveDisciplinePromptPath('spec')).toContain('04-spec.md')
+    expect(resolveDisciplinePromptPath('design')).toContain('05-design.md')
+    expect(resolveDisciplinePromptPath('legal-privacy')).toContain('06-legal-privacy.md')
+    expect(resolveDisciplinePromptPath('marketing')).toContain('07-marketing.md')
+    expect(resolveDisciplinePromptPath('infrastructure')).toContain('08-infrastructure.md')
+  })
+
+  it('returns null when the file does not exist anywhere', () => {
+    expect(resolveDisciplinePromptPath('brainstorming')).toBeNull()
+  })
+})
+
+describe('loadDisciplinePrompt', () => {
+  it('returns the file body for an existing discipline', () => {
+    seed('01-brainstorming.md', '# BRAINSTORMING\n\nAsk about user, pain, trigger.')
+    const body = loadDisciplinePrompt('brainstorming')
+    expect(body).not.toBeNull()
+    expect(body).toContain('Ask about user, pain, trigger.')
+  })
+
+  it('returns null for a discipline whose file is missing', () => {
+    expect(loadDisciplinePrompt('taste')).toBeNull()
+  })
+})

--- a/dashboard/src/bridge/__tests__/seed-handler.test.ts
+++ b/dashboard/src/bridge/__tests__/seed-handler.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+// Stub the claude runner before importing seed-handler so the handler
+// picks up the mock. We drive its output per test via `mockRunClaude`.
+const mockRunClaude = vi.fn()
+vi.mock('../claude-runner', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../claude-runner')>()
+  return {
+    ...actual,
+    runClaude: (opts: unknown) => mockRunClaude(opts),
+  }
+})
+
+// Title derivation fires async haiku calls. Stub it out so tests stay
+// hermetic and fast.
+vi.mock('../derive-title', () => ({
+  maybeDeriveWorkingTitle: vi.fn(async () => {}),
+}))
+
+import { handleSeedMessage } from '../seed-handler'
+import { readSeedingState, writeSeedingState } from '../seeding-state'
+import { readChatLog } from '../chat-reader'
+
+let PROMPTS_DIR: string
+let PROJECT_DIR: string
+let prevPromptsEnv: string | undefined
+let prevOrchestratorEnv: string | undefined
+
+// Minimal stub prompts. Real content is tested elsewhere — here we only
+// care that SOMETHING non-empty is injected at the right moments.
+const STUB_ORCHESTRATOR = '# ORCHESTRATOR\n\nRun the swarm.'
+const STUB_BRAINSTORM = '# BRAINSTORMING\n\nAsk about user, pain, trigger.'
+
+beforeEach(() => {
+  mockRunClaude.mockReset()
+  PROMPTS_DIR = mkdtempSync(join(tmpdir(), 'rouge-prompts-'))
+  writeFileSync(join(PROMPTS_DIR, '00-swarm-orchestrator.md'), STUB_ORCHESTRATOR)
+  writeFileSync(join(PROMPTS_DIR, '01-brainstorming.md'), STUB_BRAINSTORM)
+
+  PROJECT_DIR = mkdtempSync(join(tmpdir(), 'rouge-proj-'))
+  writeSeedingState(PROJECT_DIR, {
+    session_id: null,
+    status: 'not-started',
+    current_discipline: 'brainstorming',
+  })
+
+  prevPromptsEnv = process.env.ROUGE_PROMPTS_DIR
+  prevOrchestratorEnv = process.env.ROUGE_ORCHESTRATOR_PROMPT
+  process.env.ROUGE_PROMPTS_DIR = PROMPTS_DIR
+  process.env.ROUGE_ORCHESTRATOR_PROMPT = join(PROMPTS_DIR, '00-swarm-orchestrator.md')
+})
+
+afterEach(() => {
+  if (prevPromptsEnv === undefined) delete process.env.ROUGE_PROMPTS_DIR
+  else process.env.ROUGE_PROMPTS_DIR = prevPromptsEnv
+  if (prevOrchestratorEnv === undefined) delete process.env.ROUGE_ORCHESTRATOR_PROMPT
+  else process.env.ROUGE_ORCHESTRATOR_PROMPT = prevOrchestratorEnv
+
+  rmSync(PROMPTS_DIR, { recursive: true, force: true })
+  rmSync(PROJECT_DIR, { recursive: true, force: true })
+})
+
+describe('handleSeedMessage — prompt injection', () => {
+  it('injects both orchestrator and brainstorming sub-prompt on the first turn', async () => {
+    mockRunClaude.mockResolvedValueOnce({
+      result: 'Current understanding: you want X. Who is the user?',
+      session_id: 'session-1',
+    })
+
+    await handleSeedMessage(PROJECT_DIR, 'I want to build a testimonials widget.')
+
+    expect(mockRunClaude).toHaveBeenCalledTimes(1)
+    const sentPrompt: string = mockRunClaude.mock.calls[0][0].prompt
+    expect(sentPrompt).toContain('# ORCHESTRATOR')
+    expect(sentPrompt).toContain('DISCIPLINE TRANSITION — entering BRAINSTORMING')
+    expect(sentPrompt).toContain('Ask about user, pain, trigger.')
+    expect(sentPrompt).toContain('I want to build a testimonials widget.')
+  })
+
+  it('records the discipline as prompted so subsequent turns skip re-injection', async () => {
+    mockRunClaude
+      .mockResolvedValueOnce({ result: 'First reply.', session_id: 'session-1' })
+      .mockResolvedValueOnce({ result: 'Second reply.', session_id: 'session-1' })
+
+    await handleSeedMessage(PROJECT_DIR, 'first message')
+    await handleSeedMessage(PROJECT_DIR, 'second message')
+
+    const state = readSeedingState(PROJECT_DIR)
+    expect(state.disciplines_prompted).toContain('brainstorming')
+
+    const secondPrompt: string = mockRunClaude.mock.calls[1][0].prompt
+    expect(secondPrompt).not.toContain('# ORCHESTRATOR')
+    expect(secondPrompt).not.toContain('DISCIPLINE TRANSITION')
+    expect(secondPrompt).toBe('second message')
+  })
+})
+
+describe('handleSeedMessage — marker verification', () => {
+  it('rejects [DISCIPLINE_COMPLETE: brainstorming] when the artifact is missing', async () => {
+    mockRunClaude.mockResolvedValueOnce({
+      result: 'All done.\n\n[DISCIPLINE_COMPLETE: brainstorming]',
+      session_id: 'session-1',
+    })
+
+    const result = await handleSeedMessage(PROJECT_DIR, 'ship it')
+
+    // Handler reports no accepted disciplines.
+    expect(result.disciplineComplete).toBeUndefined()
+
+    // State stays on brainstorming.
+    const state = readSeedingState(PROJECT_DIR)
+    expect(state.disciplines_complete ?? []).not.toContain('brainstorming')
+    expect(state.current_discipline).toBe('brainstorming')
+
+    // Chat log carries a system note explaining the rejection.
+    const log = readChatLog(PROJECT_DIR)
+    const note = log.find((m) => m.content.includes('was rejected'))
+    expect(note).toBeDefined()
+    expect(note?.content).toContain('DISCIPLINE_COMPLETE(brainstorming) was rejected')
+  })
+
+  it('accepts [DISCIPLINE_COMPLETE: brainstorming] when the artifact is on disk with real content', async () => {
+    mkdirSync(join(PROJECT_DIR, 'seed_spec'), { recursive: true })
+    writeFileSync(
+      join(PROJECT_DIR, 'seed_spec', 'brainstorming.md'),
+      '# Design Doc\n\n' + 'body '.repeat(200),
+    )
+    mockRunClaude.mockResolvedValueOnce({
+      result: 'Design doc written.\n\n[DISCIPLINE_COMPLETE: brainstorming]',
+      session_id: 'session-1',
+    })
+
+    const result = await handleSeedMessage(PROJECT_DIR, 'done')
+
+    expect(result.disciplineComplete).toEqual(['brainstorming'])
+    const state = readSeedingState(PROJECT_DIR)
+    expect(state.disciplines_complete).toContain('brainstorming')
+    // Current discipline auto-advances to the next in sequence.
+    expect(state.current_discipline).toBe('competition')
+  })
+
+  it('silently ignores unknown discipline names in markers', async () => {
+    mockRunClaude.mockResolvedValueOnce({
+      result: '[DISCIPLINE_COMPLETE: hallucinated-discipline]',
+      session_id: 'session-1',
+    })
+
+    const result = await handleSeedMessage(PROJECT_DIR, 'msg')
+    expect(result.disciplineComplete).toBeUndefined()
+    const log = readChatLog(PROJECT_DIR)
+    const note = log.find((m) => m.content.startsWith('[SYSTEM NOTE]'))
+    expect(note?.content).toContain('rejected')
+    expect(note?.content).toContain('hallucinated-discipline')
+  })
+})
+
+describe('handleSeedMessage — discipline transition injection', () => {
+  it('injects the next discipline\'s sub-prompt after brainstorming completes', async () => {
+    writeFileSync(join(PROMPTS_DIR, '02-competition.md'), '# COMPETITION\n\nFind competitors.')
+    // Seed a completed brainstorming state with its artifact present.
+    mkdirSync(join(PROJECT_DIR, 'seed_spec'), { recursive: true })
+    writeFileSync(
+      join(PROJECT_DIR, 'seed_spec', 'brainstorming.md'),
+      '# Design Doc\n\n' + 'body '.repeat(200),
+    )
+    writeSeedingState(PROJECT_DIR, {
+      session_id: 'session-1',
+      status: 'active',
+      disciplines_complete: ['brainstorming'],
+      disciplines_prompted: ['brainstorming'],
+      current_discipline: 'competition',
+    })
+
+    mockRunClaude.mockResolvedValueOnce({
+      result: 'Looking at competitors.',
+      session_id: 'session-1',
+    })
+
+    await handleSeedMessage(PROJECT_DIR, 'keep going')
+
+    const sentPrompt: string = mockRunClaude.mock.calls[0][0].prompt
+    // No orchestrator re-injection (session already active).
+    expect(sentPrompt).not.toContain('# ORCHESTRATOR')
+    // Does inject the new discipline's prompt.
+    expect(sentPrompt).toContain('DISCIPLINE TRANSITION — entering COMPETITION')
+    expect(sentPrompt).toContain('Find competitors.')
+
+    const state = readSeedingState(PROJECT_DIR)
+    expect(state.disciplines_prompted).toContain('competition')
+  })
+})

--- a/dashboard/src/bridge/discipline-artifacts.ts
+++ b/dashboard/src/bridge/discipline-artifacts.ts
@@ -1,0 +1,90 @@
+import { existsSync, readdirSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import type { Discipline } from './discipline-prompts'
+
+/**
+ * Verifies the artifact(s) a discipline is required to produce before its
+ * `[DISCIPLINE_COMPLETE: X]` marker is accepted.
+ *
+ * The orchestrator prompt is emphatic that the marker must follow real
+ * on-disk content, not summaries or intentions (lines 30-51 of
+ * `00-swarm-orchestrator.md`). The agent still emits the marker
+ * prematurely sometimes — today's testimonials run did so with zero
+ * brainstorming artifact on disk. Policing it agent-side was not
+ * sufficient; we now police it dashboard-side. See #147.
+ */
+
+type ArtifactSpec =
+  | { kind: 'file'; path: string; minBytes: number }
+  | { kind: 'dir'; path: string; minFiles: number }
+
+// Each discipline produces at least one of these artifacts. Any hit wins.
+// Paths are relative to the project directory.
+const ARTIFACT_SPECS: Record<Discipline, ArtifactSpec[]> = {
+  brainstorming: [
+    { kind: 'file', path: 'seed_spec/brainstorming.md', minBytes: 500 },
+    { kind: 'file', path: 'seed_spec/brainstorming-design-doc.md', minBytes: 500 },
+  ],
+  competition: [
+    { kind: 'file', path: 'seed_spec/competition_brief.md', minBytes: 500 },
+    { kind: 'file', path: 'seed_spec/competition.md', minBytes: 500 },
+  ],
+  taste: [
+    { kind: 'file', path: 'seed_spec/taste_verdict.md', minBytes: 300 },
+    { kind: 'file', path: 'seed_spec/taste.md', minBytes: 300 },
+  ],
+  spec: [{ kind: 'file', path: 'seed_spec/milestones.json', minBytes: 500 }],
+  infrastructure: [{ kind: 'file', path: 'infrastructure_manifest.json', minBytes: 200 }],
+  design: [{ kind: 'dir', path: 'design', minFiles: 1 }],
+  'legal-privacy': [{ kind: 'dir', path: 'legal', minFiles: 1 }],
+  marketing: [{ kind: 'dir', path: 'marketing', minFiles: 1 }],
+}
+
+export interface ArtifactCheck {
+  ok: boolean
+  discipline: Discipline
+  reason?: string
+  checkedPaths: string[]
+}
+
+export function verifyDisciplineArtifact(
+  projectDir: string,
+  discipline: Discipline,
+): ArtifactCheck {
+  const specs = ARTIFACT_SPECS[discipline]
+  if (!specs) {
+    return { ok: false, discipline, reason: 'unknown discipline', checkedPaths: [] }
+  }
+
+  const checked: string[] = []
+  for (const spec of specs) {
+    const full = join(projectDir, spec.path)
+    checked.push(spec.path)
+    if (!existsSync(full)) continue
+
+    if (spec.kind === 'file') {
+      try {
+        const size = statSync(full).size
+        if (size >= spec.minBytes) return { ok: true, discipline, checkedPaths: checked }
+      } catch {
+        continue
+      }
+    } else {
+      try {
+        const entries = readdirSync(full).filter((f) => !f.startsWith('.'))
+        if (entries.length >= spec.minFiles) return { ok: true, discipline, checkedPaths: checked }
+      } catch {
+        continue
+      }
+    }
+  }
+
+  return {
+    ok: false,
+    discipline,
+    reason: `no artifact found matching ${specs
+      .map((s) => (s.kind === 'file' ? `file ${s.path} (≥${s.minBytes}B)` : `dir ${s.path}/ (≥${s.minFiles} files)`))
+      .join(' or ')}`,
+    checkedPaths: checked,
+  }
+}

--- a/dashboard/src/bridge/discipline-prompts.ts
+++ b/dashboard/src/bridge/discipline-prompts.ts
@@ -1,0 +1,89 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+/**
+ * Loads the detailed sub-discipline prompt for a given seeding phase.
+ *
+ * The orchestrator prompt (`00-swarm-orchestrator.md`) only *mentions* the
+ * sub-prompt filenames — it never instructs the agent to read them and
+ * never inlines their content. As a result, the agent has been running
+ * each discipline off four-word descriptions like "Depth-first idea
+ * exploration" and improvising. That's why brainstorming was opening
+ * with stack-architecture questions instead of asking about user / pain /
+ * trigger as the real prompt demands. See #147.
+ *
+ * We inject the active discipline's full sub-prompt at every transition
+ * so Claude has the detailed rules in context when it needs them.
+ */
+
+export type Discipline =
+  | 'brainstorming'
+  | 'competition'
+  | 'taste'
+  | 'spec'
+  | 'infrastructure'
+  | 'design'
+  | 'legal-privacy'
+  | 'marketing'
+
+// Maps discipline names to their prompt filenames in `src/prompts/seeding/`.
+const DISCIPLINE_FILES: Record<Discipline, string> = {
+  brainstorming: '01-brainstorming.md',
+  competition: '02-competition.md',
+  taste: '03-taste.md',
+  spec: '04-spec.md',
+  design: '05-design.md',
+  'legal-privacy': '06-legal-privacy.md',
+  marketing: '07-marketing.md',
+  infrastructure: '08-infrastructure.md',
+}
+
+function candidatesFor(filename: string): string[] {
+  const envHint = process.env.ROUGE_PROMPTS_DIR
+  // When the env var is set it's authoritative — callers use it to pin
+  // lookup to a specific directory (tests do this, and operators can use
+  // it to point Rouge at a custom prompt checkout). Don't fall back to
+  // cwd/__dirname in that case or tests silently pick up the repo's real
+  // prompts and false-pass.
+  if (envHint) return [resolve(envHint, filename)]
+  return [
+    // Dashboard invoked from repo root.
+    resolve(process.cwd(), 'src/prompts/seeding', filename),
+    // Dashboard invoked from its own dir (`cd dashboard && npm run dev`).
+    resolve(process.cwd(), '../src/prompts/seeding', filename),
+    // __dirname fallbacks — unreliable under Turbopack, useful when the
+    // module is imported directly from tests or a standalone server.
+    resolve(__dirname, '../../../src/prompts/seeding', filename),
+    resolve(__dirname, '../..', '../src/prompts/seeding', filename),
+  ]
+}
+
+/**
+ * Returns the absolute path to a discipline's sub-prompt on disk, or null
+ * if we can't find it anywhere. Throws nothing — callers handle null by
+ * falling back to the orchestrator's summary alone.
+ */
+export function resolveDisciplinePromptPath(discipline: Discipline): string | null {
+  const filename = DISCIPLINE_FILES[discipline]
+  if (!filename) return null
+  for (const candidate of candidatesFor(filename)) {
+    if (existsSync(candidate)) return candidate
+  }
+  return null
+}
+
+/**
+ * Returns the full text of a discipline's sub-prompt, or null if the file
+ * can't be located or read. Caller is responsible for handling null —
+ * usually by sending the user message bare, which degrades to the old
+ * improvised behaviour rather than crashing.
+ */
+export function loadDisciplinePrompt(discipline: Discipline): string | null {
+  const path = resolveDisciplinePromptPath(discipline)
+  if (!path) return null
+  try {
+    return readFileSync(path, 'utf-8')
+  } catch {
+    return null
+  }
+}

--- a/dashboard/src/bridge/seed-handler.ts
+++ b/dashboard/src/bridge/seed-handler.ts
@@ -2,9 +2,12 @@ import { existsSync, readFileSync } from 'fs'
 import { resolve } from 'path'
 import { runClaude, detectRateLimit, extractMarkers } from './claude-runner'
 import { appendChatMessage } from './chat-reader'
-import { readSeedingState, updateSessionId, markDisciplineComplete, markSeedingComplete, setStatus } from './seeding-state'
+import { readSeedingState, updateSessionId, markDisciplineComplete, markDisciplinePrompted, markSeedingComplete, setStatus } from './seeding-state'
 import { finalizeSeeding } from './seeding-finalize'
 import { maybeDeriveWorkingTitle } from './derive-title'
+import { loadDisciplinePrompt, type Discipline } from './discipline-prompts'
+import { verifyDisciplineArtifact } from './discipline-artifacts'
+import { DISCIPLINE_SEQUENCE } from './types'
 
 // Locate the seeding orchestrator prompt at startup.
 //
@@ -40,7 +43,12 @@ function resolveOrchestratorPromptPath(): string {
   return candidates[0]
 }
 
-const ORCHESTRATOR_PROMPT_PATH = resolveOrchestratorPromptPath()
+// Resolved lazily per-call (not cached at module load) so tests can
+// point this at a fixture via `ROUGE_ORCHESTRATOR_PROMPT` after the
+// module has already imported.
+function currentOrchestratorPromptPath(): string {
+  return resolveOrchestratorPromptPath()
+}
 
 function genId(): string {
   return `msg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
@@ -92,27 +100,51 @@ export async function handleSeedMessage(
   // the conversation after seeding completes — to amend spec, add missing
   // artifacts, or clarify decisions. Claude remembers context via session_id.
 
-  // First message from the user: inline the orchestrator prompt so the
-  // agent enters the brainstorming discipline. Previously this ran from
-  // a fire-and-forget `startSeedingSession` at project creation, which
-  // raced with the auto-slug rename (#137) and ENOENT'd on the stale
-  // project directory — leaving the session bare-bones Opus.
-  let prompt = userText
-  if (state.session_id === null) {
+  const activeDiscipline = resolveActiveDiscipline(state.current_discipline)
+  const alreadyPrompted = state.disciplines_prompted ?? []
+  const isFirstTurn = state.session_id === null
+  const needsDisciplinePrompt =
+    activeDiscipline !== null && !alreadyPrompted.includes(activeDiscipline)
+
+  // Build the prompt. Two injections can fire:
+  //
+  // 1) Orchestrator prompt on the session's very first turn — sets the
+  //    swarm context, discipline list, markers protocol (#146).
+  // 2) The ACTIVE discipline's full sub-prompt the first time we enter
+  //    that discipline in this session (#147). Without this, the agent
+  //    had been improvising each discipline from the orchestrator's
+  //    one-line summary and skipping the real rules (ask user/pain/
+  //    trigger, one question at a time, produce the Design Document, etc).
+  //    Session resume carries the prompt forward for subsequent turns in
+  //    the same discipline — we inject once per discipline, not per turn.
+  const sections: string[] = []
+  if (isFirstTurn) {
     try {
-      const orchestratorPrompt = readFileSync(ORCHESTRATOR_PROMPT_PATH, 'utf-8')
-      prompt = [
-        orchestratorPrompt,
-        '---',
-        'The user has described what they want to build. Begin the seeding swarm — enter BRAINSTORMING and explore their idea per the discipline\'s rules. Their first message is below.',
-        '---',
-        userText,
-      ].join('\n\n')
+      sections.push(readFileSync(currentOrchestratorPromptPath(), 'utf-8'))
     } catch (err) {
       console.error('[seeding] orchestrator prompt unreadable:', err)
-      // Fall through with raw userText — better than 500'ing the chat.
     }
   }
+  if (needsDisciplinePrompt && activeDiscipline) {
+    const sub = loadDisciplinePrompt(activeDiscipline)
+    if (sub) {
+      sections.push(
+        '---',
+        `DISCIPLINE TRANSITION — entering ${activeDiscipline.toUpperCase()}. Follow the rules below exactly. Ignore any temptation to shortcut into later disciplines (spec, infrastructure, deployment choice) — that is a separate phase. Complete this discipline's artifact on disk before emitting its completion marker.`,
+        sub,
+      )
+    } else {
+      console.error(`[seeding] discipline prompt unreadable for ${activeDiscipline}`)
+    }
+  }
+  if (isFirstTurn && sections.length > 0) {
+    sections.push(
+      '---',
+      'The user has described what they want to build. Their first message is below — respond in character as the active discipline.',
+    )
+  }
+  sections.push(userText)
+  const prompt = sections.join('\n\n')
 
   const result = await runClaude({
     projectDir,
@@ -128,15 +160,18 @@ export async function handleSeedMessage(
     return { ok: false, status: 500, error: result.error }
   }
 
-  // Capture the discipline that was active when this message started.
-  // We tag messages with this discipline (even if markers advance it afterwards).
-  const activeDiscipline = state.current_discipline
-
-  // Detect rate limit
+  // Detect rate limit BEFORE marking the discipline prompted so a rate-
+  // limited turn retries with the same injection next time.
   if (detectRateLimit(result.result)) {
     setStatus(projectDir, 'paused')
-    appendMessages(projectDir, userText, result.result, activeDiscipline)
+    appendMessages(projectDir, userText, result.result, activeDiscipline ?? undefined)
     return { ok: false, status: 429, error: 'Claude rate-limited', rateLimited: true }
+  }
+
+  // We successfully handed the discipline's sub-prompt to Claude; record
+  // it so we don't re-inject on every subsequent turn in the same phase.
+  if (needsDisciplinePrompt && activeDiscipline) {
+    markDisciplinePrompted(projectDir, activeDiscipline)
   }
 
   // Persist session_id if new
@@ -149,15 +184,51 @@ export async function handleSeedMessage(
     setStatus(projectDir, 'active')
   }
 
-  // Parse markers
+  // Parse markers. We only advance discipline state for markers whose
+  // artifact actually exists on disk — the orchestrator prompt forbids
+  // premature markers, but the agent has been known to emit them
+  // anyway (#147). Dashboard-side enforcement is the backstop.
   const markers = extractMarkers(result.result)
+  const acceptedDisciplines: string[] = []
+  const rejectedDisciplines: Array<{ discipline: string; reason: string }> = []
   for (const d of markers.disciplinesComplete) {
-    markDisciplineComplete(projectDir, d)
+    if (!isKnownDiscipline(d)) {
+      rejectedDisciplines.push({ discipline: d, reason: 'unknown discipline name' })
+      continue
+    }
+    const check = verifyDisciplineArtifact(projectDir, d)
+    if (check.ok) {
+      markDisciplineComplete(projectDir, d)
+      acceptedDisciplines.push(d)
+    } else {
+      console.warn(
+        `[seeding] rejecting DISCIPLINE_COMPLETE(${d}) — ${check.reason}`,
+      )
+      rejectedDisciplines.push({ discipline: d, reason: check.reason ?? 'artifact missing' })
+    }
   }
 
   // Append conversation (user message + rouge response) tagged with the
-  // discipline that was active BEFORE markers fired.
-  appendMessages(projectDir, userText, result.result, activeDiscipline)
+  // discipline that was active BEFORE markers fired. If the agent emitted
+  // markers for disciplines whose artifacts aren't on disk, append a
+  // follow-up note so both the human (in the UI) and the agent (via
+  // session history on the next turn) see that the marker was rejected.
+  appendMessages(projectDir, userText, result.result, activeDiscipline ?? undefined)
+  if (rejectedDisciplines.length > 0) {
+    const note = rejectedDisciplines
+      .map(
+        (r) =>
+          `[SYSTEM NOTE] DISCIPLINE_COMPLETE(${r.discipline}) was rejected — ${r.reason}. The discipline remains active. Continue the work on disk and emit the marker only when the artifact exists with real content.`,
+      )
+      .join('\n')
+    appendChatMessage(projectDir, {
+      id: genId(),
+      role: 'rouge',
+      content: note,
+      timestamp: new Date().toISOString(),
+      metadata: { discipline: activeDiscipline ?? undefined },
+    })
+  }
 
   // If this was the first user message and the project is still
   // placeholder-named, derive a working title in the background.
@@ -180,59 +251,18 @@ export async function handleSeedMessage(
   return {
     ok: true,
     status: 200,
-    disciplineComplete: markers.disciplinesComplete.length > 0 ? markers.disciplinesComplete : undefined,
+    disciplineComplete: acceptedDisciplines.length > 0 ? acceptedDisciplines : undefined,
     seedingComplete: markers.seedingComplete,
     readyTransition,
     missingArtifacts,
   }
 }
 
-export async function startSeedingSession(
-  projectDir: string,
-  projectName: string,
-): Promise<SendMessageResult> {
-  const orchestratorPrompt = readFileSync(ORCHESTRATOR_PROMPT_PATH, 'utf-8')
-  const initialPrompt = orchestratorPrompt +
-    '\n\n---\n\nThe user wants to build a product called "' + projectName + '". Start the seeding swarm. Ask the first question.'
+function isKnownDiscipline(name: string): name is Discipline {
+  return (DISCIPLINE_SEQUENCE as readonly string[]).includes(name)
+}
 
-  const result = await runClaude({
-    projectDir,
-    prompt: initialPrompt,
-    sessionId: null,
-  })
-
-  if (result.timeout) {
-    return { ok: false, status: 504, error: 'Claude timed out' }
-  }
-  if (result.error) {
-    return { ok: false, status: 500, error: result.error }
-  }
-
-  // First-ever message always starts with brainstorming
-  const activeDiscipline = 'brainstorming'
-
-  if (detectRateLimit(result.result)) {
-    setStatus(projectDir, 'paused')
-    appendMessages(projectDir, null, result.result, activeDiscipline)
-    return { ok: false, status: 429, error: 'Claude rate-limited', rateLimited: true }
-  }
-
-  if (result.session_id) {
-    updateSessionId(projectDir, result.session_id)
-  }
-  setStatus(projectDir, 'active')
-
-  const markers = extractMarkers(result.result)
-  for (const d of markers.disciplinesComplete) {
-    markDisciplineComplete(projectDir, d)
-  }
-
-  // Only Rouge's message (no user input initiated this)
-  appendMessages(projectDir, null, result.result, activeDiscipline)
-
-  return {
-    ok: true,
-    status: 200,
-    disciplineComplete: markers.disciplinesComplete.length > 0 ? markers.disciplinesComplete : undefined,
-  }
+function resolveActiveDiscipline(raw: string | undefined): Discipline | null {
+  if (!raw) return DISCIPLINE_SEQUENCE[0] as Discipline
+  return isKnownDiscipline(raw) ? raw : null
 }

--- a/dashboard/src/bridge/seeding-state.ts
+++ b/dashboard/src/bridge/seeding-state.ts
@@ -98,3 +98,19 @@ export function setStatus(projectDir: string, status: SeedingSessionState['statu
   state.last_activity = new Date().toISOString()
   writeSeedingState(projectDir, state)
 }
+
+/**
+ * Mark a discipline's detailed sub-prompt as having been injected into
+ * the current session at least once. Used by the seed handler to decide
+ * whether to re-inject on the next turn (#147).
+ */
+export function markDisciplinePrompted(projectDir: string, discipline: string): void {
+  const state = readSeedingState(projectDir)
+  const prompted = state.disciplines_prompted ?? []
+  if (!prompted.includes(discipline)) {
+    prompted.push(discipline)
+    state.disciplines_prompted = prompted
+    state.last_activity = new Date().toISOString()
+    writeSeedingState(projectDir, state)
+  }
+}

--- a/dashboard/src/bridge/types.ts
+++ b/dashboard/src/bridge/types.ts
@@ -122,6 +122,11 @@ export interface SeedingSessionState {
   disciplines_complete?: string[]
   current_discipline?: string
   seeding_complete?: boolean
+  // Disciplines whose detailed sub-prompt has already been sent to Claude
+  // in this session. Used by the seed handler to inject each discipline's
+  // prompt exactly once per discipline (#147) — subsequent turns within a
+  // discipline ride on session memory.
+  disciplines_prompted?: string[]
 }
 
 // The canonical sequence of disciplines used when auto-advancing current_discipline


### PR DESCRIPTION
Closes #147.

## Why the brainstorm has been generic

Two bugs compounded.

**1. Detailed sub-discipline prompts never reached Claude.** `seed-handler` only loaded `00-swarm-orchestrator.md`. The orchestrator mentions the sub-prompt filenames but never instructs the agent to read them and never inlines their content. Every discipline has been running on its four-word summary (`BRAINSTORMING — Depth-first idea exploration`) while the 200-line rulebook (ask about user/pain/trigger, one question at a time, produce a Design Document) sits unread on disk.

**2. `[DISCIPLINE_COMPLETE: X]` markers were accepted unchecked.** The agent has been emitting them prematurely — today's testimonials run declared brainstorming complete with zero artifact on disk. Policing was agent-side only; no backstop.

Moving projects out of the repo (#143) also ended whatever opportunistic file traversal let older runs improvise closer to the intended script.

## What this changes

**Per-discipline prompt injection at transitions**
- `discipline-prompts.ts` — resolves each sub-prompt via the same fallback-paths pattern as #145. `ROUGE_PROMPTS_DIR` is authoritative when set.
- `handleSeedMessage` — inlines the active discipline's full sub-prompt the first time we enter that discipline in a session, framed by a `DISCIPLINE TRANSITION — entering X` banner. Session resume carries it forward for subsequent turns. We inject once per discipline, not per turn.
- `seeding-state` — tracks `disciplines_prompted[]` so transitions (including loop-backs) can be detected.

**Artifact verification**
- `discipline-artifacts.ts` — maps each discipline to expected paths with minimum size/content thresholds: `seed_spec/brainstorming.md` >=500 B, `design/` >=1 non-dotfile, etc.
- When Claude emits `[DISCIPLINE_COMPLETE: X]`, the handler verifies before advancing state. Rejected markers produce a `[SYSTEM NOTE]` in the chat log so both the human (UI) and Claude (via session history on the next turn) see the rejection; the discipline stays active.

**Cleanup**
- Removed the `startSeedingSession` function — made obsolete by #146. Orchestrator injection now lives on the first turn of `handleSeedMessage`.
- `ORCHESTRATOR_PROMPT_PATH` now resolves lazily per call so tests can redirect via env var after module import.

## Test plan

- [x] 17 new unit tests (loader + verifier across all 8 disciplines)
- [x] 6 new integration tests (first-turn orchestrator+sub-prompt injection; subsequent turns skip re-injection; marker accepted with real artifact; marker rejected with system note on missing artifact; unknown discipline names rejected; transition injection after discipline advances)
- [x] Full dashboard suite: 246 pass (up from 223)
- [ ] Manual: restart dashboard, new spec, describe testimonials — expect a BRAINSTORMING-voiced reply asking about user/pain/trigger, one question at a time