### PR TITLE
fix: resolve config-file relative paths against the config's own dir

### DIFF
--- a/dashboard/src/lib/__tests__/server-config.test.ts
+++ b/dashboard/src/lib/__tests__/server-config.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { loadServerConfig } from '../server-config'
+
+// server-config reads rouge-dashboard.config.json from `process.cwd()`
+// first, so we redirect cwd to a temp dir for each test. Also scrub
+// relevant env vars so they don't win over the config.
+let testRoot: string
+let origCwd: string
+let origEnvProjects: string | undefined
+let origEnvCli: string | undefined
+
+beforeEach(() => {
+  testRoot = mkdtempSync(join(tmpdir(), 'server-config-'))
+  origCwd = process.cwd()
+  process.chdir(testRoot)
+
+  origEnvProjects = process.env.ROUGE_PROJECTS_DIR
+  origEnvCli = process.env.ROUGE_CLI
+  delete process.env.ROUGE_PROJECTS_DIR
+  delete process.env.ROUGE_CLI
+})
+
+afterEach(() => {
+  process.chdir(origCwd)
+  if (origEnvProjects === undefined) delete process.env.ROUGE_PROJECTS_DIR
+  else process.env.ROUGE_PROJECTS_DIR = origEnvProjects
+  if (origEnvCli === undefined) delete process.env.ROUGE_CLI
+  else process.env.ROUGE_CLI = origEnvCli
+  rmSync(testRoot, { recursive: true, force: true })
+})
+
+describe('loadServerConfig', () => {
+  it('resolves relative rouge_cli from the config file as an absolute path', () => {
+    // Layout mirrors the real repo: dashboard/rouge-dashboard.config.json
+    // references ../src/launcher/rouge-cli.js. The raw relative string
+    // leaking into callers like build-runner caused #159-followup
+    // (node spawned with cwd of ".." and tried to resolve the loop
+    // script one directory above the repo).
+    writeFileSync(
+      join(testRoot, 'rouge-dashboard.config.json'),
+      JSON.stringify({
+        rouge_cli: '../src/launcher/rouge-cli.js',
+        projects_root: '../projects',
+      }),
+    )
+    const cfg = loadServerConfig()
+    // Expected: resolved against testRoot (config file's dir).
+    expect(cfg.rougeCli.endsWith('/src/launcher/rouge-cli.js')).toBe(true)
+    expect(cfg.rougeCli.startsWith('/')).toBe(true) // absolute
+    expect(cfg.projectsRoot.endsWith('/projects')).toBe(true)
+    expect(cfg.projectsRoot.startsWith('/')).toBe(true)
+    // Specifically — the resolved path goes UP from cwd once. Use
+    // process.cwd() rather than testRoot because macOS resolves
+    // /var/folders → /private/var/folders on chdir.
+    const parent = join(process.cwd(), '..')
+    expect(cfg.rougeCli).toBe(join(parent, 'src/launcher/rouge-cli.js'))
+  })
+
+  it('leaves absolute paths in the config file untouched', () => {
+    writeFileSync(
+      join(testRoot, 'rouge-dashboard.config.json'),
+      JSON.stringify({
+        rouge_cli: '/absolute/path/to/rouge-cli.js',
+        projects_root: '/absolute/projects',
+      }),
+    )
+    const cfg = loadServerConfig()
+    expect(cfg.rougeCli).toBe('/absolute/path/to/rouge-cli.js')
+    expect(cfg.projectsRoot).toBe('/absolute/projects')
+  })
+
+  it('env vars still win over file-based paths', () => {
+    writeFileSync(
+      join(testRoot, 'rouge-dashboard.config.json'),
+      JSON.stringify({ rouge_cli: '../src/launcher/rouge-cli.js' }),
+    )
+    process.env.ROUGE_CLI = '/env/override/rouge-cli.js'
+    const cfg = loadServerConfig()
+    expect(cfg.rougeCli).toBe('/env/override/rouge-cli.js')
+  })
+
+  it('falls back to home-dir defaults when no config and no env', () => {
+    const cfg = loadServerConfig()
+    // Both should end with the expected suffixes (home dir varies).
+    expect(cfg.projectsRoot.endsWith('/.rouge/projects')).toBe(true)
+    expect(cfg.rougeCli.endsWith('/.rouge/bin/rouge')).toBe(true)
+  })
+})

