### PR TITLE
fix: four bugs surfaced by the post-shipping audit

### DIFF
--- a/dashboard/src/bridge/__tests__/discipline-artifacts.test.ts
+++ b/dashboard/src/bridge/__tests__/discipline-artifacts.test.ts
@@ -105,6 +105,20 @@ describe('verifyDisciplineArtifact', () => {
     expect(verifyDisciplineArtifact(PROJECT_DIR, 'design').ok).toBe(true)
   })
 
+  it('accepts design when the three pass files use underscore names (testimonial session shape)', () => {
+    // Agent wrote pass_1_ux_architecture.yaml etc. even with hyphens
+    // pinned in the sub-prompt. Recognise the work.
+    writeFile('design/pass_1_ux_architecture.yaml', 'x'.repeat(400))
+    writeFile('design/pass_2_component_design.yaml', 'x'.repeat(400))
+    writeFile('design/pass_3_visual_design.yaml', 'x'.repeat(400))
+    expect(verifyDisciplineArtifact(PROJECT_DIR, 'design').ok).toBe(true)
+  })
+
+  it('still rejects when only one underscore-named pass exists (incomplete design)', () => {
+    writeFile('design/pass_1_ux_architecture.yaml', 'x'.repeat(400))
+    expect(verifyDisciplineArtifact(PROJECT_DIR, 'design').ok).toBe(false)
+  })
+
   it('rejects design when only Pass 1 exists (phantom-complete bug from Praise session)', () => {
     writeFile('design/pass-1-ux-architecture.yaml', 'x'.repeat(400))
     // Pass 2 and Pass 3 missing — the exact failure mode the user

--- a/dashboard/src/bridge/__tests__/seed-handler.test.ts
+++ b/dashboard/src/bridge/__tests__/seed-handler.test.ts
@@ -142,6 +142,58 @@ describe('handleSeedMessage — marker verification', () => {
     expect(state.current_discipline).toBe('competition')
   })
 
+  it('preserves pending correction when runClaude times out (no silent loss)', async () => {
+    // Stash a pending correction, then make the next turn time out.
+    // Correction must still be in state afterwards so a subsequent turn
+    // can deliver it.
+    mockRunClaude.mockResolvedValueOnce({
+      result: 'Done.\n\n[DISCIPLINE_COMPLETE: brainstorming]',
+      session_id: 'session-1',
+    })
+    await handleSeedMessage(PROJECT_DIR, 'first')
+    expect(readSeedingState(PROJECT_DIR).pending_correction).toMatch(/was rejected/)
+
+    // Now simulate a timeout on the follow-up turn.
+    mockRunClaude.mockResolvedValueOnce({
+      result: '',
+      session_id: null,
+      timeout: true,
+    })
+    const result = await handleSeedMessage(PROJECT_DIR, 'retry')
+    expect(result.ok).toBe(false)
+    expect(result.status).toBe(504)
+
+    // Correction must still be stashed — we peeked, didn't consume.
+    expect(readSeedingState(PROJECT_DIR).pending_correction).toMatch(/was rejected/)
+
+    // A subsequent turn succeeds and the correction IS delivered and cleared.
+    mockRunClaude.mockResolvedValueOnce({
+      result: 'Understood.',
+      session_id: 'session-1',
+    })
+    await handleSeedMessage(PROJECT_DIR, 'try again')
+    const lastPrompt: string = mockRunClaude.mock.calls[2][0].prompt
+    expect(lastPrompt).toMatch(/was rejected/)
+    expect(readSeedingState(PROJECT_DIR).pending_correction).toBeUndefined()
+  })
+
+  it('preserves pending correction when runClaude rate-limits', async () => {
+    mockRunClaude.mockResolvedValueOnce({
+      result: 'Done.\n\n[DISCIPLINE_COMPLETE: brainstorming]',
+      session_id: 'session-1',
+    })
+    await handleSeedMessage(PROJECT_DIR, 'first')
+
+    mockRunClaude.mockResolvedValueOnce({
+      result: 'you have hit your limit',
+      session_id: 'session-1',
+    })
+    await handleSeedMessage(PROJECT_DIR, 'retry')
+
+    // Rate-limit counts as "Claude didn't act on the correction" — keep it.
+    expect(readSeedingState(PROJECT_DIR).pending_correction).toMatch(/was rejected/)
+  })
+
   it('delivers a prior rejection to Claude on the following turn', async () => {
     // Turn 1: agent emits a marker without the artifact; handler rejects.
     mockRunClaude.mockResolvedValueOnce({

--- a/dashboard/src/bridge/__tests__/seeding-state.test.ts
+++ b/dashboard/src/bridge/__tests__/seeding-state.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, afterEach } from 'vitest'
-import { readSeedingState, writeSeedingState, updateSessionId, markDisciplineComplete, markSeedingComplete } from '../seeding-state'
-import { mkdirSync, rmSync } from 'fs'
+import { readSeedingState, writeSeedingState, updateSessionId, markDisciplineComplete, markSeedingComplete, appendPendingCorrection, peekPendingCorrection, clearPendingCorrection } from '../seeding-state'
+import { mkdirSync, readdirSync, rmSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 
@@ -84,5 +84,43 @@ describe('seeding-state', () => {
     const state = readSeedingState(testDir)
     expect(state.seeding_complete).toBe(true)
     expect(state.status).toBe('complete')
+  })
+
+  it('writeSeedingState leaves no .tmp file behind on success', () => {
+    mkdirSync(testDir, { recursive: true })
+    writeSeedingState(testDir, { session_id: 'a', status: 'active' })
+    writeSeedingState(testDir, { session_id: 'b', status: 'active' })
+    writeSeedingState(testDir, { session_id: 'c', status: 'active' })
+    const stray = readdirSync(testDir).filter((f) => f.endsWith('.tmp'))
+    expect(stray).toEqual([])
+  })
+
+  it('peek returns pending correction without clearing it', () => {
+    mkdirSync(testDir, { recursive: true })
+    writeSeedingState(testDir, { session_id: 's', status: 'active' })
+    appendPendingCorrection(testDir, 'marker X rejected')
+    expect(peekPendingCorrection(testDir)).toBe('marker X rejected')
+    // Still there.
+    expect(peekPendingCorrection(testDir)).toBe('marker X rejected')
+    expect(readSeedingState(testDir).pending_correction).toBe('marker X rejected')
+  })
+
+  it('clear removes the pending correction and preserves other state', () => {
+    mkdirSync(testDir, { recursive: true })
+    writeSeedingState(testDir, { session_id: 's1', status: 'active' })
+    appendPendingCorrection(testDir, 'rejected')
+    clearPendingCorrection(testDir)
+    expect(peekPendingCorrection(testDir)).toBeNull()
+    // Other fields preserved.
+    expect(readSeedingState(testDir).session_id).toBe('s1')
+    expect(readSeedingState(testDir).status).toBe('active')
+  })
+
+  it('clear is a no-op when there is no pending correction', () => {
+    mkdirSync(testDir, { recursive: true })
+    writeSeedingState(testDir, { session_id: 's', status: 'active' })
+    // Should not throw.
+    clearPendingCorrection(testDir)
+    expect(readSeedingState(testDir).session_id).toBe('s')
   })
 })

--- a/dashboard/src/bridge/discipline-artifacts.ts
+++ b/dashboard/src/bridge/discipline-artifacts.ts
@@ -72,6 +72,19 @@ const ARTIFACT_SPECS: Record<Discipline, ArtifactSpec[]> = {
         { path: 'design/pass-3-visual-design.yaml', minBytes: 300 },
       ],
     },
+    // Underscore variant of the three-pass set. Observed in the
+    // testimonial session: the agent wrote `pass_1_ux_architecture.yaml`
+    // rather than `pass-1-...`, even with the hyphenated names pinned
+    // in the sub-prompt. Recognise the work rather than reject 80KB of
+    // real content over a typographic detail.
+    {
+      kind: 'files',
+      paths: [
+        { path: 'design/pass_1_ux_architecture.yaml', minBytes: 300 },
+        { path: 'design/pass_2_component_design.yaml', minBytes: 300 },
+        { path: 'design/pass_3_visual_design.yaml', minBytes: 300 },
+      ],
+    },
     // Fallback: combined design.yaml large enough to plausibly contain
     // all three passes. ~2KB covers the orchestrator's scored-dimension
     // structure for three passes.

--- a/dashboard/src/bridge/seed-handler.ts
+++ b/dashboard/src/bridge/seed-handler.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync } from 'fs'
 import { resolve } from 'path'
 import { runClaude, detectRateLimit, extractMarkers } from './claude-runner'
 import { appendChatMessage } from './chat-reader'
-import { readSeedingState, updateSessionId, markDisciplineComplete, markDisciplinePrompted, markSeedingComplete, setStatus, appendPendingCorrection, consumePendingCorrection } from './seeding-state'
+import { readSeedingState, updateSessionId, markDisciplineComplete, markDisciplinePrompted, markSeedingComplete, setStatus, appendPendingCorrection, peekPendingCorrection, clearPendingCorrection } from './seeding-state'
 import { finalizeSeeding } from './seeding-finalize'
 import { maybeDeriveWorkingTitle } from './derive-title'
 import { loadDisciplinePrompt, type Discipline } from './discipline-prompts'
@@ -121,16 +121,23 @@ async function runSeedingTurn(
   // accumulate around them. Walk in sequence, mark any discipline whose
   // artifact now passes verification, and stop at the first gap so we
   // respect the orchestrator's sequential rule.
-  const reconciled = reconcileDisciplineState(projectDir)
-  if (reconciled.length > 0) {
-    console.log(`[seeding] reconciled stranded disciplines: ${reconciled.join(', ')}`)
-    const note = `[SYSTEM NOTE] Reconciled earlier discipline state: ${reconciled.join(', ')} now marked complete (artifact verified on disk). Seeding continues.`
-    appendChatMessage(projectDir, {
-      id: genId(),
-      role: 'rouge',
-      content: note,
-      timestamp: new Date().toISOString(),
-    })
+  //
+  // Skipped on auto-kickoff turns: the user-initiated turn that
+  // triggered the kickoff just reconciled, and nothing's changed on
+  // disk between that turn and this recursive one. No artifacts have
+  // been written by Claude yet in this kickoff.
+  if (!isKickoff) {
+    const reconciled = reconcileDisciplineState(projectDir)
+    if (reconciled.length > 0) {
+      console.log(`[seeding] reconciled stranded disciplines: ${reconciled.join(', ')}`)
+      const note = `[SYSTEM NOTE] Reconciled earlier discipline state: ${reconciled.join(', ')} now marked complete (artifact verified on disk). Seeding continues.`
+      appendChatMessage(projectDir, {
+        id: genId(),
+        role: 'rouge',
+        content: note,
+        timestamp: new Date().toISOString(),
+      })
+    }
   }
 
   const state = readSeedingState(projectDir)
@@ -181,7 +188,12 @@ async function runSeedingTurn(
   // we appended — its `--resume` only replays the server-side session —
   // so without this, rejections would be invisible to the agent and it
   // would either advance blindly or repeat the same mistake.
-  const pendingCorrection = consumePendingCorrection(projectDir)
+  //
+  // Peek rather than consume: if runClaude times out or errors below,
+  // the correction must stay stashed so the next turn can deliver it.
+  // We only clear after Claude returns successfully (post rate-limit
+  // check).
+  const pendingCorrection = peekPendingCorrection(projectDir)
   if (pendingCorrection) {
     sections.push('---', pendingCorrection)
   }
@@ -209,11 +221,19 @@ async function runSeedingTurn(
   }
 
   // Detect rate limit BEFORE marking the discipline prompted so a rate-
-  // limited turn retries with the same injection next time.
+  // limited turn retries with the same injection next time. Also don't
+  // clear the pending correction — a rate-limit means Claude never got
+  // to act on it.
   if (detectRateLimit(result.result)) {
     setStatus(projectDir, 'paused')
     appendMessages(projectDir, isKickoff ? null : text, result.result, activeDiscipline ?? undefined)
     return { ok: false, status: 429, error: 'Claude rate-limited', rateLimited: true }
+  }
+
+  // Claude returned a real response — the correction (if any) reached
+  // it via the prompt above. Safe to clear now.
+  if (pendingCorrection) {
+    clearPendingCorrection(projectDir)
   }
 
   // We successfully handed the discipline's sub-prompt to Claude; record

--- a/dashboard/src/bridge/seeding-state.ts
+++ b/dashboard/src/bridge/seeding-state.ts
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync, existsSync } from 'fs'
+import { readFileSync, writeFileSync, renameSync, unlinkSync, existsSync } from 'fs'
 import { join } from 'path'
 import { DISCIPLINE_SEQUENCE, type SeedingSessionState } from './types'
 import { statePath } from './state-path'
@@ -21,9 +21,26 @@ export function readSeedingState(projectDir: string): SeedingSessionState {
   }
 }
 
+/**
+ * Atomic write via tmp + rename. `rename(2)` is atomic on POSIX for
+ * paths on the same filesystem, so a concurrent reader never sees a
+ * torn write. Two concurrent *writers* still race (last finished
+ * renames wins) — that's a read-modify-write concern at the caller
+ * level — but at least neither leaves a half-written JSON on disk.
+ * Matches the launcher's existing `writeJson` helper pattern.
+ */
 export function writeSeedingState(projectDir: string, state: SeedingSessionState): void {
   const path = join(projectDir, STATE_FILE)
-  writeFileSync(path, JSON.stringify(state, null, 2))
+  const tmp = `${path}.${process.pid}.${Date.now()}.tmp`
+  try {
+    writeFileSync(tmp, JSON.stringify(state, null, 2))
+    renameSync(tmp, path)
+  } catch (err) {
+    // If tmp exists but rename failed, clean it up so we don't leak
+    // per-turn .tmp files on every failure.
+    try { if (existsSync(tmp)) unlinkSync(tmp) } catch { /* ignore */ }
+    throw err
+  }
 }
 
 export function updateSessionId(projectDir: string, sessionId: string): void {
@@ -129,14 +146,35 @@ export function appendPendingCorrection(projectDir: string, note: string): void 
 }
 
 /**
- * Read and clear any pending correction. Returns null if there was none.
+ * Read any pending correction without clearing it. Use this before
+ * runClaude so that if the turn times out or errors we don't silently
+ * drop the rejection context — the next turn can still deliver it.
  */
-export function consumePendingCorrection(projectDir: string): string | null {
+export function peekPendingCorrection(projectDir: string): string | null {
   const state = readSeedingState(projectDir)
-  const pending = state.pending_correction
-  if (!pending) return null
+  return state.pending_correction ?? null
+}
+
+/**
+ * Clear any pending correction. Call AFTER the correction has been
+ * successfully delivered to Claude (i.e., after runClaude returned
+ * without timeout or error).
+ */
+export function clearPendingCorrection(projectDir: string): void {
+  const state = readSeedingState(projectDir)
+  if (!state.pending_correction) return
   delete state.pending_correction
   state.last_activity = new Date().toISOString()
   writeSeedingState(projectDir, state)
+}
+
+/**
+ * Read and clear any pending correction in one step. Deprecated for
+ * handleSeedMessage (use peek + clear to survive Claude failures), but
+ * retained for paths that atomically need the text now.
+ */
+export function consumePendingCorrection(projectDir: string): string | null {
+  const pending = peekPendingCorrection(projectDir)
+  if (pending) clearPendingCorrection(projectDir)
   return pending
 }


### PR DESCRIPTION
Bundle of audit findings. All four are bugs in code I shipped today.

## 1. DESIGN verifier hyphen-vs-underscore mismatch (blocker)
The testimonial session has \`design/pass_1_ux_architecture.yaml\` (40KB), pass_2 (23KB), pass_3 (18KB) on disk — 80KB of real work. Verifier only recognises hyphenated names. Marker rejected for a typographic detail. Add underscore variants as a second conjunctive check.

## 2. Pending correction lost on Claude timeout/error
\`consumePendingCorrection()\` ran at turn start. A runClaude timeout bailed before delivery; the correction was gone from state with no way back. Split into peek + clear: only clear after a successful, non-rate-limited Claude call.

## 3. Non-atomic seeding-state writes
Plain \`writeFileSync(path, …)\` — a crash mid-write or a concurrent writer could leave a torn JSON. Switched to tmp+rename. Matches the launcher's existing pattern. Concurrent read-modify-write at the caller level remains a separate issue (flagged in the audit) but the file itself is now never half-written.

## 4. Reconciliation on auto-kickoff turns
Redundant — the user-initiated turn that triggered the kickoff just reconciled, and nothing on disk changed in between. Skip when \`isKickoff\`.

## Impact on your current testimonial session
Once this lands, your next user message on testimonial will:
- Reconciliation scans design/ (already reconciled? no — state still says pending for marketing etc.). Actually most disciplines marked — reconciliation is idempotent, nothing to do.
- When the agent re-emits \`[DISCIPLINE_COMPLETE: design]\`, the verifier now accepts the underscore-named files and the marker goes through.
- If you prefer not to wait for the agent to re-emit, the reconciliation pass will pick it up on the next user turn regardless.

## Test plan
- [x] +2 design verifier cases (underscore happy path, underscore-incomplete rejection)
- [x] +2 seed-handler cases (pending correction survives timeout and rate-limit)
- [x] +4 seeding-state cases (peek/clear/atomic-write leaves no .tmp)
- [x] 284 dashboard tests pass (up from 276)