### PR TITLE
fix: flip to Build tab automatically when a build starts

### DIFF
--- a/dashboard/src/components/__tests__/project-tabs.test.tsx
+++ b/dashboard/src/components/__tests__/project-tabs.test.tsx
@@ -42,4 +42,57 @@ describe('ProjectTabs', () => {
     const buildTab = screen.getByRole('tab', { name: /build/i })
     expect(buildTab.hasAttribute('disabled')).toBe(true)
   })
+
+  it('flips to build when defaultTab transitions from spec to build', async () => {
+    // Simulates the post-Start flow: user was on spec while build was
+    // disabled; the build-status poll picks up the running subprocess,
+    // parent recomputes defaultTab from 'spec' to 'build', and the tab
+    // should follow automatically.
+    const { rerender } = render(
+      <ProjectTabs
+        defaultTab="spec"
+        buildDisabled={true}
+        specContent={<div>SPEC</div>}
+        buildContent={<div>BUILD</div>}
+      />
+    )
+    expect(screen.getByText('SPEC')).toBeDefined()
+
+    rerender(
+      <ProjectTabs
+        defaultTab="build"
+        buildDisabled={false}
+        specContent={<div>SPEC</div>}
+        buildContent={<div>BUILD</div>}
+      />
+    )
+    expect(screen.getByText('BUILD')).toBeDefined()
+  })
+
+  it('preserves a user\'s explicit click to Spec after build has started', async () => {
+    const user = userEvent.setup()
+    const { rerender } = render(
+      <ProjectTabs
+        defaultTab="build"
+        buildDisabled={false}
+        specContent={<div>SPEC</div>}
+        buildContent={<div>BUILD</div>}
+      />
+    )
+    // User clicks Spec.
+    await user.click(screen.getByRole('tab', { name: /^spec$/i }))
+    expect(screen.getByText('SPEC')).toBeDefined()
+
+    // Parent rerenders (e.g. poll tick). defaultTab is still 'build';
+    // user's choice should stick.
+    rerender(
+      <ProjectTabs
+        defaultTab="build"
+        buildDisabled={false}
+        specContent={<div>SPEC</div>}
+        buildContent={<div>BUILD</div>}
+      />
+    )
+    expect(screen.getByText('SPEC')).toBeDefined()
+  })
 })

--- a/dashboard/src/components/project-tabs.tsx
+++ b/dashboard/src/components/project-tabs.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { cn } from '@/lib/utils'
 
 type Tab = 'spec' | 'build'
@@ -17,6 +17,17 @@ export function ProjectTabs({
   buildContent: React.ReactNode
 }) {
   const [active, setActive] = useState<Tab>(defaultTab)
+
+  // When the page recomputes defaultTab — most commonly on the 'spec' →
+  // 'build' transition after the user presses Start and the build-status
+  // poll picks up the running subprocess — sync the active tab so the
+  // user is taken to Build automatically. Depending only on defaultTab
+  // (not on every render) means a user's explicit click to Spec after
+  // that initial flip is preserved: defaultTab won't change again while
+  // the build keeps running.
+  useEffect(() => {
+    setActive(defaultTab)
+  }, [defaultTab])
 
   function tabClass(isActive: boolean, isDisabled = false) {
     if (isDisabled) return 'cursor-not-allowed pb-2 text-gray-300'


### PR DESCRIPTION
Small UX fix. `ProjectTabs` seeded its local `active` state from `defaultTab` once on mount and never resynced. Pressing Start recomputed the page's `defaultTab` from 'spec' to 'build' (~5s later when the build-status poll picked up the running subprocess), and the Build tab became clickable — but the active tab stayed on Spec unless the user manually clicked Build.

Sync with a small `useEffect` keyed on `defaultTab`. User's explicit Spec click after the initial flip is preserved: once the build is running `defaultTab` stays 'build' and the effect doesn't re-fire.

Tests: +2 cases (transition flip; explicit user click preserved across rerenders). 272 dashboard tests pass.