### PR TITLE
fix: recognise seeding artifacts under docs/ + pin canonical path in sub-prompts

### DIFF
--- a/dashboard/src/bridge/__tests__/discipline-artifacts.test.ts
+++ b/dashboard/src/bridge/__tests__/discipline-artifacts.test.ts
@@ -42,6 +42,11 @@ describe('verifyDisciplineArtifact', () => {
     expect(verifyDisciplineArtifact(PROJECT_DIR, 'brainstorming').ok).toBe(true)
   })
 
+  it('accepts brainstorming written under docs/ when the agent improvised the path', () => {
+    writeFile('docs/brainstorming.md', LONG_BODY)
+    expect(verifyDisciplineArtifact(PROJECT_DIR, 'brainstorming').ok).toBe(true)
+  })
+
   it('rejects brainstorming when the file exists but is a stub', () => {
     writeFile('seed_spec/brainstorming.md', TINY_BODY)
     const r = verifyDisciplineArtifact(PROJECT_DIR, 'brainstorming')
@@ -58,8 +63,18 @@ describe('verifyDisciplineArtifact', () => {
     expect(verifyDisciplineArtifact(PROJECT_DIR, 'competition').ok).toBe(true)
   })
 
+  it('accepts competition written under docs/', () => {
+    writeFile('docs/competition.md', LONG_BODY)
+    expect(verifyDisciplineArtifact(PROJECT_DIR, 'competition').ok).toBe(true)
+  })
+
   it('accepts taste via seed_spec/taste_verdict.md', () => {
     writeFile('seed_spec/taste_verdict.md', LONG_BODY)
+    expect(verifyDisciplineArtifact(PROJECT_DIR, 'taste').ok).toBe(true)
+  })
+
+  it('accepts taste written under docs/', () => {
+    writeFile('docs/taste.md', LONG_BODY)
     expect(verifyDisciplineArtifact(PROJECT_DIR, 'taste').ok).toBe(true)
   })
 

--- a/dashboard/src/bridge/discipline-artifacts.ts
+++ b/dashboard/src/bridge/discipline-artifacts.ts
@@ -20,18 +20,30 @@ type ArtifactSpec =
 
 // Each discipline produces at least one of these artifacts. Any hit wins.
 // Paths are relative to the project directory.
+//
+// For text-artifact disciplines (brainstorming, competition, taste) we
+// accept both `seed_spec/*.md` and `docs/*.md` — the sub-prompts nudge
+// toward `seed_spec/` but some runs improvise and write under `docs/`
+// with real content. The verifier's job is to recognise real work, not
+// to police the path. Hard-specified-path disciplines (spec, infra,
+// design/, legal/, marketing/) keep their canonical-only mapping.
 const ARTIFACT_SPECS: Record<Discipline, ArtifactSpec[]> = {
   brainstorming: [
     { kind: 'file', path: 'seed_spec/brainstorming.md', minBytes: 500 },
     { kind: 'file', path: 'seed_spec/brainstorming-design-doc.md', minBytes: 500 },
+    { kind: 'file', path: 'docs/brainstorming.md', minBytes: 500 },
   ],
   competition: [
     { kind: 'file', path: 'seed_spec/competition_brief.md', minBytes: 500 },
     { kind: 'file', path: 'seed_spec/competition.md', minBytes: 500 },
+    { kind: 'file', path: 'docs/competition.md', minBytes: 500 },
+    { kind: 'file', path: 'docs/competition_brief.md', minBytes: 500 },
   ],
   taste: [
     { kind: 'file', path: 'seed_spec/taste_verdict.md', minBytes: 300 },
     { kind: 'file', path: 'seed_spec/taste.md', minBytes: 300 },
+    { kind: 'file', path: 'docs/taste.md', minBytes: 300 },
+    { kind: 'file', path: 'docs/taste_verdict.md', minBytes: 300 },
   ],
   spec: [{ kind: 'file', path: 'seed_spec/milestones.json', minBytes: 500 }],
   infrastructure: [{ kind: 'file', path: 'infrastructure_manifest.json', minBytes: 200 }],

--- a/src/prompts/seeding/01-brainstorming.md
+++ b/src/prompts/seeding/01-brainstorming.md
@@ -113,6 +113,8 @@ This reframes scope decisions around actual AI capability, not human intuition a
 
 ## Output: The Design Document
 
+**Write the document to `seed_spec/brainstorming.md`** in the project root. Create the `seed_spec/` directory if it doesn't exist. Do not write to `docs/` or any other path — the dashboard verifies the artifact at this location before accepting the `[DISCIPLINE_COMPLETE: brainstorming]` marker.
+
 Your final output is a structured design document. This is NOT a feature list. It is a product vision document that tells the story of what this product IS, who it serves, and why it matters.
 
 ### Document Structure

--- a/src/prompts/seeding/02-competition.md
+++ b/src/prompts/seeding/02-competition.md
@@ -16,7 +16,9 @@ You are executing the COMPETITION discipline of The Rouge's seeding swarm. You m
 
 ## Output
 
-A **competition brief** written to the project's seed artifacts. Contains:
+**Write the competition brief to `seed_spec/competition.md`** in the project root. Create the `seed_spec/` directory if it doesn't exist. Do not write to `docs/` or any other path — the dashboard verifies the artifact at this location before accepting the `[DISCIPLINE_COMPLETE: competition]` marker.
+
+The brief contains:
 1. Market landscape map (density classification + competitor table)
 2. Gap analysis (what nobody does well)
 3. Differentiation angle (where this idea wins)

--- a/src/prompts/seeding/03-taste.md
+++ b/src/prompts/seeding/03-taste.md
@@ -242,7 +242,9 @@ You are interactive during seeding. The human is present via Slack.
 
 ## Output Format
 
-Return your output to the orchestrator as:
+**Write the taste verdict to `seed_spec/taste.md`** in the project root. Create the `seed_spec/` directory if it doesn't exist. Do not write to `docs/` or any other path — the dashboard verifies the artifact at this location before accepting the `[DISCIPLINE_COMPLETE: taste]` marker.
+
+The markdown file wraps the structured JSON block below (use a fenced code block for the JSON so the orchestrator can still parse it):
 
 ```json
 {


### PR DESCRIPTION
## Observed
Testimonials seeding wrote real 41KB brainstorming and 20KB competition briefs to `docs/brainstorming.md` / `docs/competition.md` — but the verifier (#148) only checked `seed_spec/`, so the `[DISCIPLINE_COMPLETE]` markers were rejected despite the work being correct. The agent improvised `docs/` because the sub-prompts never specified a path.

## Fix
**1. Widen verifier.** For free-form text disciplines (brainstorming, competition, taste) accept either `seed_spec/*.md` or `docs/*.md`. The verifier's job is to recognise real work, not police the path. Hard-path disciplines (spec, infrastructure, design/, legal/, marketing/) keep their canonical-only mapping.

Immediate effect on the current testimonials session: the artifacts already on disk now match; when the user sends the next message, the stashed rejection note (#149) reaches Claude and it can re-emit the markers which will be accepted.

**2. Pin canonical path in the three sub-prompts** (`01-brainstorming.md`, `02-competition.md`, `03-taste.md`) — explicit "write to `seed_spec/<name>.md`, do not write to `docs/`" guidance. Prevents future improvisation.

## Test plan
- [x] 3 new unit tests (docs/ path acceptance for brainstorming, competition, taste)
- [x] Full dashboard suite: 250 tests pass