### PR TITLE
feat(#157): end-to-end containerised self-host build support

### DIFF
--- a/src/launcher/deploy-to-staging.js
+++ b/src/launcher/deploy-to-staging.js
@@ -93,6 +93,8 @@ const DEPLOY_HANDLERS = {
   'vercel': deployVercel,
   'cloudflare': deployCloudflare,
   'cloudflare-workers': deployCloudflare, // alias used in vision.json.infrastructure
+  'docker-compose': deployDockerCompose, // self-hosted containerised stack (#157)
+  'docker': deployDockerCompose, // alias
 };
 
 function deployVercel(projectDir) {
@@ -110,6 +112,56 @@ function deployVercel(projectDir) {
   const projectName = projectJson?.projectName || path.basename(projectDir);
   const stagingUrl = `https://${projectName}.vercel.app`;
   log(`Deployed to ${stagingUrl}`);
+  return stagingUrl;
+}
+
+/**
+ * Docker-compose staging deploy (#157).
+ *
+ * The product ships as its own stack — Dockerfile + compose file live in
+ * the project repo. Rouge's staging job is to run that stack on
+ * localhost, smoke-test it, and hand back a URL the health check can
+ * hit. Multi-arch image builds and GHCR publishing are the product's
+ * own CI responsibility (the loop's build prompt writes a GitHub Actions
+ * workflow for that).
+ *
+ * Staging port resolution:
+ *   1. `infrastructure_manifest.json.staging.port` if declared
+ *   2. `vision.json.infrastructure.staging_port` if declared
+ *   3. Default to 3000 (Node convention)
+ *
+ * There is no rollback. A previous compose run is torn down before the
+ * new one starts; if the new one fails the health check, the stack is
+ * just left stopped — there's no deploy-specific "previous version" to
+ * roll forward to like Cloudflare has.
+ */
+function deployDockerCompose(projectDir) {
+  const manifest = readJson(path.join(projectDir, 'infrastructure_manifest.json'));
+  const vision = readJson(path.join(projectDir, 'vision.json'));
+  const port =
+    manifest?.staging?.port ??
+    manifest?.staging_port ??
+    vision?.infrastructure?.staging_port ??
+    3000;
+  const stagingUrl = `http://localhost:${port}`;
+
+  // Tear down any prior stack so we don't accidentally "deploy" by
+  // leaving the previous image running. --remove-orphans catches
+  // services that were removed from compose between runs. Failure is
+  // benign (nothing was running).
+  try {
+    run('docker compose down --remove-orphans', { cwd: projectDir, timeout: 60000 });
+  } catch {
+    // ignore
+  }
+
+  // `--build` forces an image rebuild so subsequent deploys don't
+  // silently run against a stale image cached from the first run.
+  // Timeout is 10 min: multi-arch or large-base-image builds (alpine+
+  // ffmpeg, for instance) routinely exceed the 5-min Cloudflare timeout.
+  run('docker compose up -d --build', { cwd: projectDir, timeout: 600000 });
+
+  log(`Docker Compose stack started on ${stagingUrl}`);
   return stagingUrl;
 }
 

--- a/src/launcher/provision-infrastructure.js
+++ b/src/launcher/provision-infrastructure.js
@@ -336,14 +336,26 @@ function main() {
   } else if (target === 'vercel') {
     log('Vercel: project must be linked via `vercel link` before deploy. Skipping Cloudflare provisioning.');
     log('Vercel: the deploy handler in deploy-to-staging.js handles `vercel deploy --yes --prod`.');
-  } else if (target === 'docker-compose' || target === 'none') {
+  } else if (target === 'docker-compose' || target === 'docker' || target === 'none') {
     log(`${target}: no cloud provisioning needed.`);
   } else {
     log(`❌ Unknown deployment_target "${target}" — no provisioner registered. Supported: cloudflare, cloudflare-workers, vercel, docker-compose, none`);
   }
 
-  // Supabase (if needed)
-  if (infra.needs_database || infra.needs_auth) {
+  // Supabase (if needed).
+  //
+  // Self-hosted targets (docker-compose, docker) ship their own database
+  // service in the compose stack — claiming a Supabase cloud slot for
+  // them would waste a slot on a product that doesn't route any traffic
+  // there. Record that the DB is compose-bundled in cycle_context so
+  // downstream phases (deploy, migrations) know not to expect a cloud
+  // `ctx.supabase.project_ref`. See #157.
+  const isSelfHosted = target === 'docker-compose' || target === 'docker';
+  if ((infra.needs_database || infra.needs_auth) && isSelfHosted) {
+    log('Self-hosted target: database/auth shipped inside the compose stack — skipping Supabase cloud provisioning.');
+    ctx.infrastructure = ctx.infrastructure || {};
+    ctx.infrastructure.database_mode = 'compose-bundled';
+  } else if (infra.needs_database || infra.needs_auth) {
     const supaResult = provisionSupabase(projectDir, projectName);
     if (supaResult) {
       ctx.supabase = ctx.supabase || {};

--- a/src/launcher/rouge-safety-check.sh
+++ b/src/launcher/rouge-safety-check.sh
@@ -186,6 +186,18 @@ pre_bash() {
     fi
   fi
 
+  # --- Docker registry pushes (#157) ---
+  # docker compose / docker build / docker run etc. are implicitly allowed
+  # — self-hosted products run their stack locally for staging. But
+  # `docker push` publishes an image to a remote registry, which is a
+  # ship-phase concern that should go through the product's CI (GitHub
+  # Actions on tag), not a direct Rouge agent invocation. Block direct
+  # pushes from the agent so a runaway loop can't accidentally publish
+  # a broken build to GHCR or DockerHub.
+  if echo "$cmd" | grep -qE '(^|[[:space:]]|;|&&|\|\|)docker[[:space:]]+push(\s|$)'; then
+    block "pre-bash" "$summary" "Blocked: direct 'docker push' — registry publishing must go through the product's CI (e.g. GitHub Actions on release tag), not a direct agent call"
+  fi
+
   # --- Custom blocked commands from config ---
   local custom_blocked
   custom_blocked=$(load_custom_blocked)

--- a/src/prompts/loop/00-foundation-building.md
+++ b/src/prompts/loop/00-foundation-building.md
@@ -78,6 +78,28 @@ Read `foundation_spec` from `cycle_context.json`. Your scope is EXACTLY what's l
 - Environment variable documentation
 - Health check endpoint
 
+#### Containerised deployments (`deployment_target: docker-compose` / `docker`)
+
+When `infrastructure_manifest.json.deployment_target` is `docker-compose` or `docker`, foundation also writes:
+
+**`Dockerfile`** — production image for the app. Use a multi-stage build:
+
+1. **Build stage** — `node:alpine` (or language-equivalent). Install build deps, run the production build, prune dev dependencies.
+2. **Runtime stage** — `node:alpine` again, or `distroless` if the app has no shell needs. Copy only the built artifacts. Declare a non-root `USER`. `EXPOSE` the HTTP port. Define `HEALTHCHECK` against the health endpoint from this section.
+
+System dependencies (ffmpeg, imagemagick, sharp native bindings, etc.) go in the runtime stage only — don't ship the full build toolchain. Alpine's apk index is your friend; pin versions where available. For `ffmpeg` specifically, prefer the LGPL build (`apk add ffmpeg`) unless the product's licence explicitly allows GPL — most MIT/Apache products should NOT ship the GPL build.
+
+**`docker-compose.yml`** — the local staging stack. Minimum services:
+- `app` — builds from the Dockerfile, mounts nothing that the image should own (code is baked in), exposes the app port.
+- `db` (if `infrastructure.database_mode === "compose-bundled"`) — Postgres or MySQL service, named volume for persistence, health check so `app` waits for it.
+- Any other bundled services declared in the manifest (e.g. MinIO for S3-compat, Redis, Mailhog).
+
+Rouge's staging deploy handler runs `docker compose up -d --build` from the project root (#157) and hits `http://localhost:<port>` for the health check. The port default is 3000; override via `infrastructure_manifest.json.staging.port`.
+
+**`.dockerignore`** — aggressive. Exclude `node_modules`, `.next`, `.git`, `coverage`, `.env*`, test fixtures, dev-only docs. Image size scales with layer size; lazy ignores add megabytes.
+
+**CI workflow** — a GitHub Actions workflow at `.github/workflows/publish-image.yml` that builds multi-arch images (`linux/amd64`, `linux/arm64`) and publishes to GHCR on release-tag push. Template in `01-building.md` step for ship preparation; foundation just needs the Dockerfile + compose file present so the staging deploy can run during the build loop.
+
 ### Test Fixtures
 - Seed data for every entity in the schema
 - Data generators for testing at scale

--- a/src/prompts/loop/01-building.md
+++ b/src/prompts/loop/01-building.md
@@ -423,10 +423,50 @@ If `pending-action.json` is not available or you need more control, you can depl
 
 - **Cloudflare Workers** (`cloudflare` or `cloudflare-workers`): `npx @opennextjs/cloudflare build && npx wrangler deploy --env staging`
 - **Vercel** (`vercel`): `npx vercel deploy --yes --prod` (use `--prod` because Vercel Hobby plan preview URLs return 401)
-- **Docker Compose** (`docker-compose`): `docker compose up -d --build`
+- **Docker Compose** (`docker-compose` or `docker`): `docker compose up -d --build`. Staging URL is `http://localhost:<port>`; port comes from `infrastructure_manifest.json.staging.port` (default 3000). Rouge's deploy handler (#157) runs `docker compose down --remove-orphans` before `up` to guarantee a fresh image. Direct `docker push` to a registry is blocked by the safety hook — publishing is a ship-phase CI concern (see below), not something the build loop does.
 - **Other**: read the deploy pattern from `library/integrations/` for the declared target. If no pattern exists, ESCALATE.
 
 Capture the staging URL from the deploy output. You will need it for `cycle_context.json`.
+
+### Multi-arch image publishing CI (containerised products)
+
+For `docker-compose` / `docker` targets, write a GitHub Actions workflow at `.github/workflows/publish-image.yml` that publishes multi-arch images to GHCR on release-tag push. This runs in the product's own CI, not in Rouge's execution — Rouge's safety hook blocks direct `docker push`.
+
+Minimum shape:
+
+```yaml
+name: Publish image
+on:
+  push:
+    tags: ['v*.*.*']
+permissions:
+  contents: read
+  packages: write
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+            ghcr.io/${{ github.repository }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+```
+
+Write this file during foundation or the first story that touches deployment; the actual publish fires when a human cuts a release tag (outside Rouge's loop).
 
 ### Other infrastructure actions via intent
 

--- a/test/launcher/deploy-to-staging.test.js
+++ b/test/launcher/deploy-to-staging.test.js
@@ -144,6 +144,31 @@ describe('deploy-to-staging', () => {
       assert.ok(logs.join('\n').includes('target: cloudflare-workers)'));
     });
 
+    test('docker-compose target passes handler lookup (#157)', () => {
+      projectDir = makeTempProject({
+        infrastructure: { deployment_target: 'docker-compose' },
+      });
+      const { result, logs } = captureLogs(() => deploy(projectDir));
+      // Actual docker compose call fails (no compose file, no docker
+      // running in test). What we care about is the handler WAS found
+      // and attempted — no "no handler is registered" error.
+      assert.strictEqual(result, null);
+      const logText = logs.join('\n');
+      assert.ok(logText.includes('target: docker-compose)'), 'should log target');
+      assert.ok(!logText.includes('no handler is registered'), 'handler must be registered');
+    });
+
+    test('docker alias passes handler lookup (#157)', () => {
+      projectDir = makeTempProject({
+        infrastructure: { deployment_target: 'docker' },
+      });
+      const { result, logs } = captureLogs(() => deploy(projectDir));
+      assert.strictEqual(result, null);
+      const logText = logs.join('\n');
+      assert.ok(logText.includes('target: docker)'), 'should log target');
+      assert.ok(!logText.includes('no handler is registered'), 'alias must resolve to docker-compose handler');
+    });
+
     test('unknown target logs "no handler" message', () => {
       projectDir = makeTempProject({
         infrastructure: { deployment_target: 'heroku' },

--- a/tests/safety-hooks.test.sh
+++ b/tests/safety-hooks.test.sh
@@ -105,6 +105,13 @@ assert_blocked "supabase db drop" \
 assert_blocked "supabase DROP TABLE" \
   "$SAFETY_CHECK" pre-bash '{"command": "supabase db execute \"DROP TABLE users\""}'
 
+# docker push — registry publishing must go through product CI (#157)
+assert_blocked "docker push to ghcr.io" \
+  "$SAFETY_CHECK" pre-bash '{"command": "docker push ghcr.io/myorg/app:latest"}'
+
+assert_blocked "docker push with multiple words before" \
+  "$SAFETY_CHECK" pre-bash '{"command": "cd /tmp && docker push myorg/app:v1.0.0"}'
+
 echo ""
 echo "=== pre-bash: safe commands allowed ==="
 
@@ -143,6 +150,19 @@ assert_allowed "rm in project (no root)" \
 
 assert_allowed "supabase status" \
   "$SAFETY_CHECK" pre-bash '{"command": "supabase status"}'
+
+# docker build / compose / run — local staging commands are allowed (#157)
+assert_allowed "docker compose up" \
+  "$SAFETY_CHECK" pre-bash '{"command": "docker compose up -d --build"}'
+
+assert_allowed "docker compose down" \
+  "$SAFETY_CHECK" pre-bash '{"command": "docker compose down --remove-orphans"}'
+
+assert_allowed "docker build local image" \
+  "$SAFETY_CHECK" pre-bash '{"command": "docker build -t myapp:dev ."}'
+
+assert_allowed "docker run locally" \
+  "$SAFETY_CHECK" pre-bash '{"command": "docker run --rm myapp:dev node --version"}'
 
 # ---------------------------------------------------------------------------
 # PRE-WRITE TESTS


### PR DESCRIPTION
Closes #157.

## Gap
Infrastructure discipline advertised \`docker-compose\` as a staging target, but only vercel/cloudflare/cloudflare-workers had deploy handlers. Containerised products (like Praise) escalated on first staging deploy with "no handler is registered."

## Full B fix — four coordinated changes

**Deploy handler** (\`deploy-to-staging.js\`)
\`deployDockerCompose()\`: down→up with --build, 10-min timeout, port-from-manifest staging URL. Registered under \`docker-compose\` and \`docker\` aliases.

**Self-host provisioning skip** (\`provision-infrastructure.js\`)
Docker-compose targets skip Supabase cloud slot acquisition (their DB ships in the compose stack). Marks \`database_mode: 'compose-bundled'\` in cycle_context.

**Safety allowlist** (\`rouge-safety-check.sh\`)
Blocks direct \`docker push\` — registry publishing goes through product CI, not agent execution. docker compose/build/run remain allowed for local staging.

**Prompt guidance** (\`00-foundation-building.md\`, \`01-building.md\`)
Dockerfile section: multi-stage, Alpine, system deps (with ffmpeg LGPL vs GPL caveat), .dockerignore, compose stack shape. CI template: GHCR multi-arch buildx+push on release tags.

## Test plan
- [x] deploy-to-staging: 16 tests pass (+2 for docker-compose and docker alias handler lookup)
- [x] safety-hooks: 51 tests pass (+2 blocks for docker push, +4 allows for compose/build/run)
- [x] 270 dashboard tests pass (prompt contract and everything else unaffected)
- [x] 321 root tests pass (1 pre-existing Claude-API wording flake unrelated)