### PR TITLE
fix: deliver rejected DISCIPLINE_COMPLETE notes to Claude on next turn

### DIFF
--- a/dashboard/src/bridge/__tests__/seed-handler.test.ts
+++ b/dashboard/src/bridge/__tests__/seed-handler.test.ts
@@ -142,6 +142,34 @@ describe('handleSeedMessage — marker verification', () => {
     expect(state.current_discipline).toBe('competition')
   })
 
+  it('delivers a prior rejection to Claude on the following turn', async () => {
+    // Turn 1: agent emits a marker without the artifact; handler rejects.
+    mockRunClaude.mockResolvedValueOnce({
+      result: 'Done.\n\n[DISCIPLINE_COMPLETE: brainstorming]',
+      session_id: 'session-1',
+    })
+    await handleSeedMessage(PROJECT_DIR, 'first message')
+
+    // Pending correction should be stashed in state.
+    const afterReject = readSeedingState(PROJECT_DIR)
+    expect(afterReject.pending_correction).toMatch(/was rejected/)
+
+    // Turn 2: user sends a follow-up; the rejection note must be in the
+    // prompt sent to Claude, and cleared from state afterwards.
+    mockRunClaude.mockResolvedValueOnce({
+      result: 'Understood — writing the artifact.',
+      session_id: 'session-1',
+    })
+    await handleSeedMessage(PROJECT_DIR, 'continue')
+
+    const turn2Prompt: string = mockRunClaude.mock.calls[1][0].prompt
+    expect(turn2Prompt).toMatch(/was rejected/)
+    expect(turn2Prompt).toContain('continue')
+
+    const afterTurn2 = readSeedingState(PROJECT_DIR)
+    expect(afterTurn2.pending_correction).toBeUndefined()
+  })
+
   it('silently ignores unknown discipline names in markers', async () => {
     mockRunClaude.mockResolvedValueOnce({
       result: '[DISCIPLINE_COMPLETE: hallucinated-discipline]',

--- a/dashboard/src/bridge/seed-handler.ts
+++ b/dashboard/src/bridge/seed-handler.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync } from 'fs'
 import { resolve } from 'path'
 import { runClaude, detectRateLimit, extractMarkers } from './claude-runner'
 import { appendChatMessage } from './chat-reader'
-import { readSeedingState, updateSessionId, markDisciplineComplete, markDisciplinePrompted, markSeedingComplete, setStatus } from './seeding-state'
+import { readSeedingState, updateSessionId, markDisciplineComplete, markDisciplinePrompted, markSeedingComplete, setStatus, appendPendingCorrection, consumePendingCorrection } from './seeding-state'
 import { finalizeSeeding } from './seeding-finalize'
 import { maybeDeriveWorkingTitle } from './derive-title'
 import { loadDisciplinePrompt, type Discipline } from './discipline-prompts'
@@ -137,6 +137,15 @@ export async function handleSeedMessage(
       console.error(`[seeding] discipline prompt unreadable for ${activeDiscipline}`)
     }
   }
+  // Deliver any correction stashed from the previous turn (e.g. a
+  // rejected DISCIPLINE_COMPLETE). Claude doesn't see the chat-log note
+  // we appended — its `--resume` only replays the server-side session —
+  // so without this, rejections would be invisible to the agent and it
+  // would either advance blindly or repeat the same mistake.
+  const pendingCorrection = consumePendingCorrection(projectDir)
+  if (pendingCorrection) {
+    sections.push('---', pendingCorrection)
+  }
   if (isFirstTurn && sections.length > 0) {
     sections.push(
       '---',
@@ -221,6 +230,7 @@ export async function handleSeedMessage(
           `[SYSTEM NOTE] DISCIPLINE_COMPLETE(${r.discipline}) was rejected — ${r.reason}. The discipline remains active. Continue the work on disk and emit the marker only when the artifact exists with real content.`,
       )
       .join('\n')
+    // Visible to the human in the chat log UI.
     appendChatMessage(projectDir, {
       id: genId(),
       role: 'rouge',
@@ -228,6 +238,9 @@ export async function handleSeedMessage(
       timestamp: new Date().toISOString(),
       metadata: { discipline: activeDiscipline ?? undefined },
     })
+    // Delivered to Claude on the next turn (session memory alone wouldn't
+    // carry this note — our chat log is separate from Claude's session).
+    appendPendingCorrection(projectDir, note)
   }
 
   // If this was the first user message and the project is still

--- a/dashboard/src/bridge/seeding-state.ts
+++ b/dashboard/src/bridge/seeding-state.ts
@@ -114,3 +114,29 @@ export function markDisciplinePrompted(projectDir: string, discipline: string): 
     writeSeedingState(projectDir, state)
   }
 }
+
+/**
+ * Stash a correction note (e.g. "your DISCIPLINE_COMPLETE was rejected —
+ * write the artifact first") for delivery on the next turn. Multiple
+ * corrections in a single turn stack. See #148.
+ */
+export function appendPendingCorrection(projectDir: string, note: string): void {
+  const state = readSeedingState(projectDir)
+  const existing = state.pending_correction
+  state.pending_correction = existing ? `${existing}\n${note}` : note
+  state.last_activity = new Date().toISOString()
+  writeSeedingState(projectDir, state)
+}
+
+/**
+ * Read and clear any pending correction. Returns null if there was none.
+ */
+export function consumePendingCorrection(projectDir: string): string | null {
+  const state = readSeedingState(projectDir)
+  const pending = state.pending_correction
+  if (!pending) return null
+  delete state.pending_correction
+  state.last_activity = new Date().toISOString()
+  writeSeedingState(projectDir, state)
+  return pending
+}

--- a/dashboard/src/bridge/types.ts
+++ b/dashboard/src/bridge/types.ts
@@ -127,6 +127,13 @@ export interface SeedingSessionState {
   // prompt exactly once per discipline (#147) — subsequent turns within a
   // discipline ride on session memory.
   disciplines_prompted?: string[]
+  // A correction note that needs to be delivered to Claude on the next
+  // turn. Populated when the dashboard rejects a `[DISCIPLINE_COMPLETE]`
+  // marker because the artifact isn't on disk (#148). Appending to the
+  // chat log alone isn't enough: Claude Code's `--resume` replays the
+  // server-side session, not our jsonl, so Claude wouldn't see the
+  // rejection otherwise. Consumed (and cleared) on the next message.
+  pending_correction?: string
 }
 
 // The canonical sequence of disciplines used when auto-advancing current_discipline


### PR DESCRIPTION
Follow-up to #148.

## Why
#148 rejected false completion markers and posted a `[SYSTEM NOTE]` to the chat log. The human sees it in the UI — but Claude doesn't. `claude -p --resume` replays the server-side session, not our jsonl, so the rejection never reaches the agent. On the next turn it would advance blindly or repeat the same mistake.

Observed: brainstormed the testimonials spec, agent emitted `[DISCIPLINE_COMPLETE: brainstorming]` without writing `seed_spec/brainstorming.md`, dashboard rejected, human saw the note but agent did not.

## What
- Stash the rejection note in `seeding-state.pending_correction` when a marker fails verification.
- On the next `handleSeedMessage` call, consume the correction and prepend it to the prompt sent to Claude. Clears after delivery.
- Multiple rejections in the same turn stack.
- Chat-log `[SYSTEM NOTE]` still posts for the human.

## Test plan
- [x] New integration test: turn 1 rejects false marker and stashes the note; turn 2 prompt contains the note and state is cleared.
- [x] Full dashboard suite: 247 tests pass.