### PR TITLE
fix: reconcile stranded discipline state + enforce sequential completion

### DIFF
--- a/dashboard/src/bridge/__tests__/seed-handler.test.ts
+++ b/dashboard/src/bridge/__tests__/seed-handler.test.ts
@@ -188,16 +188,18 @@ describe('handleSeedMessage — marker verification', () => {
 describe('handleSeedMessage — auto-kickoff on marker acceptance', () => {
   it('fires a follow-up turn after accepting a marker', async () => {
     writeFileSync(join(PROMPTS_DIR, '02-competition.md'), '# COMPETITION\n\nFind competitors.')
-    mkdirSync(join(PROJECT_DIR, 'seed_spec'), { recursive: true })
-    writeFileSync(
-      join(PROJECT_DIR, 'seed_spec', 'brainstorming.md'),
-      '# Design Doc\n\n' + 'body '.repeat(200),
-    )
 
-    // Turn 1: accepts brainstorming marker.
-    mockRunClaude.mockResolvedValueOnce({
-      result: 'Done.\n\n[DISCIPLINE_COMPLETE: brainstorming]',
-      session_id: 'session-1',
+    // Turn 1: agent writes the brainstorming artifact during its turn,
+    // then emits the marker. Using mockImplementationOnce so we can
+    // write the file between the "turn start" reconciliation pass and
+    // the marker-accept step that verifies the artifact.
+    mockRunClaude.mockImplementationOnce(async () => {
+      mkdirSync(join(PROJECT_DIR, 'seed_spec'), { recursive: true })
+      writeFileSync(
+        join(PROJECT_DIR, 'seed_spec', 'brainstorming.md'),
+        '# Design Doc\n\n' + 'body '.repeat(200),
+      )
+      return { result: 'Done.\n\n[DISCIPLINE_COMPLETE: brainstorming]', session_id: 'session-1' }
     })
     // Kickoff turn: enters competition.
     mockRunClaude.mockResolvedValueOnce({
@@ -270,32 +272,89 @@ describe('handleSeedMessage — auto-kickoff on marker acceptance', () => {
   it('kickoff turn does not recurse — at most one follow-up per user turn', async () => {
     writeFileSync(join(PROMPTS_DIR, '02-competition.md'), '# COMPETITION\n\nFind competitors.')
     writeFileSync(join(PROMPTS_DIR, '03-taste.md'), '# TASTE\n\nChallenge the premise.')
-    mkdirSync(join(PROJECT_DIR, 'seed_spec'), { recursive: true })
-    writeFileSync(
-      join(PROJECT_DIR, 'seed_spec', 'brainstorming.md'),
-      'x'.repeat(1000),
-    )
-    writeFileSync(
-      join(PROJECT_DIR, 'seed_spec', 'competition.md'),
-      'x'.repeat(1000),
-    )
 
-    // Turn 1: accepts brainstorming.
-    mockRunClaude.mockResolvedValueOnce({
-      result: '[DISCIPLINE_COMPLETE: brainstorming]',
-      session_id: 's1',
+    // Turn 1: agent writes brainstorming artifact during its turn, emits marker.
+    mockRunClaude.mockImplementationOnce(async () => {
+      mkdirSync(join(PROJECT_DIR, 'seed_spec'), { recursive: true })
+      writeFileSync(join(PROJECT_DIR, 'seed_spec', 'brainstorming.md'), 'x'.repeat(1000))
+      return { result: '[DISCIPLINE_COMPLETE: brainstorming]', session_id: 's1' }
     })
-    // Kickoff turn: the agent pathologically also emits competition complete.
-    // We should NOT fire a second kickoff.
-    mockRunClaude.mockResolvedValueOnce({
-      result: 'Entering competition.\n\n[DISCIPLINE_COMPLETE: competition]',
-      session_id: 's1',
+    // Kickoff turn: the agent writes competition artifact + emits
+    // competition-complete marker too (pathological chain). We should
+    // NOT fire a second kickoff.
+    mockRunClaude.mockImplementationOnce(async () => {
+      writeFileSync(join(PROJECT_DIR, 'seed_spec', 'competition.md'), 'x'.repeat(1000))
+      return { result: 'Entering competition.\n\n[DISCIPLINE_COMPLETE: competition]', session_id: 's1' }
     })
 
     await handleSeedMessage(PROJECT_DIR, 'begin')
 
     // Two calls total: user turn + ONE kickoff. No third call.
     expect(mockRunClaude).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('handleSeedMessage — reconciliation of stranded state', () => {
+  it('catches up a stranded earlier discipline when its artifact already exists', async () => {
+    writeFileSync(join(PROMPTS_DIR, '04-spec.md'), '# SPEC\n\nWrite milestones.')
+
+    // Stranded state: later disciplines marked complete but brainstorming
+    // was rejected historically and its marker never re-fired.
+    // brainstorming artifact is on disk, matching what happens when a
+    // user session went through the old verifier rejection path.
+    mkdirSync(join(PROJECT_DIR, 'docs'), { recursive: true })
+    writeFileSync(join(PROJECT_DIR, 'docs', 'brainstorming.md'), 'x'.repeat(1000))
+    writeSeedingState(PROJECT_DIR, {
+      session_id: 's-stranded',
+      status: 'active',
+      disciplines_complete: ['competition', 'taste'],
+      disciplines_prompted: ['brainstorming'],
+      current_discipline: 'brainstorming',
+    })
+
+    // Mock returns a plain no-marker response for this turn.
+    mockRunClaude.mockResolvedValueOnce({
+      result: 'Continuing.',
+      session_id: 's-stranded',
+    })
+
+    await handleSeedMessage(PROJECT_DIR, 'continue')
+
+    // Reconciliation pass should have marked brainstorming complete and
+    // advanced the current discipline to the next gap (spec — because
+    // competition and taste were already complete).
+    const state = readSeedingState(PROJECT_DIR)
+    expect(state.disciplines_complete).toContain('brainstorming')
+    expect(state.current_discipline).toBe('spec')
+
+    // Chat log includes the reconciliation system note.
+    const log = readChatLog(PROJECT_DIR)
+    const note = log.find((m) => m.content.includes('Reconciled earlier discipline state'))
+    expect(note?.content).toContain('brainstorming')
+  })
+
+  it('rejects an out-of-order DISCIPLINE_COMPLETE when an earlier discipline genuinely has no artifact', async () => {
+    // No brainstorming artifact. Agent tries to skip ahead and declare
+    // competition complete.
+    mkdirSync(join(PROJECT_DIR, 'seed_spec'), { recursive: true })
+    writeFileSync(join(PROJECT_DIR, 'seed_spec', 'competition.md'), 'x'.repeat(1000))
+
+    mockRunClaude.mockResolvedValueOnce({
+      result: 'Competition analysis done.\n\n[DISCIPLINE_COMPLETE: competition]',
+      session_id: 's1',
+    })
+
+    const result = await handleSeedMessage(PROJECT_DIR, 'ship it')
+
+    // Marker rejected, state did NOT advance competition.
+    expect(result.disciplineComplete).toBeUndefined()
+    const state = readSeedingState(PROJECT_DIR)
+    expect(state.disciplines_complete ?? []).not.toContain('competition')
+
+    // System note explains the sequential gap.
+    const log = readChatLog(PROJECT_DIR)
+    const note = log.find((m) => m.content.includes('was rejected'))
+    expect(note?.content).toMatch(/earlier discipline brainstorming is still pending/)
   })
 })
 

--- a/dashboard/src/bridge/seed-handler.ts
+++ b/dashboard/src/bridge/seed-handler.ts
@@ -113,6 +113,26 @@ async function runSeedingTurn(
   options: TurnOptions,
 ): Promise<SendMessageResult> {
   const { isKickoff = false, suppressKickoff = false } = options
+
+  // Reconcile stranded state before anything else. Earlier runs may have
+  // had markers rejected (e.g. wrong artifact path pre-#150) that later
+  // got valid artifacts on disk when the verifier widened; without this
+  // pass, those disciplines stay "pending" forever while later ones
+  // accumulate around them. Walk in sequence, mark any discipline whose
+  // artifact now passes verification, and stop at the first gap so we
+  // respect the orchestrator's sequential rule.
+  const reconciled = reconcileDisciplineState(projectDir)
+  if (reconciled.length > 0) {
+    console.log(`[seeding] reconciled stranded disciplines: ${reconciled.join(', ')}`)
+    const note = `[SYSTEM NOTE] Reconciled earlier discipline state: ${reconciled.join(', ')} now marked complete (artifact verified on disk). Seeding continues.`
+    appendChatMessage(projectDir, {
+      id: genId(),
+      role: 'rouge',
+      content: note,
+      timestamp: new Date().toISOString(),
+    })
+  }
+
   const state = readSeedingState(projectDir)
   // Note: we intentionally allow messages even when status === 'complete'.
   // The Revise mode in the dashboard uses this path to let users continue
@@ -216,12 +236,27 @@ async function runSeedingTurn(
   // artifact actually exists on disk — the orchestrator prompt forbids
   // premature markers, but the agent has been known to emit them
   // anyway (#147). Dashboard-side enforcement is the backstop.
+  //
+  // Sequential enforcement: we also reject a marker if any earlier
+  // discipline in DISCIPLINE_SEQUENCE is still pending AND has no valid
+  // artifact on disk. That prevents the out-of-order-completion bug
+  // where a later marker got accepted while an earlier one sat rejected.
+  // Reconciliation (above) already picks up earlier disciplines that DO
+  // have artifacts, so by this point the only remaining gaps are real.
   const markers = extractMarkers(result.result)
   const acceptedDisciplines: string[] = []
   const rejectedDisciplines: Array<{ discipline: string; reason: string }> = []
   for (const d of markers.disciplinesComplete) {
     if (!isKnownDiscipline(d)) {
       rejectedDisciplines.push({ discipline: d, reason: 'unknown discipline name' })
+      continue
+    }
+    const gap = firstUncompletedEarlierDiscipline(projectDir, d)
+    if (gap) {
+      rejectedDisciplines.push({
+        discipline: d,
+        reason: `cannot complete ${d} — earlier discipline ${gap} is still pending with no artifact. Complete ${gap} first.`,
+      })
       continue
     }
     const check = verifyDisciplineArtifact(projectDir, d)
@@ -343,4 +378,64 @@ function isKnownDiscipline(name: string): name is Discipline {
 function resolveActiveDiscipline(raw: string | undefined): Discipline | null {
   if (!raw) return DISCIPLINE_SEQUENCE[0] as Discipline
   return isKnownDiscipline(raw) ? raw : null
+}
+
+/**
+ * Walk disciplines in sequence; mark any not-yet-complete discipline
+ * whose artifact passes verification. Stops at the first gap so we
+ * preserve the orchestrator's sequential rule. Returns the list of
+ * disciplines newly marked complete this pass.
+ *
+ * Exists because early runs had markers rejected (artifact-path
+ * mismatches fixed in #150/#151) and the state never caught up when the
+ * verifier later accepted those paths. This pass picks up the stranded
+ * work on the next user turn automatically. See the testimonials
+ * session symptom: `disciplines_complete: ['competition','taste','spec']`
+ * while brainstorming stayed pending with a real 41KB artifact on disk.
+ */
+function reconcileDisciplineState(projectDir: string): string[] {
+  const state = readSeedingState(projectDir)
+  const complete = new Set(state.disciplines_complete ?? [])
+  const newlyComplete: string[] = []
+
+  for (const d of DISCIPLINE_SEQUENCE) {
+    if (complete.has(d)) continue
+    const check = verifyDisciplineArtifact(projectDir, d)
+    if (check.ok) {
+      markDisciplineComplete(projectDir, d)
+      complete.add(d)
+      newlyComplete.push(d)
+    } else {
+      // First real gap — don't look further. If brainstorming genuinely
+      // has no artifact, we cannot mark competition etc. as complete
+      // even if those have artifacts.
+      break
+    }
+  }
+
+  return newlyComplete
+}
+
+/**
+ * Returns the first discipline earlier than `target` in the sequence
+ * that is NOT complete and has no verifiable artifact on disk. If
+ * non-null, emitting `[DISCIPLINE_COMPLETE: target]` should be rejected
+ * because earlier work is genuinely missing.
+ */
+function firstUncompletedEarlierDiscipline(
+  projectDir: string,
+  target: Discipline,
+): string | null {
+  const state = readSeedingState(projectDir)
+  const complete = new Set(state.disciplines_complete ?? [])
+  for (const d of DISCIPLINE_SEQUENCE) {
+    if (d === target) return null
+    if (complete.has(d)) continue
+    // Artifact present but unmarked — reconciliation (called earlier in
+    // the turn) should have caught this. If it didn't, the artifact
+    // doesn't pass verification, so count this as a real gap.
+    const check = verifyDisciplineArtifact(projectDir, d)
+    if (!check.ok) return d
+  }
+  return null
 }


### PR DESCRIPTION
## The bug you saw

Your testimonials session has:
\`\`\`json
{
  \"disciplines_complete\": [\"competition\", \"taste\", \"spec\"],
  \"current_discipline\": \"brainstorming\"
}
\`\`\`

Brainstorming never marked complete even though competition, taste, and spec are. A real 41KB brainstorming artifact sits at \`docs/brainstorming.md\`. The sidebar's empty circle on Brainstorming + green checks on the three after it was not a rendering glitch — the state on disk is genuinely that shape.

Cause: early in the session, Claude emitted \`[DISCIPLINE_COMPLETE: brainstorming]\` but the verifier at that point only checked \`seed_spec/brainstorming.md\`. Your artifact was at \`docs/\`. Rejected. #150 later widened fallbacks to include \`docs/\`, so subsequent markers for competition/taste/spec sailed through — but brainstorming's marker never fired again, so it stayed stranded while the ones after it filled in.

## Fix

**1. Reconciliation pass at turn start.** Walk disciplines in sequence; mark any not-yet-complete discipline whose artifact now passes verification, stop at the first real gap. Your stranded brainstorming gets caught up automatically on the next user message. Chat log posts a system note naming what was reconciled.

**2. Sequential enforcement on marker acceptance.** Reject \`[DISCIPLINE_COMPLETE: X]\` if any earlier discipline is still pending AND has no verifiable artifact. Reason string names the specific gap (\"earlier discipline brainstorming is still pending — complete it first\"). Delivered to Claude via the existing pending-correction path (#149). Prevents the out-of-order acceptance bug that created this in the first place.

## What this does to your current session

Next time you send a message, reconciliation will pick up the brainstorming artifact already on disk, mark brainstorming complete, advance \`current_discipline\` to \`infrastructure\` (the next real gap). Stepper should show all 4 disciplines green after that.

## Test plan
- [x] Updated auto-kickoff tests (#153) to write the artifact during the mock turn (was relying on pre-existing state that reconciliation would now catch first)
- [x] +1 reconciliation test: stranded state with artifact on disk + later disciplines marked → caught up
- [x] +1 sequential-enforcement test: out-of-order marker with real gap → rejected with named reason
- [x] 265 dashboard tests pass (up from 263)