### PR TITLE
fix: write-before-present rule for mid-discipline sign-off gates

### DIFF
--- a/src/prompts/seeding/00-swarm-orchestrator.md
+++ b/src/prompts/seeding/00-swarm-orchestrator.md
@@ -50,6 +50,10 @@ Never emit `[DISCIPLINE_COMPLETE: <name>]` based on summaries, plans, intentions
 
 **No false completion claims.** Never self-score a discipline as complete if the work is only in your head. Never invoke "background agents" or "async workers" to explain why an artifact isn't on disk yet (see Sequential execution below — there is only one worker, and it is you, and the work is done when the file exists with content).
 
+**Write artifacts before presenting.** Before asking the human to confirm any scope, naming, decomposition, or taste decision *mid-discipline* — not just before emitting `[DISCIPLINE_COMPLETE]`, but also at every intermediate sign-off gate a sub-discipline defines — write the current state of your work to the discipline's canonical artifact on disk first. Phrases like "Draft written", "Analysis complete", "Here's the decomposition" must be literally true when you say them: the file must exist with the content you're describing.
+
+If a field in the draft depends on the human's answer (e.g., product name, scope cut, complexity profile), write the current draft with that field as `<TBD — pending human sign-off>` and update it after they answer. Never ask the human to respond to a draft that only exists in the conversation — they cannot verify what they cannot read, and the dashboard cannot verify what isn't on disk.
+
 ## Resumption
 
 Every message after the first in a seeding session is delivered to you via `claude -p --resume <sessionId>`. Your context is restored from the session, but the discipline state tracker you maintain in your head is NOT authoritative after a resume — especially after a rate limit interrupts mid-discipline.

--- a/src/prompts/seeding/04-spec.md
+++ b/src/prompts/seeding/04-spec.md
@@ -341,7 +341,11 @@ Group stories into milestones. A milestone is a batch that gets evaluated togeth
 
 ### Present decomposition to human
 
-After decomposition, present:
+**Before presenting, write the decomposition to `seed_spec/milestones.json`.** Do not summarise a decomposition that only exists in your reply — the human cannot sight-verify it and the dashboard cannot recognise progress until the file exists. If the human's answer might alter scope (carousel cut, importer narrowing, naming change), write the current best-guess decomposition first, then ask for the adjustments, then update the file.
+
+Common failure to avoid: saying "Draft written. Three decisions for you to sign off…" when `seed_spec/milestones.json` does not exist on disk. That is a false claim — don't make it.
+
+After the file is on disk, present:
 ```
 DECOMPOSITION for <product-name>:
 
@@ -362,7 +366,7 @@ Average stories per milestone: <X>
 Longest dependency chain: <N> stories
 ```
 
-The human may adjust milestone grouping or story boundaries. Update accordingly.
+The human may adjust milestone grouping or story boundaries. Update `seed_spec/milestones.json` accordingly.
 
 ## Cross-Feature Consistency Check
 

--- a/src/prompts/seeding/05-design.md
+++ b/src/prompts/seeding/05-design.md
@@ -711,6 +711,8 @@ design_po_checks:
 
 **Write the combined artifact to `design/design.yaml`** in the project root. Create the `design/` directory if it doesn't exist. If additional per-screen or per-pass breakout files help, put them alongside in `design/`. Do not write to `seed_spec/` or `docs/` for the combined artifact — the dashboard verifies at least one file exists in `design/` before accepting the `[DISCIPLINE_COMPLETE: design]` marker.
 
+**Write before presenting scores or asking for pass sign-off.** Each pass produces scored dimensions; each pass has a natural "here are the scores, approve?" checkpoint. Write the pass's portion of `design/design.yaml` (or a pass-specific breakout file in `design/`) *before* asking the human to approve scores. Never present scores or slop-flags that exist only in your reply — the human cannot cross-check a YAML they cannot read.
+
 When all three passes are approved, produce the combined design artifact for the orchestrator:
 
 ```yaml


### PR DESCRIPTION
## The class of bug

Artifact verification (#148) catches `[DISCIPLINE_COMPLETE]` fired without the artifact on disk. But SPEC and DESIGN have natural mid-process sign-off gates *before* that marker ("present the decomposition and ask for adjustments", "show scores for this pass and get approval"), and at those gates the agent can still say "Draft written. Three decisions for you to sign off…" with nothing on disk — we saw this in the testimonials SPEC run.

The verifier catches the terminal moment; it doesn't catch the human being asked to confirm a conversation-only draft.

## The rule

**Write artifacts before presenting.** At every sign-off gate (not just at `[DISCIPLINE_COMPLETE]`), the canonical artifact must exist on disk with the content the agent is describing. Fields that depend on the human's answer get written as `<TBD — pending human sign-off>` and updated after they answer.

Added in three places:

- `00-swarm-orchestrator.md` — universal rule alongside the existing pre-emission check.
- `04-spec.md` — require `seed_spec/milestones.json` on disk before presenting the decomposition; calls out the exact phantom-draft phrasing to avoid.
- `05-design.md` — require the current pass's YAML on disk before presenting scores.

Only SPEC and DESIGN get the pointed reinforcement — the other six disciplines don't exhibit the pattern (concrete named deliverables, no intermediate sign-off gates, or strict schemas).

## No code changes
The existing verifier (#148) and pending-correction delivery (#149) remain the backstop. This edit tightens upstream behaviour so the backstop fires less often.

## Test plan
- [x] Prompt contract validation: 64/64 pass
- [x] Dashboard suite: 257/257 pass
- [ ] Manual: continue the testimonials session; confirm agent writes `seed_spec/milestones.json` before re-presenting decomposition