### PR TITLE
fix: enforce DESIGN three-pass artifacts + require vision/product_standard at finalize

### DIFF
--- a/dashboard/src/bridge/__tests__/discipline-artifacts.test.ts
+++ b/dashboard/src/bridge/__tests__/discipline-artifacts.test.ts
@@ -98,27 +98,43 @@ describe('verifyDisciplineArtifact', () => {
     expect(verifyDisciplineArtifact(PROJECT_DIR, 'infrastructure').ok).toBe(true)
   })
 
-  it('accepts design when design/ has at least one file', () => {
-    writeDir('design', { 'layout.yaml': 'hi' })
+  it('accepts design when all three pass files exist', () => {
+    writeFile('design/pass-1-ux-architecture.yaml', 'x'.repeat(400))
+    writeFile('design/pass-2-component-design.yaml', 'x'.repeat(400))
+    writeFile('design/pass-3-visual-design.yaml', 'x'.repeat(400))
     expect(verifyDisciplineArtifact(PROJECT_DIR, 'design').ok).toBe(true)
   })
 
+  it('rejects design when only Pass 1 exists (phantom-complete bug from Praise session)', () => {
+    writeFile('design/pass-1-ux-architecture.yaml', 'x'.repeat(400))
+    // Pass 2 and Pass 3 missing — the exact failure mode the user
+    // flagged. Single-file design/ shouldn't satisfy the marker.
+    const r = verifyDisciplineArtifact(PROJECT_DIR, 'design')
+    expect(r.ok).toBe(false)
+    expect(r.reason).toMatch(/pass-2-component-design/)
+  })
+
+  it('accepts design via combined design/design.yaml when large enough', () => {
+    writeFile('design/design.yaml', 'x'.repeat(2500))
+    expect(verifyDisciplineArtifact(PROJECT_DIR, 'design').ok).toBe(true)
+  })
+
+  it('rejects a small design/design.yaml that likely contains only one pass', () => {
+    writeFile('design/design.yaml', 'x'.repeat(400))
+    expect(verifyDisciplineArtifact(PROJECT_DIR, 'design').ok).toBe(false)
+  })
+
   it('accepts design via seed_spec/design_artifact.md fallback (old convention)', () => {
-    writeFile('seed_spec/design_artifact.md', LONG_BODY)
+    writeFile('seed_spec/design_artifact.md', 'x'.repeat(2500))
     expect(verifyDisciplineArtifact(PROJECT_DIR, 'design').ok).toBe(true)
   })
 
   it('accepts design via docs/design.md when agent improvises', () => {
-    writeFile('docs/design.md', LONG_BODY)
+    writeFile('docs/design.md', 'x'.repeat(2500))
     expect(verifyDisciplineArtifact(PROJECT_DIR, 'design').ok).toBe(true)
   })
 
-  it('rejects design when design/ is empty', () => {
-    writeDir('design', {})
-    expect(verifyDisciplineArtifact(PROJECT_DIR, 'design').ok).toBe(false)
-  })
-
-  it('rejects design when design/ only contains dotfiles', () => {
+  it('rejects design when no artifact pattern is satisfied', () => {
     writeDir('design', { '.DS_Store': '' })
     expect(verifyDisciplineArtifact(PROJECT_DIR, 'design').ok).toBe(false)
   })

--- a/dashboard/src/bridge/__tests__/seeding-finalize.test.ts
+++ b/dashboard/src/bridge/__tests__/seeding-finalize.test.ts
@@ -11,32 +11,59 @@ describe('finalizeSeeding', () => {
     rmSync(testDir, { recursive: true, force: true })
   })
 
-  it('returns missingArtifacts when task_ledger.json is missing', () => {
-    mkdirSync(join(testDir, 'seed_spec'), { recursive: true })
-    writeFileSync(join(testDir, 'seed_spec', 'milestones.json'), '{}')
-    writeFileSync(join(testDir, 'state.json'), JSON.stringify({ current_state: 'seeding' }))
+  const LONG = 'x'.repeat(500)
 
+  function seedCompleteProject(): void {
+    mkdirSync(join(testDir, 'seed_spec'), { recursive: true })
+    writeFileSync(join(testDir, 'task_ledger.json'), '{}')
+    writeFileSync(join(testDir, 'seed_spec', 'milestones.json'), '{}')
+    writeFileSync(join(testDir, 'vision.json'), LONG)
+    writeFileSync(join(testDir, 'product_standard.json'), LONG)
+    writeFileSync(join(testDir, 'state.json'), JSON.stringify({ current_state: 'seeding', name: 'test' }))
+  }
+
+  it('returns missingArtifacts when task_ledger.json is missing', () => {
+    seedCompleteProject()
+    rmSync(join(testDir, 'task_ledger.json'))
     const result = finalizeSeeding(testDir)
     expect(result.ok).toBe(false)
     expect(result.missingArtifacts).toContain('task_ledger.json')
   })
 
   it('returns missingArtifacts when seed_spec/ has no files', () => {
-    mkdirSync(testDir, { recursive: true })
-    writeFileSync(join(testDir, 'task_ledger.json'), '{}')
-    writeFileSync(join(testDir, 'state.json'), JSON.stringify({ current_state: 'seeding' }))
-
+    seedCompleteProject()
+    rmSync(join(testDir, 'seed_spec', 'milestones.json'))
     const result = finalizeSeeding(testDir)
     expect(result.ok).toBe(false)
     expect(result.missingArtifacts).toContain('seed_spec/')
   })
 
-  it('transitions state to ready when both artifacts exist', () => {
-    mkdirSync(join(testDir, 'seed_spec'), { recursive: true })
-    writeFileSync(join(testDir, 'task_ledger.json'), '{}')
-    writeFileSync(join(testDir, 'seed_spec', 'milestones.json'), '{}')
-    writeFileSync(join(testDir, 'state.json'), JSON.stringify({ current_state: 'seeding', name: 'test' }))
+  it('returns missingArtifacts when vision.json is missing', () => {
+    seedCompleteProject()
+    rmSync(join(testDir, 'vision.json'))
+    const result = finalizeSeeding(testDir)
+    expect(result.ok).toBe(false)
+    expect(result.missingArtifacts).toContain('vision.json')
+  })
 
+  it('returns missingArtifacts when product_standard.json is missing', () => {
+    seedCompleteProject()
+    rmSync(join(testDir, 'product_standard.json'))
+    const result = finalizeSeeding(testDir)
+    expect(result.ok).toBe(false)
+    expect(result.missingArtifacts).toContain('product_standard.json')
+  })
+
+  it('returns missingArtifacts when vision.json is a stub (below byte floor)', () => {
+    seedCompleteProject()
+    writeFileSync(join(testDir, 'vision.json'), '{}')
+    const result = finalizeSeeding(testDir)
+    expect(result.ok).toBe(false)
+    expect(result.missingArtifacts).toContain('vision.json')
+  })
+
+  it('transitions state to ready when all required artifacts exist', () => {
+    seedCompleteProject()
     const result = finalizeSeeding(testDir)
     expect(result.ok).toBe(true)
 

--- a/dashboard/src/bridge/discipline-artifacts.ts
+++ b/dashboard/src/bridge/discipline-artifacts.ts
@@ -17,6 +17,11 @@ import type { Discipline } from './discipline-prompts'
 type ArtifactSpec =
   | { kind: 'file'; path: string; minBytes: number }
   | { kind: 'dir'; path: string; minFiles: number }
+  // All listed files must exist with their minBytes. Used where a
+  // discipline's contract mandates multiple discrete outputs (e.g.
+  // DESIGN's three scored passes) — a single-dir existence check
+  // accepts work that only did one pass and called it done.
+  | { kind: 'files'; paths: { path: string; minBytes: number }[] }
 
 // Each discipline produces at least one of these artifacts. Any hit wins.
 // Paths are relative to the project directory — `join(projectDir, path)`
@@ -55,11 +60,28 @@ const ARTIFACT_SPECS: Record<Discipline, ArtifactSpec[]> = {
     { kind: 'file', path: 'infrastructure_manifest.json', minBytes: 200 },
   ],
   design: [
-    { kind: 'dir', path: 'design', minFiles: 1 },
-    { kind: 'file', path: 'seed_spec/design.md', minBytes: 500 },
-    { kind: 'file', path: 'seed_spec/design_artifact.md', minBytes: 500 },
-    { kind: 'file', path: 'seed_spec/design_artifact.yaml', minBytes: 500 },
-    { kind: 'file', path: 'docs/design.md', minBytes: 500 },
+    // Primary: all three scored passes must exist as discrete YAML
+    // artifacts. Prevents the phantom-complete pattern where Pass 1
+    // ran, the agent emitted DISCIPLINE_COMPLETE, and Pass 2/3 were
+    // never actually performed — observed in the Praise session.
+    {
+      kind: 'files',
+      paths: [
+        { path: 'design/pass-1-ux-architecture.yaml', minBytes: 300 },
+        { path: 'design/pass-2-component-design.yaml', minBytes: 300 },
+        { path: 'design/pass-3-visual-design.yaml', minBytes: 300 },
+      ],
+    },
+    // Fallback: combined design.yaml large enough to plausibly contain
+    // all three passes. ~2KB covers the orchestrator's scored-dimension
+    // structure for three passes.
+    { kind: 'file', path: 'design/design.yaml', minBytes: 2000 },
+    // Legacy / agent-improvised paths. Keep for backwards compat with
+    // older convention (construction-coordinator's design_artifact.md).
+    { kind: 'file', path: 'seed_spec/design.md', minBytes: 2000 },
+    { kind: 'file', path: 'seed_spec/design_artifact.md', minBytes: 2000 },
+    { kind: 'file', path: 'seed_spec/design_artifact.yaml', minBytes: 2000 },
+    { kind: 'file', path: 'docs/design.md', minBytes: 2000 },
   ],
   'legal-privacy': [
     { kind: 'dir', path: 'legal', minFiles: 1 },
@@ -91,24 +113,40 @@ export function verifyDisciplineArtifact(
 
   const checked: string[] = []
   for (const spec of specs) {
-    const full = join(projectDir, spec.path)
-    checked.push(spec.path)
-    if (!existsSync(full)) continue
-
     if (spec.kind === 'file') {
+      const full = join(projectDir, spec.path)
+      checked.push(spec.path)
+      if (!existsSync(full)) continue
       try {
-        const size = statSync(full).size
-        if (size >= spec.minBytes) return { ok: true, discipline, checkedPaths: checked }
-      } catch {
-        continue
-      }
-    } else {
+        if (statSync(full).size >= spec.minBytes) {
+          return { ok: true, discipline, checkedPaths: checked }
+        }
+      } catch { /* skip */ }
+    } else if (spec.kind === 'dir') {
+      const full = join(projectDir, spec.path)
+      checked.push(spec.path)
+      if (!existsSync(full)) continue
       try {
         const entries = readdirSync(full).filter((f) => !f.startsWith('.'))
-        if (entries.length >= spec.minFiles) return { ok: true, discipline, checkedPaths: checked }
-      } catch {
-        continue
+        if (entries.length >= spec.minFiles) {
+          return { ok: true, discipline, checkedPaths: checked }
+        }
+      } catch { /* skip */ }
+    } else {
+      // 'files' — all listed paths must exist at their floor.
+      for (const p of spec.paths) {
+        if (!checked.includes(p.path)) checked.push(p.path)
       }
+      const allOk = spec.paths.every((p) => {
+        const full = join(projectDir, p.path)
+        if (!existsSync(full)) return false
+        try {
+          return statSync(full).size >= p.minBytes
+        } catch {
+          return false
+        }
+      })
+      if (allOk) return { ok: true, discipline, checkedPaths: checked }
     }
   }
 
@@ -116,7 +154,11 @@ export function verifyDisciplineArtifact(
     ok: false,
     discipline,
     reason: `no artifact found matching ${specs
-      .map((s) => (s.kind === 'file' ? `file ${s.path} (≥${s.minBytes}B)` : `dir ${s.path}/ (≥${s.minFiles} files)`))
+      .map((s) => {
+        if (s.kind === 'file') return `file ${s.path} (≥${s.minBytes}B)`
+        if (s.kind === 'dir') return `dir ${s.path}/ (≥${s.minFiles} files)`
+        return `all of [${s.paths.map((p) => p.path).join(', ')}] (each ≥${s.paths[0]?.minBytes ?? 0}B)`
+      })
       .join(' or ')}`,
     checkedPaths: checked,
   }

--- a/dashboard/src/bridge/seeding-finalize.ts
+++ b/dashboard/src/bridge/seeding-finalize.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, writeFileSync, readdirSync } from 'fs'
+import { existsSync, readFileSync, writeFileSync, readdirSync, statSync } from 'fs'
 import { join } from 'path'
 import { statePath as resolveStatePath } from './state-path'
 
@@ -7,15 +7,27 @@ export interface FinalizeResult {
   missingArtifacts?: string[]
 }
 
+/** Minimum byte floor for "looks like real content, not a stub". */
+const MIN_FILE_BYTES = 200
+
+function fileLooksReal(path: string): boolean {
+  if (!existsSync(path)) return false
+  try {
+    return statSync(path).size >= MIN_FILE_BYTES
+  } catch {
+    return false
+  }
+}
+
 export function finalizeSeeding(projectDir: string): FinalizeResult {
   const missing: string[] = []
 
-  // Verify task_ledger.json
+  // Task ledger — V3 story/milestone tracking the launcher consumes.
   if (!existsSync(join(projectDir, 'task_ledger.json'))) {
     missing.push('task_ledger.json')
   }
 
-  // Verify seed_spec/ has at least one file
+  // Seed spec directory — per-feature spec files.
   const seedSpecDir = join(projectDir, 'seed_spec')
   if (!existsSync(seedSpecDir)) {
     missing.push('seed_spec/')
@@ -26,11 +38,27 @@ export function finalizeSeeding(projectDir: string): FinalizeResult {
     }
   }
 
+  // vision.json — machine-readable product vision the orchestrator
+  // (line 147) and complexity-profile step (line 479) both require.
+  // The V2 schema finalization writes infrastructure.services into
+  // this file too.
+  if (!fileLooksReal(join(projectDir, 'vision.json'))) {
+    missing.push('vision.json')
+  }
+
+  // product_standard.json — inherited global + domain + project
+  // overrides (orchestrator line 148). Drives what the Factory holds
+  // the build to during loop evaluation.
+  if (!fileLooksReal(join(projectDir, 'product_standard.json'))) {
+    missing.push('product_standard.json')
+  }
+
   if (missing.length > 0) {
     return { ok: false, missingArtifacts: missing }
   }
 
-  // Transition state.json to ready
+  // All artifacts present — promote state to ready so the build loop
+  // can pick it up when the human triggers it.
   const statePath = resolveStatePath(projectDir)
   if (existsSync(statePath)) {
     const state = JSON.parse(readFileSync(statePath, 'utf-8'))

--- a/src/prompts/seeding/05-design.md
+++ b/src/prompts/seeding/05-design.md
@@ -707,11 +707,21 @@ design_po_checks:
 
 ---
 
+## Output Artifacts — three passes, three files
+
+**Each of the three passes writes a discrete YAML artifact in `design/`:**
+
+- Pass 1 (UX architecture) → `design/pass-1-ux-architecture.yaml`
+- Pass 2 (component design) → `design/pass-2-component-design.yaml`
+- Pass 3 (visual design) → `design/pass-3-visual-design.yaml`
+
+Plus a combined rollup: `design/design.yaml` — the structure in the "Combined Output Artifact" section below, which references the three pass files.
+
+**The dashboard verifies all three pass files exist at ≥300 bytes each before accepting `[DISCIPLINE_COMPLETE: design]`.** Writing only Pass 1 and emitting the marker (observed in the Praise session) is rejected — Pass 2 and Pass 3 are not optional; they're how component and visual quality get scored for PO review. If the combined `design/design.yaml` exists at ≥2000 bytes as a single-file rollup, that is also accepted — but the three-pass structure must be present within it.
+
+**Write before presenting scores or asking for pass sign-off.** Each pass has a natural "here are the scores, approve?" checkpoint. Write the pass's YAML to disk *before* asking the human to approve. Never present scores or slop-flags that exist only in your reply — the human cannot cross-check a YAML they cannot read, and a conversation-only score does not satisfy the verifier.
+
 ## Combined Output Artifact
-
-**Write the combined artifact to `design/design.yaml`** in the project root. Create the `design/` directory if it doesn't exist. If additional per-screen or per-pass breakout files help, put them alongside in `design/`. Do not write to `seed_spec/` or `docs/` for the combined artifact — the dashboard verifies at least one file exists in `design/` before accepting the `[DISCIPLINE_COMPLETE: design]` marker.
-
-**Write before presenting scores or asking for pass sign-off.** Each pass produces scored dimensions; each pass has a natural "here are the scores, approve?" checkpoint. Write the pass's portion of `design/design.yaml` (or a pass-specific breakout file in `design/`) *before* asking the human to approve scores. Never present scores or slop-flags that exist only in your reply — the human cannot cross-check a YAML they cannot read.
 
 When all three passes are approved, produce the combined design artifact for the orchestrator:
 


### PR DESCRIPTION
Post-mortem fixes from the Praise session feedback.

## Two structural holes

**1. DESIGN Pass 2 and Pass 3 were skipped.** Agent emitted \`[DISCIPLINE_COMPLETE: design]\` after Pass 1 (UX architecture) without running Pass 2 (component design) or Pass 3 (visual design). Verifier accepted because \`design/\` had at least one file. Sub-prompt described three passes in text but never pinned each to a discrete output.

**2. V2 finalization artifacts missing.** \`vision.json\` and \`product_standard.json\` — both required by the orchestrator (lines 147, 148) and read by the complexity-profile step — weren't emitted. \`finalizeSeeding()\` only checked \`task_ledger.json\` and \`seed_spec/\` files.

## Fix

**DESIGN three-pass enforcement**
- New \`ArtifactSpec\` kind \`files\` (plural): conjunctive check — all listed paths must exist at their byte floor. Sits alongside disjunctive 'file' and 'dir' specs.
- DESIGN primary check is now all three pass YAMLs:
  - \`design/pass-1-ux-architecture.yaml\` (≥300 B)
  - \`design/pass-2-component-design.yaml\` (≥300 B)
  - \`design/pass-3-visual-design.yaml\` (≥300 B)
- Fallbacks: \`design/design.yaml\` ≥2000 B (plausibly contains all three as sections), plus the old \`seed_spec/design*.md\` paths.
- \`05-design.md\` pins each pass's output path and calls out the Praise failure mode explicitly.

**V2 finalization**
- \`finalizeSeeding()\` now also requires \`vision.json\` and \`product_standard.json\` at ≥200 B before promoting state to \`ready\`. Missing ones surface through the existing rejection path (#148).

## Test plan
- [x] 5 new design verifier cases (three-pass happy path; Pass 1 only rejected; combined rollup accepted; undersized rollup rejected; no-artifact rejected)
- [x] 2 new + 1 rewritten finalization cases (vision.json missing; product_standard.json missing; stubs below byte floor rejected; happy path with all artifacts promotes state to ready)
- [x] 270 dashboard tests pass (up from 265)