### PR TITLE
feat(#153): auto-kickoff next discipline + collapse + elapsed-time liveness

### DIFF
--- a/dashboard/src/bridge/__tests__/seed-handler.test.ts
+++ b/dashboard/src/bridge/__tests__/seed-handler.test.ts
@@ -185,6 +185,120 @@ describe('handleSeedMessage — marker verification', () => {
   })
 })
 
+describe('handleSeedMessage — auto-kickoff on marker acceptance', () => {
+  it('fires a follow-up turn after accepting a marker', async () => {
+    writeFileSync(join(PROMPTS_DIR, '02-competition.md'), '# COMPETITION\n\nFind competitors.')
+    mkdirSync(join(PROJECT_DIR, 'seed_spec'), { recursive: true })
+    writeFileSync(
+      join(PROJECT_DIR, 'seed_spec', 'brainstorming.md'),
+      '# Design Doc\n\n' + 'body '.repeat(200),
+    )
+
+    // Turn 1: accepts brainstorming marker.
+    mockRunClaude.mockResolvedValueOnce({
+      result: 'Done.\n\n[DISCIPLINE_COMPLETE: brainstorming]',
+      session_id: 'session-1',
+    })
+    // Kickoff turn: enters competition.
+    mockRunClaude.mockResolvedValueOnce({
+      result: 'Entering competition. Who are the named competitors you already know?',
+      session_id: 'session-1',
+    })
+
+    await handleSeedMessage(PROJECT_DIR, 'ship it')
+
+    // Both turns ran.
+    expect(mockRunClaude).toHaveBeenCalledTimes(2)
+
+    // Second call's prompt contains the competition sub-prompt and the
+    // kickoff framing.
+    const kickoffPrompt: string = mockRunClaude.mock.calls[1][0].prompt
+    expect(kickoffPrompt).toContain('DISCIPLINE TRANSITION — entering COMPETITION')
+    expect(kickoffPrompt).toContain('Find competitors.')
+    expect(kickoffPrompt).toContain('[SYSTEM]')
+
+    // Chat log: ONE human message (the user's), TWO rouge messages
+    // (original response + kickoff response). The kickoff's system text
+    // must NOT appear as a human message.
+    const log = readChatLog(PROJECT_DIR)
+    const humanCount = log.filter((m) => m.role === 'human').length
+    const rougeCount = log.filter((m) => m.role === 'rouge').length
+    expect(humanCount).toBe(1)
+    expect(rougeCount).toBe(2)
+
+    // Kickoff marked the new discipline as prompted.
+    const state = readSeedingState(PROJECT_DIR)
+    expect(state.disciplines_prompted).toContain('competition')
+  })
+
+  it('does NOT auto-kickoff when the marker is rejected (no artifact)', async () => {
+    mockRunClaude.mockResolvedValueOnce({
+      result: 'Done.\n\n[DISCIPLINE_COMPLETE: brainstorming]',
+      session_id: 'session-1',
+    })
+
+    await handleSeedMessage(PROJECT_DIR, 'done')
+
+    // Only the one turn — rejection means no state advance, no kickoff.
+    expect(mockRunClaude).toHaveBeenCalledTimes(1)
+  })
+
+  it('does NOT auto-kickoff when seeding is complete', async () => {
+    writeFileSync(join(PROMPTS_DIR, '07-marketing.md'), '# MARKETING\n\nWrite the README.')
+    mkdirSync(join(PROJECT_DIR, 'marketing'), { recursive: true })
+    writeFileSync(join(PROJECT_DIR, 'marketing', 'landing-page-copy.md'), 'x'.repeat(500))
+
+    writeSeedingState(PROJECT_DIR, {
+      session_id: 'session-1',
+      status: 'active',
+      disciplines_complete: ['brainstorming', 'competition', 'taste', 'spec', 'infrastructure', 'design', 'legal-privacy'],
+      disciplines_prompted: ['brainstorming', 'competition', 'taste', 'spec', 'infrastructure', 'design', 'legal-privacy', 'marketing'],
+      current_discipline: 'marketing',
+    })
+
+    mockRunClaude.mockResolvedValueOnce({
+      result: 'All done.\n\n[DISCIPLINE_COMPLETE: marketing]\n\nSEEDING_COMPLETE',
+      session_id: 'session-1',
+    })
+
+    await handleSeedMessage(PROJECT_DIR, 'wrap')
+
+    // Only the one turn — seeding done, nothing to kick off.
+    expect(mockRunClaude).toHaveBeenCalledTimes(1)
+  })
+
+  it('kickoff turn does not recurse — at most one follow-up per user turn', async () => {
+    writeFileSync(join(PROMPTS_DIR, '02-competition.md'), '# COMPETITION\n\nFind competitors.')
+    writeFileSync(join(PROMPTS_DIR, '03-taste.md'), '# TASTE\n\nChallenge the premise.')
+    mkdirSync(join(PROJECT_DIR, 'seed_spec'), { recursive: true })
+    writeFileSync(
+      join(PROJECT_DIR, 'seed_spec', 'brainstorming.md'),
+      'x'.repeat(1000),
+    )
+    writeFileSync(
+      join(PROJECT_DIR, 'seed_spec', 'competition.md'),
+      'x'.repeat(1000),
+    )
+
+    // Turn 1: accepts brainstorming.
+    mockRunClaude.mockResolvedValueOnce({
+      result: '[DISCIPLINE_COMPLETE: brainstorming]',
+      session_id: 's1',
+    })
+    // Kickoff turn: the agent pathologically also emits competition complete.
+    // We should NOT fire a second kickoff.
+    mockRunClaude.mockResolvedValueOnce({
+      result: 'Entering competition.\n\n[DISCIPLINE_COMPLETE: competition]',
+      session_id: 's1',
+    })
+
+    await handleSeedMessage(PROJECT_DIR, 'begin')
+
+    // Two calls total: user turn + ONE kickoff. No third call.
+    expect(mockRunClaude).toHaveBeenCalledTimes(2)
+  })
+})
+
 describe('handleSeedMessage — discipline transition injection', () => {
   it('injects the next discipline\'s sub-prompt after brainstorming completes', async () => {
     writeFileSync(join(PROMPTS_DIR, '02-competition.md'), '# COMPETITION\n\nFind competitors.')

--- a/dashboard/src/bridge/seed-handler.ts
+++ b/dashboard/src/bridge/seed-handler.ts
@@ -90,10 +90,29 @@ export interface SendMessageResult {
   missingArtifacts?: string[]
 }
 
+interface TurnOptions {
+  /** Turn was triggered by the dashboard after a discipline completed, not
+   * by user input. The `text` passed in is a system instruction, so we
+   * skip logging a human message to the chat. */
+  isKickoff?: boolean
+  /** Don't chain another auto-kickoff at the end of this turn. Guards
+   * against recursion — at most one kickoff per user-initiated turn. */
+  suppressKickoff?: boolean
+}
+
 export async function handleSeedMessage(
   projectDir: string,
   userText: string,
 ): Promise<SendMessageResult> {
+  return runSeedingTurn(projectDir, userText, {})
+}
+
+async function runSeedingTurn(
+  projectDir: string,
+  text: string,
+  options: TurnOptions,
+): Promise<SendMessageResult> {
+  const { isKickoff = false, suppressKickoff = false } = options
   const state = readSeedingState(projectDir)
   // Note: we intentionally allow messages even when status === 'complete'.
   // The Revise mode in the dashboard uses this path to let users continue
@@ -152,7 +171,7 @@ export async function handleSeedMessage(
       'The user has described what they want to build. Their first message is below — respond in character as the active discipline.',
     )
   }
-  sections.push(userText)
+  sections.push(text)
   const prompt = sections.join('\n\n')
 
   const result = await runClaude({
@@ -173,7 +192,7 @@ export async function handleSeedMessage(
   // limited turn retries with the same injection next time.
   if (detectRateLimit(result.result)) {
     setStatus(projectDir, 'paused')
-    appendMessages(projectDir, userText, result.result, activeDiscipline ?? undefined)
+    appendMessages(projectDir, isKickoff ? null : text, result.result, activeDiscipline ?? undefined)
     return { ok: false, status: 429, error: 'Claude rate-limited', rateLimited: true }
   }
 
@@ -218,11 +237,13 @@ export async function handleSeedMessage(
   }
 
   // Append conversation (user message + rouge response) tagged with the
-  // discipline that was active BEFORE markers fired. If the agent emitted
-  // markers for disciplines whose artifacts aren't on disk, append a
-  // follow-up note so both the human (in the UI) and the agent (via
-  // session history on the next turn) see that the marker was rejected.
-  appendMessages(projectDir, userText, result.result, activeDiscipline ?? undefined)
+  // discipline that was active BEFORE markers fired. Kickoff turns skip
+  // the human entry — the `text` we sent in was a system instruction,
+  // not something the user typed. If the agent emitted markers for
+  // disciplines whose artifacts aren't on disk, append a follow-up note
+  // so both the human (in the UI) and the agent (via session history on
+  // the next turn) see that the marker was rejected.
+  appendMessages(projectDir, isKickoff ? null : text, result.result, activeDiscipline ?? undefined)
   if (rejectedDisciplines.length > 0) {
     const note = rejectedDisciplines
       .map(
@@ -245,8 +266,12 @@ export async function handleSeedMessage(
 
   // If this was the first user message and the project is still
   // placeholder-named, derive a working title in the background.
-  // Fire-and-forget: the chat response does not wait on it.
-  void maybeDeriveWorkingTitle(projectDir, userText)
+  // Fire-and-forget: the chat response does not wait on it. Skipped on
+  // kickoff turns — the `text` is a system instruction, not a real user
+  // message.
+  if (!isKickoff) {
+    void maybeDeriveWorkingTitle(projectDir, text)
+  }
 
   // Check for SEEDING_COMPLETE
   let readyTransition = false
@@ -258,6 +283,46 @@ export async function handleSeedMessage(
       readyTransition = true
     } else {
       missingArtifacts = finalizeResult.missingArtifacts
+    }
+  }
+
+  // Auto-kickoff the next discipline. When a marker is accepted and
+  // seeding isn't finished, the conversation otherwise dangles until the
+  // user types something — because agent turns are triggered by user
+  // input and the agent has no way to send an unprompted message. Fire
+  // a follow-up turn here with a system-style kickoff prompt so the new
+  // discipline's sub-prompt injects (#147) and the agent asks its first
+  // question automatically. The HTTP response waits for the kickoff to
+  // complete so both agent messages arrive together in the client —
+  // elapsed-time display covers the full combined wait.
+  //
+  // Guarded against recursion via `suppressKickoff` — at most one
+  // kickoff per user-initiated turn.
+  if (
+    !suppressKickoff &&
+    acceptedDisciplines.length > 0 &&
+    !markers.seedingComplete
+  ) {
+    const postState = readSeedingState(projectDir)
+    const nextDiscipline = resolveActiveDiscipline(postState.current_discipline)
+    const alreadyKicked = postState.disciplines_prompted ?? []
+    if (nextDiscipline && !alreadyKicked.includes(nextDiscipline)) {
+      const previous = acceptedDisciplines.join(', ')
+      const kickoffText = [
+        `[SYSTEM] Discipline(s) ${previous} accepted — artifact verified on disk. State has advanced.`,
+        `You are now entering ${nextDiscipline.toUpperCase()}. The sub-prompt for that discipline is attached to this turn; follow its rules exactly.`,
+        `Begin the new discipline by asking its first question to the human, in the format the sub-prompt specifies. Do NOT summarise the previous discipline's conclusions — the human already has them.`,
+      ].join(' ')
+      try {
+        await runSeedingTurn(projectDir, kickoffText, {
+          isKickoff: true,
+          suppressKickoff: true,
+        })
+      } catch (err) {
+        // Kickoff is best-effort. If it fails, the user can just send
+        // a message to nudge the next discipline into starting.
+        console.error('[seeding] auto-kickoff failed:', err)
+      }
     }
   }
 

--- a/dashboard/src/components/__tests__/chat-panel.test.tsx
+++ b/dashboard/src/components/__tests__/chat-panel.test.tsx
@@ -88,4 +88,49 @@ describe('ChatPanel', () => {
     render(<ChatPanel messages={messages} />)
     expect(screen.queryByTestId('resume-button')).not.toBeInTheDocument()
   })
+
+  describe('progression signals', () => {
+    const groupedMessages: ChatMessage[] = [
+      {
+        id: 'b-1',
+        role: 'rouge',
+        type: 'question',
+        discipline: 'brainstorming',
+        content: 'Brainstorming question.',
+        timestamp: '2026-04-01T09:00:00Z',
+      },
+      {
+        id: 'c-1',
+        role: 'rouge',
+        type: 'question',
+        discipline: 'competition',
+        content: 'Competition question.',
+        timestamp: '2026-04-01T09:05:00Z',
+      },
+    ]
+
+    it('renders a transition banner after a completed discipline', () => {
+      render(
+        <ChatPanel
+          messages={groupedMessages}
+          completedDisciplines={['brainstorming']}
+          currentDiscipline="competition"
+        />,
+      )
+      const banner = screen.getByTestId('discipline-transition-banner')
+      expect(banner).toHaveTextContent(/Brainstorming complete/i)
+      expect(banner).toHaveTextContent(/now in Competition/i)
+    })
+
+    it('does not render a transition banner when no discipline is complete', () => {
+      render(
+        <ChatPanel
+          messages={groupedMessages}
+          completedDisciplines={[]}
+          currentDiscipline="brainstorming"
+        />,
+      )
+      expect(screen.queryByTestId('discipline-transition-banner')).not.toBeInTheDocument()
+    })
+  })
 })

--- a/dashboard/src/components/chat-panel.tsx
+++ b/dashboard/src/components/chat-panel.tsx
@@ -6,10 +6,25 @@ import { ChatMessage } from '@/components/chat-message'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Textarea } from '@/components/ui/textarea'
 import { Button } from '@/components/ui/button'
-import { Play, Send, ChevronDown, ChevronRight, Check, Circle } from 'lucide-react'
+import { ArrowRight, Play, Send, ChevronDown, ChevronRight, Check, Circle, Loader2 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { isBridgeEnabled } from '@/lib/bridge-client'
 import { useSeeding } from '@/lib/use-seeding'
+
+// Rough per-discipline expected durations for an agent turn, derived
+// from observed runs. Used to give the elapsed-time display a baseline
+// so "2 minutes" means "on track for spec" rather than "alarming".
+// Tune as we collect more data.
+const TYPICAL_DURATION_SEC: Record<string, { low: number; high: number }> = {
+  brainstorming: { low: 60, high: 180 },
+  competition: { low: 90, high: 240 },
+  taste: { low: 60, high: 150 },
+  spec: { low: 180, high: 480 },
+  infrastructure: { low: 60, high: 180 },
+  design: { low: 240, high: 600 },
+  'legal-privacy': { low: 60, high: 180 },
+  marketing: { low: 120, high: 300 },
+}
 
 interface ChatPanelProps {
   messages: ChatMessageType[]
@@ -123,6 +138,29 @@ export function ChatPanel({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentDiscipline, groups.length])
 
+  // Auto-collapse disciplines when they flip to 'complete'. Keeps the
+  // chat focused on the current discipline instead of accumulating an
+  // ever-growing column of completed work. User's explicitly selected
+  // discipline stays expanded so they can still read through it.
+  const prevCompletedRef = useRef<Set<string>>(new Set(completedDisciplines ?? []))
+  useEffect(() => {
+    const now = new Set(completedDisciplines ?? [])
+    const newlyComplete: string[] = []
+    for (const d of now) {
+      if (!prevCompletedRef.current.has(d)) newlyComplete.push(d)
+    }
+    if (newlyComplete.length > 0) {
+      setExpanded((current) => {
+        const next = new Set(current)
+        for (const d of newlyComplete) {
+          if (d !== selectedDiscipline) next.delete(d)
+        }
+        return next
+      })
+    }
+    prevCompletedRef.current = now
+  }, [completedDisciplines, selectedDiscipline])
+
   // When user clicks a discipline in the stepper (selectedDiscipline changes),
   // expand that group and scroll to it.
   useEffect(() => {
@@ -184,14 +222,34 @@ export function ChatPanel({
             // Untagged messages — render flat
             displayMessages.map((msg) => <ChatMessage key={msg.id} message={msg} />)
           ) : (
-            groups.map((group) => (
-              <DisciplineSection
-                key={group.discipline}
-                group={group}
-                expanded={expanded.has(group.discipline)}
-                onToggle={() => toggleExpanded(group.discipline)}
-              />
-            ))
+            groups.map((group, idx) => {
+              // After a completed discipline, insert a transition banner
+              // pointing at the next one in the stream. Gives the
+              // "something changed" signal the stepper alone lacks.
+              const next = groups[idx + 1]
+              const showBanner = group.status === 'complete' && next
+              return (
+                <div key={group.discipline} className="flex flex-col gap-2">
+                  <DisciplineSection
+                    group={group}
+                    expanded={expanded.has(group.discipline)}
+                    onToggle={() => toggleExpanded(group.discipline)}
+                  />
+                  {showBanner && (
+                    <TransitionBanner
+                      from={DISCIPLINE_LABELS[group.discipline] ?? group.discipline}
+                      to={DISCIPLINE_LABELS[next.discipline] ?? next.discipline}
+                    />
+                  )}
+                </div>
+              )
+            })
+          )}
+          {bridgeActive && seeding.isSending && seeding.sendingStartedAt !== null && (
+            <ElapsedTimeIndicator
+              startedAt={seeding.sendingStartedAt}
+              discipline={currentDiscipline}
+            />
           )}
         </div>
       </ScrollArea>
@@ -248,6 +306,69 @@ export function ChatPanel({
       )}
     </div>
   )
+}
+
+function TransitionBanner({ from, to }: { from: string; to: string }) {
+  return (
+    <div
+      data-testid="discipline-transition-banner"
+      className="flex items-center gap-2 rounded-md border border-dashed border-green-300 bg-green-50/60 px-3 py-1.5 text-xs text-green-900"
+    >
+      <Check className="size-3.5 text-green-600" />
+      <span className="font-medium">{from} complete</span>
+      <ArrowRight className="size-3 text-green-600" />
+      <span className="text-green-800">now in {to}</span>
+    </div>
+  )
+}
+
+function ElapsedTimeIndicator({
+  startedAt,
+  discipline,
+}: {
+  startedAt: number
+  discipline?: string
+}) {
+  const [now, setNow] = useState<number>(Date.now())
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 1000)
+    return () => clearInterval(id)
+  }, [])
+
+  const elapsedSec = Math.max(0, Math.floor((now - startedAt) / 1000))
+  const typical = discipline ? TYPICAL_DURATION_SEC[discipline] : undefined
+  const overTypical = typical ? elapsedSec > typical.high : false
+
+  return (
+    <div
+      data-testid="elapsed-time-indicator"
+      className={cn(
+        'mt-2 flex items-center gap-2 rounded-md border px-3 py-2 text-xs',
+        overTypical
+          ? 'border-amber-300 bg-amber-50 text-amber-900'
+          : 'border-blue-200 bg-blue-50 text-blue-900',
+      )}
+    >
+      <Loader2 className="size-3.5 animate-spin" />
+      <span className="font-medium tabular-nums">Rouge is thinking · {formatDuration(elapsedSec)}</span>
+      {typical && (
+        <span className="text-muted-foreground">
+          · typical for {discipline}: {formatDuration(typical.low)}–{formatDuration(typical.high)}
+        </span>
+      )}
+      {overTypical && (
+        <span className="ml-auto font-medium">longer than usual — still working</span>
+      )}
+    </div>
+  )
+}
+
+function formatDuration(totalSec: number): string {
+  if (totalSec < 60) return `${totalSec}s`
+  const min = Math.floor(totalSec / 60)
+  const sec = totalSec % 60
+  if (sec === 0) return `${min}m`
+  return `${min}m ${sec}s`
 }
 
 function DisciplineSection({

--- a/dashboard/src/components/discipline-stepper.tsx
+++ b/dashboard/src/components/discipline-stepper.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useEffect, useRef, useState } from 'react'
 import type { DisciplineProgress, SeedingDiscipline } from '@/lib/types'
 import { cn } from '@/lib/utils'
 import { Check, Circle, Loader2 } from 'lucide-react'
@@ -26,13 +27,24 @@ const DISCIPLINE_LABELS: Record<SeedingDiscipline, string> = {
   marketing: 'Marketing',
 }
 
-function StatusIcon({ status }: { status: DisciplineProgress['status'] }) {
+function StatusIcon({
+  status,
+  justCompleted,
+}: {
+  status: DisciplineProgress['status']
+  justCompleted?: boolean
+}) {
   if (status === 'complete') {
     return (
       <div
         data-testid="discipline-icon"
         data-status="complete"
-        className="flex size-6 items-center justify-center rounded-full bg-green-100 text-green-600"
+        className={cn(
+          'flex size-6 items-center justify-center rounded-full bg-green-100 text-green-600',
+          // Pulse once when a discipline flips to complete. The `key`
+          // trick on the parent retriggers the animation reliably.
+          justCompleted && 'animate-in zoom-in-50 duration-500',
+        )}
       >
         <Check className="size-3.5" />
       </div>
@@ -79,6 +91,27 @@ export function DisciplineStepper({
     disciplines.map((d) => [d.discipline, d.status])
   )
 
+  // Track which disciplines flipped to complete this render cycle so we
+  // can retrigger the pulse animation on just those. Keyed on the
+  // StatusIcon so the animation plays cleanly.
+  const prevStatusRef = useRef<Map<SeedingDiscipline, DisciplineProgress['status']>>(new Map())
+  const [justCompleted, setJustCompleted] = useState<Set<SeedingDiscipline>>(new Set())
+  useEffect(() => {
+    const newly = new Set<SeedingDiscipline>()
+    for (const d of DISCIPLINE_ORDER) {
+      const prev = prevStatusRef.current.get(d)
+      const cur = statusMap.get(d)
+      if (cur === 'complete' && prev !== 'complete') newly.add(d)
+      if (cur) prevStatusRef.current.set(d, cur)
+    }
+    if (newly.size > 0) {
+      setJustCompleted(newly)
+      const id = setTimeout(() => setJustCompleted(new Set()), 1200)
+      return () => clearTimeout(id)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [disciplines])
+
   return (
     <nav
       className="flex flex-col gap-0.5"
@@ -107,7 +140,11 @@ export function DisciplineStepper({
           >
             {/* Vertical connector line */}
             <div className="flex flex-col items-center">
-              <StatusIcon status={status} />
+              <StatusIcon
+                key={justCompleted.has(discipline) ? `${discipline}-pulse` : discipline}
+                status={status}
+                justCompleted={justCompleted.has(discipline)}
+              />
               {!isLast && (
                 <div
                   className={cn(

--- a/dashboard/src/lib/use-seeding.ts
+++ b/dashboard/src/lib/use-seeding.ts
@@ -7,6 +7,10 @@ import { useBridgeEvents } from './use-bridge-events'
 interface UseSeedingResult {
   messages: SeedingChatMessage[]
   isSending: boolean
+  /** Wall-clock timestamp (ms) when the current send started, or null
+   * when no send is in flight. Lets the UI render an elapsed-time signal
+   * during the long agent turns. */
+  sendingStartedAt: number | null
   isPaused: boolean
   error: string | null
   sendMessage: (text: string) => Promise<void>
@@ -16,6 +20,7 @@ interface UseSeedingResult {
 export function useSeeding(slug: string): UseSeedingResult {
   const [messages, setMessages] = useState<SeedingChatMessage[]>([])
   const [isSending, setIsSending] = useState(false)
+  const [sendingStartedAt, setSendingStartedAt] = useState<number | null>(null)
   const [isPaused, setIsPaused] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -40,6 +45,7 @@ export function useSeeding(slug: string): UseSeedingResult {
   const sendMessage = useCallback(async (text: string) => {
     if (!slug || !text.trim() || isSending) return
     setIsSending(true)
+    setSendingStartedAt(Date.now())
     setError(null)
     try {
       const result = await sendSeedMessage(slug, text.trim())
@@ -59,8 +65,9 @@ export function useSeeding(slug: string): UseSeedingResult {
       setError(err instanceof Error ? err.message : String(err))
     } finally {
       setIsSending(false)
+      setSendingStartedAt(null)
     }
   }, [slug, isSending, refetch])
 
-  return { messages, isSending, isPaused, error, sendMessage, refetch }
+  return { messages, isSending, sendingStartedAt, isPaused, error, sendMessage, refetch }
 }


### PR DESCRIPTION
Closes #153.

## Problem
- After `[DISCIPLINE_COMPLETE: X]` is accepted, the conversation dangled until the user typed something — the agent has no way to send an unprompted next message.
- Completed discipline sections stayed expanded in the chat, muting the "we moved on" signal.
- During long agent turns (1–8 min) the UI only showed "Rouge is thinking…" with no elapsed time or baseline, making real thinking indistinguishable from hanging.

## Changes

### Flow — auto-kickoff
`handleSeedMessage` refactored into `runSeedingTurn(projectDir, text, options)` with `isKickoff` / `suppressKickoff` flags. After a marker is accepted and the next discipline exists, fires a synchronous follow-up turn with a system-style kickoff prompt. Sub-prompt injection (#147) delivers the new discipline's rules; the agent asks its first question automatically. Kickoff skips the human-message log append and title derivation. Guarded against recursion.

### Chat panel — progression visibility
- **Auto-collapse**: completed disciplines collapse on status flip unless user selected them. Preserves click-to-expand.
- **Transition banner**: inline `X complete → now in Y` in the chat stream between completed and next discipline groups.
- **Elapsed-time indicator**: per-second counter during `isSending`, paired with a hardcoded typical duration per discipline. Flips amber past the high end of typical with "longer than usual — still working".

### Stepper — completion pulse
Brief zoom-in animation on the green check when a discipline flips to complete. Key-reset retriggers cleanly, auto-clears after 1.2s.

## Out of scope
- No streaming output format from claude CLI — user rejected that route. Liveness signal is surrogate: elapsed time + pending-fetch as the proof-of-life.
- No cancel/abort affordance. Can add as a follow-up if the elapsed-time signal alone isn't enough.

## Test plan
- [x] 4 new seed-handler integration tests (kickoff fires on accept; doesn't on reject; doesn't when seeding-complete; doesn't recurse)
- [x] 2 new chat-panel component tests (banner renders/doesn't as appropriate)
- [x] 263 dashboard tests pass (up from 257)
- [ ] Manual: continue the testimonials session — after answering Claude's question, watch the discipline auto-progress, old section collapse, elapsed counter appear during the 2-5min turns