--- a/dashboard/src/lib/server-config.ts
+++ b/dashboard/src/lib/server-config.ts
@@ -27,6 +27,7 @@ export function loadServerConfig(): ServerConfig {
   const envCli = process.env.ROUGE_CLI;
 
   let fileCfg: { projects_root?: string; rouge_cli?: string } = {};
+  let fileCfgDir: string | null = null;
   // Look in cwd first (dev), then in the repo root relative to this file
   // (works when the standalone server.js is run from .next/standalone/).
   const candidates = [
@@ -37,6 +38,7 @@ export function loadServerConfig(): ServerConfig {
     if (existsSync(candidate)) {
       try {
         fileCfg = JSON.parse(readFileSync(candidate, "utf-8"));
+        fileCfgDir = path.dirname(candidate);
         break;
       } catch {
         // ignore parse error; fall through to defaults
@@ -44,15 +46,31 @@ export function loadServerConfig(): ServerConfig {
     }
   }
 
+  // Relative paths in the config file are resolved against the config
+  // file's own directory — that's what the `../src/launcher/rouge-cli.js`
+  // entry actually means. Without this, a raw relative string leaks into
+  // `build-runner.ts`, which does `join(rougeCliPath, '..', '..', '..')`
+  // to derive the subprocess cwd; the cwd comes out as ".." and the
+  // spawned `node ../src/launcher/rouge-loop.js` resolves one directory
+  // above the repo root. The error looks like:
+  //   Cannot find module '/Users/…/ClaudeCode/src/launcher/rouge-loop.js'
+  // instead of `…/ClaudeCode/The-Rouge/src/launcher/rouge-loop.js`.
+  function resolveAgainstConfig(p: string | undefined): string | undefined {
+    if (!p) return undefined;
+    if (path.isAbsolute(p)) return p;
+    if (!fileCfgDir) return p; // no file → nothing to resolve against
+    return path.resolve(fileCfgDir, p);
+  }
+
   const home = homedir();
   return {
     projectsRoot:
       envProjects ||
-      fileCfg.projects_root ||
+      resolveAgainstConfig(fileCfg.projects_root) ||
       path.join(home, ".rouge", "projects"),
     rougeCli:
       envCli ||
-      fileCfg.rouge_cli ||
+      resolveAgainstConfig(fileCfg.rouge_cli) ||
       path.join(home, ".rouge", "bin", "rouge"),
   };
 }


### PR DESCRIPTION
## What you saw
```
Error: Cannot find module '/Users/gregario/Projects/ClaudeCode/src/launcher/rouge-loop.js'
```
Missing `The-Rouge/` segment — one directory too high.

## Why
`loadServerConfig()` returned `rouge_cli` as the raw relative string `../src/launcher/rouge-cli.js` straight from `rouge-dashboard.config.json`. `build-runner.ts` then did `join(rougeCliPath, '..', '..', '..')` to compute the subprocess cwd — which resolved to `'..'`. When the subprocess spawned `node ../src/launcher/rouge-loop.js` from that relative cwd, node resolved the arg relative to the subprocess cwd, walking up one more level than intended.

## Fix
Resolve relative config-file paths against the config file's own directory in `server-config.ts`. Absolute values pass through untouched; env vars still win. Every downstream consumer now gets an absolute path, so `join(rougeCliPath, '..', ...)` behaves predictably no matter where the dashboard process started.

## Test plan
- [x] +4 new server-config tests (relative resolve, absolute passthrough, env-var-wins, no-config defaults)
- [x] 276 dashboard tests pass
- [ ] Manual: press Start on a ready project — build subprocess spawns without ENOENT