### PR TITLE
fix: pin canonical output paths for all 8 seeding disciplines

### DIFF
--- a/dashboard/src/bridge/__tests__/discipline-artifacts.test.ts
+++ b/dashboard/src/bridge/__tests__/discipline-artifacts.test.ts
@@ -83,6 +83,16 @@ describe('verifyDisciplineArtifact', () => {
     expect(verifyDisciplineArtifact(PROJECT_DIR, 'spec').ok).toBe(true)
   })
 
+  it('accepts spec via seed_spec/spec.md when agent inlines', () => {
+    writeFile('seed_spec/spec.md', LONG_BODY)
+    expect(verifyDisciplineArtifact(PROJECT_DIR, 'spec').ok).toBe(true)
+  })
+
+  it('accepts spec via docs/spec.md when agent improvises', () => {
+    writeFile('docs/spec.md', LONG_BODY)
+    expect(verifyDisciplineArtifact(PROJECT_DIR, 'spec').ok).toBe(true)
+  })
+
   it('accepts infrastructure via infrastructure_manifest.json', () => {
     writeFile('infrastructure_manifest.json', LONG_BODY)
     expect(verifyDisciplineArtifact(PROJECT_DIR, 'infrastructure').ok).toBe(true)
@@ -90,6 +100,16 @@ describe('verifyDisciplineArtifact', () => {
 
   it('accepts design when design/ has at least one file', () => {
     writeDir('design', { 'layout.yaml': 'hi' })
+    expect(verifyDisciplineArtifact(PROJECT_DIR, 'design').ok).toBe(true)
+  })
+
+  it('accepts design via seed_spec/design_artifact.md fallback (old convention)', () => {
+    writeFile('seed_spec/design_artifact.md', LONG_BODY)
+    expect(verifyDisciplineArtifact(PROJECT_DIR, 'design').ok).toBe(true)
+  })
+
+  it('accepts design via docs/design.md when agent improvises', () => {
+    writeFile('docs/design.md', LONG_BODY)
     expect(verifyDisciplineArtifact(PROJECT_DIR, 'design').ok).toBe(true)
   })
 
@@ -108,8 +128,25 @@ describe('verifyDisciplineArtifact', () => {
     expect(verifyDisciplineArtifact(PROJECT_DIR, 'legal-privacy').ok).toBe(true)
   })
 
+  it('accepts legal-privacy via docs/legal.md fallback', () => {
+    writeFile('docs/legal.md', LONG_BODY)
+    expect(verifyDisciplineArtifact(PROJECT_DIR, 'legal-privacy').ok).toBe(true)
+  })
+
   it('accepts marketing when marketing/ has a file', () => {
     writeDir('marketing', { 'landing.md': 'hi' })
     expect(verifyDisciplineArtifact(PROJECT_DIR, 'marketing').ok).toBe(true)
+  })
+
+  it('accepts marketing via seed_spec/marketing.md fallback', () => {
+    writeFile('seed_spec/marketing.md', LONG_BODY)
+    expect(verifyDisciplineArtifact(PROJECT_DIR, 'marketing').ok).toBe(true)
+  })
+
+  it('keeps infrastructure strict — only infrastructure_manifest.json wins', () => {
+    writeFile('docs/infrastructure.md', LONG_BODY)
+    expect(verifyDisciplineArtifact(PROJECT_DIR, 'infrastructure').ok).toBe(false)
+    writeFile('infrastructure_manifest.json', LONG_BODY)
+    expect(verifyDisciplineArtifact(PROJECT_DIR, 'infrastructure').ok).toBe(true)
   })
 })

--- a/dashboard/src/bridge/discipline-artifacts.ts
+++ b/dashboard/src/bridge/discipline-artifacts.ts
@@ -19,14 +19,15 @@ type ArtifactSpec =
   | { kind: 'dir'; path: string; minFiles: number }
 
 // Each discipline produces at least one of these artifacts. Any hit wins.
-// Paths are relative to the project directory.
+// Paths are relative to the project directory — `join(projectDir, path)`
+// handles separators on Windows and Unix.
 //
-// For text-artifact disciplines (brainstorming, competition, taste) we
-// accept both `seed_spec/*.md` and `docs/*.md` — the sub-prompts nudge
-// toward `seed_spec/` but some runs improvise and write under `docs/`
-// with real content. The verifier's job is to recognise real work, not
-// to police the path. Hard-specified-path disciplines (spec, infra,
-// design/, legal/, marketing/) keep their canonical-only mapping.
+// Every discipline has a canonical output path pinned in its sub-prompt.
+// The verifier also accepts common alternatives agents have been seen to
+// improvise into (`docs/`, inline markdown for directory-artifacts) so
+// real work is recognised rather than rejected on a path technicality.
+// Infrastructure stays strict because `infrastructure_manifest.json` is
+// consumed by the launcher at build time — the path is load-bearing.
 const ARTIFACT_SPECS: Record<Discipline, ArtifactSpec[]> = {
   brainstorming: [
     { kind: 'file', path: 'seed_spec/brainstorming.md', minBytes: 500 },
@@ -34,22 +35,42 @@ const ARTIFACT_SPECS: Record<Discipline, ArtifactSpec[]> = {
     { kind: 'file', path: 'docs/brainstorming.md', minBytes: 500 },
   ],
   competition: [
-    { kind: 'file', path: 'seed_spec/competition_brief.md', minBytes: 500 },
     { kind: 'file', path: 'seed_spec/competition.md', minBytes: 500 },
+    { kind: 'file', path: 'seed_spec/competition_brief.md', minBytes: 500 },
     { kind: 'file', path: 'docs/competition.md', minBytes: 500 },
     { kind: 'file', path: 'docs/competition_brief.md', minBytes: 500 },
   ],
   taste: [
-    { kind: 'file', path: 'seed_spec/taste_verdict.md', minBytes: 300 },
     { kind: 'file', path: 'seed_spec/taste.md', minBytes: 300 },
+    { kind: 'file', path: 'seed_spec/taste_verdict.md', minBytes: 300 },
     { kind: 'file', path: 'docs/taste.md', minBytes: 300 },
     { kind: 'file', path: 'docs/taste_verdict.md', minBytes: 300 },
   ],
-  spec: [{ kind: 'file', path: 'seed_spec/milestones.json', minBytes: 500 }],
-  infrastructure: [{ kind: 'file', path: 'infrastructure_manifest.json', minBytes: 200 }],
-  design: [{ kind: 'dir', path: 'design', minFiles: 1 }],
-  'legal-privacy': [{ kind: 'dir', path: 'legal', minFiles: 1 }],
-  marketing: [{ kind: 'dir', path: 'marketing', minFiles: 1 }],
+  spec: [
+    { kind: 'file', path: 'seed_spec/milestones.json', minBytes: 500 },
+    { kind: 'file', path: 'seed_spec/spec.md', minBytes: 500 },
+    { kind: 'file', path: 'docs/spec.md', minBytes: 500 },
+  ],
+  infrastructure: [
+    { kind: 'file', path: 'infrastructure_manifest.json', minBytes: 200 },
+  ],
+  design: [
+    { kind: 'dir', path: 'design', minFiles: 1 },
+    { kind: 'file', path: 'seed_spec/design.md', minBytes: 500 },
+    { kind: 'file', path: 'seed_spec/design_artifact.md', minBytes: 500 },
+    { kind: 'file', path: 'seed_spec/design_artifact.yaml', minBytes: 500 },
+    { kind: 'file', path: 'docs/design.md', minBytes: 500 },
+  ],
+  'legal-privacy': [
+    { kind: 'dir', path: 'legal', minFiles: 1 },
+    { kind: 'file', path: 'seed_spec/legal.md', minBytes: 300 },
+    { kind: 'file', path: 'docs/legal.md', minBytes: 300 },
+  ],
+  marketing: [
+    { kind: 'dir', path: 'marketing', minFiles: 1 },
+    { kind: 'file', path: 'seed_spec/marketing.md', minBytes: 300 },
+    { kind: 'file', path: 'docs/marketing.md', minBytes: 300 },
+  ],
 }
 
 export interface ArtifactCheck {

--- a/src/prompts/seeding/04-spec.md
+++ b/src/prompts/seeding/04-spec.md
@@ -58,6 +58,12 @@ openspec update --change "<product-slug>" \
 - **Loop-back from DESIGN or TASTE:** `openspec update` to revise with new context
 - **New feature area discovered during spec:** `openspec spec` for the new area, then check if existing areas need updates due to the new dependency
 
+## Seed-Level Summary Artifact
+
+In addition to the per-area spec files managed by the OpenSpec CLI, **write a seed-level summary to `seed_spec/milestones.json`** in the project root. Create the `seed_spec/` directory if it doesn't exist. Do not write it to `docs/` or any other path — the dashboard verifies the artifact at this location before accepting the `[DISCIPLINE_COMPLETE: spec]` marker, and the launcher's V3 schema migration reads it from here.
+
+The file contains the milestone and story structure derived from the per-area specs: `{ "milestones": [{ "name": ..., "stories": [{ "id": ..., "name": ..., "status": "pending", "acceptance_criteria": [...], "depends_on": [...] }] }] }`.
+
 ## What You Produce Per Feature Area
 
 Every feature area in the seed spec MUST contain all seven sections below. No section may be omitted. No section may contain placeholder text like "TBD" or "handle appropriately."

--- a/src/prompts/seeding/05-design.md
+++ b/src/prompts/seeding/05-design.md
@@ -709,6 +709,8 @@ design_po_checks:
 
 ## Combined Output Artifact
 
+**Write the combined artifact to `design/design.yaml`** in the project root. Create the `design/` directory if it doesn't exist. If additional per-screen or per-pass breakout files help, put them alongside in `design/`. Do not write to `seed_spec/` or `docs/` for the combined artifact — the dashboard verifies at least one file exists in `design/` before accepting the `[DISCIPLINE_COMPLETE: design]` marker.
+
 When all three passes are approved, produce the combined design artifact for the orchestrator:
 
 ```yaml


### PR DESCRIPTION
Completes the audit started in #150.

## The systemic fix
Every discipline now has both:
- **Explicit canonical output path** pinned in its sub-prompt (so the agent stops guessing)
- **Verifier entries** that accept the canonical path plus the 1-3 alternatives agents have actually been seen to improvise into

| Discipline | Canonical (pinned in prompt) | Verifier fallbacks |
|---|---|---|
| brainstorming | `seed_spec/brainstorming.md` | `docs/brainstorming.md`, `seed_spec/brainstorming-design-doc.md` |
| competition | `seed_spec/competition.md` | `seed_spec/competition_brief.md`, `docs/competition.md`, `docs/competition_brief.md` |
| taste | `seed_spec/taste.md` | `seed_spec/taste_verdict.md`, `docs/taste.md`, `docs/taste_verdict.md` |
| **spec** *(newly pinned)* | `seed_spec/milestones.json` | `seed_spec/spec.md`, `docs/spec.md` |
| infrastructure | `infrastructure_manifest.json` | *(strict — path is load-bearing for the launcher)* |
| **design** *(newly pinned)* | `design/design.yaml` | `seed_spec/design.md`, `seed_spec/design_artifact.md`, `seed_spec/design_artifact.yaml`, `docs/design.md` |
| legal-privacy | `legal/` dir | `seed_spec/legal.md`, `docs/legal.md` |
| marketing | `marketing/` + `README.md` | `seed_spec/marketing.md`, `docs/marketing.md` |

## Why strict on infrastructure
`infrastructure_manifest.json` is read by the launcher at build time (see #96) and by `dashboard/src/bridge/platform-reader.ts`. The path is part of the contract, not a naming convention.

## Cross-platform
All paths go through `node:path.join` so Windows and Unix separators are handled uniformly. Hardcoded path strings use forward slashes, which Node normalises on Windows automatically.

## Build loop
Not affected. The build loop has no DISCIPLINE_COMPLETE markers or artifact-verification pattern — it's launcher-driven state-machine via `cycle_context.json`, and those paths are pinned in `loop/_preamble.md`. Different architecture, different contract, not vulnerable to this class of bug.

## Test plan
- [x] +8 unit tests covering the new fallbacks (spec × 2, design × 2, legal × 1, marketing × 1) and a strict-regression test for infrastructure
- [x] 257 dashboard tests pass (up from 250)