### PR TITLE
fix: Stop on zombie build no longer errors; Start rolls back on launch failure

### DIFF
--- a/dashboard/src/app/api/projects/[name]/start/route.ts
+++ b/dashboard/src/app/api/projects/[name]/start/route.ts
@@ -10,7 +10,7 @@ export async function POST(
 ) {
   const { name } = await params;
   const { projectsRoot, rougeCli } = loadServerConfig();
-  const result = startBuild(projectsRoot, rougeCli, name);
+  const result = await startBuild(projectsRoot, rougeCli, name);
   if (!result.ok) {
     return NextResponse.json({ error: result.error }, { status: 409 });
   }

--- a/dashboard/src/bridge/__tests__/build-runner.test.ts
+++ b/dashboard/src/bridge/__tests__/build-runner.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { stopBuild } from '../build-runner'
+
+// stopBuild tests. startBuild's settlement logic spawns real child
+// processes and is harder to test hermetically — left for integration.
+
+let projectsRoot: string
+
+beforeEach(() => {
+  projectsRoot = mkdtempSync(join(tmpdir(), 'rouge-build-runner-'))
+})
+
+afterEach(() => {
+  rmSync(projectsRoot, { recursive: true, force: true })
+})
+
+function writeProject(slug: string, stateOverrides: Record<string, unknown> = {}): string {
+  const dir = join(projectsRoot, slug)
+  mkdirSync(join(dir, '.rouge'), { recursive: true })
+  writeFileSync(
+    join(dir, '.rouge', 'state.json'),
+    JSON.stringify({ current_state: 'ready', ...stateOverrides }, null, 2),
+  )
+  return dir
+}
+
+describe('stopBuild — idempotent (#161 followup)', () => {
+  it('returns alreadyStopped when no PID file exists, state is ready', async () => {
+    writeProject('alpha', { current_state: 'ready' })
+    const result = await stopBuild(projectsRoot, 'alpha')
+    expect(result.ok).toBe(true)
+    if (result.ok && 'alreadyStopped' in result) {
+      expect(result.alreadyStopped).toBe(true)
+      expect(result.stateRolledBack).toBeUndefined()
+    } else {
+      throw new Error('expected alreadyStopped')
+    }
+  })
+
+  it('rolls back zombie foundation state to ready when no PID exists', async () => {
+    // Exact symptom from the testimonial session after the ENOENT Start
+    // crash: state claims foundation, no PID. Pressing Stop should
+    // succeed idempotently AND clean up the state.
+    const dir = writeProject('alpha', { current_state: 'foundation' })
+    const result = await stopBuild(projectsRoot, 'alpha')
+    expect(result.ok).toBe(true)
+    if (result.ok && 'alreadyStopped' in result) {
+      expect(result.alreadyStopped).toBe(true)
+      expect(result.stateRolledBack).toBe(true)
+    } else {
+      throw new Error('expected alreadyStopped with rollback')
+    }
+    const state = JSON.parse(readFileSync(join(dir, '.rouge', 'state.json'), 'utf-8'))
+    expect(state.current_state).toBe('ready')
+  })
+
+  it('rolls back zombie story-building state to ready', async () => {
+    const dir = writeProject('alpha', { current_state: 'story-building' })
+    const result = await stopBuild(projectsRoot, 'alpha')
+    expect(result.ok).toBe(true)
+    const state = JSON.parse(readFileSync(join(dir, '.rouge', 'state.json'), 'utf-8'))
+    expect(state.current_state).toBe('ready')
+  })
+
+  it('does NOT roll back non-build states (seeding, complete, escalation)', async () => {
+    const dir = writeProject('alpha', { current_state: 'seeding' })
+    const result = await stopBuild(projectsRoot, 'alpha')
+    expect(result.ok).toBe(true)
+    const state = JSON.parse(readFileSync(join(dir, '.rouge', 'state.json'), 'utf-8'))
+    // Seeding stays seeding — Stop is not meant to retreat from seeding.
+    expect(state.current_state).toBe('seeding')
+  })
+
+  it('cleans up a stale PID file (dead process) via readBuildInfo', async () => {
+    const dir = writeProject('alpha', { current_state: 'foundation' })
+    // PID 999999 — essentially guaranteed not to exist.
+    writeFileSync(
+      join(dir, '.build-pid'),
+      JSON.stringify({ pid: 999999, startedAt: new Date().toISOString() }),
+    )
+    const result = await stopBuild(projectsRoot, 'alpha')
+    expect(result.ok).toBe(true)
+    // readBuildInfo (called inside stopBuild) removes the stale file; the
+    // idempotent-stop branch then runs and rolls back state.
+    expect(existsSync(join(dir, '.build-pid'))).toBe(false)
+    const state = JSON.parse(readFileSync(join(dir, '.rouge', 'state.json'), 'utf-8'))
+    expect(state.current_state).toBe('ready')
+  })
+})

--- a/dashboard/src/bridge/build-runner.ts
+++ b/dashboard/src/bridge/build-runner.ts
@@ -57,11 +57,11 @@ export function readBuildInfo(projectDir: string): BuildInfo | null {
  * rouge-cli.js's `build` command just sets ROUGE_PROJECT_FILTER and spawns the
  * same file — we skip the wrapper to avoid an extra process layer.
  */
-export function startBuild(
+export async function startBuild(
   projectsRoot: string,
   rougeCliPath: string,
   slug: string,
-): { ok: true; pid: number; alreadyRunning?: boolean } | { ok: false; error: string } {
+): Promise<{ ok: true; pid: number; alreadyRunning?: boolean } | { ok: false; error: string }> {
   const projectDir = join(projectsRoot, slug)
   if (!existsSync(projectDir)) {
     return { ok: false, error: 'Project not found' }
@@ -71,11 +71,19 @@ export function startBuild(
   // 'story-building' if foundation is already complete). The Rouge loop
   // skips projects in 'ready' state — it's waiting for a human trigger.
   // This matches what the Slack bot does in its `start` command.
+  //
+  // We remember the prior state so we can roll back if the subprocess
+  // fails to launch — otherwise a failed Start leaves the project
+  // looking like it's building when no process exists, and the UI shows
+  // Stop against a zombie (the exact symptom from the earlier ENOENT
+  // crash; see audit finding A in #161 followup).
   const statePath = resolveStatePath(projectDir)
+  let priorCurrentState: string | null = null
   if (existsSync(statePath)) {
     try {
       const state = JSON.parse(readFileSync(statePath, 'utf-8'))
       if (state.current_state === 'ready' || state.current_state === 'seeding') {
+        priorCurrentState = state.current_state
         const foundationComplete = state.foundation?.status === 'complete'
         state.current_state = foundationComplete ? 'story-building' : 'foundation'
         writeFileSync(statePath, JSON.stringify(state, null, 2))
@@ -91,6 +99,19 @@ export function startBuild(
     }
   }
 
+  const rollbackState = () => {
+    if (priorCurrentState === null) return
+    try {
+      const st = JSON.parse(readFileSync(statePath, 'utf-8'))
+      if (st.current_state === 'foundation' || st.current_state === 'story-building') {
+        st.current_state = priorCurrentState
+        writeFileSync(statePath, JSON.stringify(st, null, 2))
+      }
+    } catch {
+      // best effort
+    }
+  }
+
   // Check if a build is already running — if so, the state transition above
   // is enough to kick it into gear on the next loop tick.
   const existing = readBuildInfo(projectDir)
@@ -101,9 +122,11 @@ export function startBuild(
   // Derive rouge-loop.js path from the CLI path (they're in the same dir)
   const loopScript = join(rougeCliPath, '..', 'rouge-loop.js')
   if (!existsSync(loopScript)) {
+    rollbackState()
     return { ok: false, error: `rouge-loop.js not found at ${loopScript}` }
   }
 
+  let child: ReturnType<typeof spawn>
   try {
     // Redirect stdout/stderr to a log file so the loop's output is captured
     // (and user can diagnose hangs). Must open files first because the child
@@ -111,7 +134,7 @@ export function startBuild(
     const logPath = join(projectDir, 'build.log')
     const logFd = openSync(logPath, 'a') // append mode
     // Leave stdin as 'ignore' — the loop reads from files, not stdin.
-    const child = spawn('node', [loopScript], {
+    child = spawn('node', [loopScript], {
       detached: true,
       stdio: ['ignore', logFd, logFd],
       // Run from the Rouge repo root (parent of src/launcher/), matching the
@@ -122,42 +145,85 @@ export function startBuild(
         ROUGE_PROJECT_FILTER: slug,
       },
     })
-    // Detach: don't keep parent event loop alive on child's account
-    child.unref()
-
-    if (!child.pid) {
-      return { ok: false, error: 'Failed to spawn process' }
-    }
-
-    const info: BuildInfo = {
-      pid: child.pid,
-      startedAt: new Date().toISOString(),
-    }
-    writeFileSync(join(projectDir, PID_FILE), JSON.stringify(info, null, 2))
-    return { ok: true, pid: child.pid }
   } catch (err) {
+    rollbackState()
     return {
       ok: false,
       error: err instanceof Error ? err.message : String(err),
     }
   }
+
+  child.unref()
+
+  if (!child.pid) {
+    rollbackState()
+    return { ok: false, error: 'Failed to spawn process' }
+  }
+
+  // Wait briefly for settlement. spawn() can succeed with a valid PID
+  // but the child may immediately crash (node can't find the script,
+  // module load throws, etc.) — see the ENOENT incident that prompted
+  // this rollback logic. If the subprocess exits within the settlement
+  // window, we roll state back so the user doesn't see a zombie Stop
+  // button against a project that was never really building.
+  const SETTLEMENT_MS = 800
+  const settled = await new Promise<{ exited: boolean; code: number | null }>((resolve) => {
+    const t = setTimeout(() => resolve({ exited: false, code: null }), SETTLEMENT_MS)
+    child.once('exit', (code) => {
+      clearTimeout(t)
+      resolve({ exited: true, code })
+    })
+  })
+
+  if (settled.exited) {
+    rollbackState()
+    return {
+      ok: false,
+      error: `build subprocess exited immediately (code ${settled.code ?? '?'}) — check build.log`,
+    }
+  }
+
+  // Still alive after settlement — consider the launch successful.
+  const info: BuildInfo = {
+    pid: child.pid,
+    startedAt: new Date().toISOString(),
+  }
+  writeFileSync(join(projectDir, PID_FILE), JSON.stringify(info, null, 2))
+  return { ok: true, pid: child.pid }
 }
+
+type StopResult =
+  | { ok: true; killed: 'sigint' | 'sigkill' }
+  | { ok: true; alreadyStopped: true; stateRolledBack?: boolean }
+  | { ok: false; error: string }
 
 /**
  * Stop a running build. Sends SIGINT first (clean shutdown — the Rouge launcher
  * exits with code 130 on SIGINT). If the process is still alive after `graceMs`,
  * escalate to SIGKILL. Note: the launcher deliberately ignores SIGTERM as a
  * daemon-resilience feature, so we don't use it.
+ *
+ * Idempotent: if no PID exists, returns `{ok: true, alreadyStopped: true}`
+ * rather than an error. Stop is semantically "ensure stopped" — if nothing
+ * is running, that's already the case, so pressing Stop twice or pressing
+ * Stop on a zombie shouldn't pop an error overlay.
+ *
+ * Zombie-state recovery: if the build PID is gone but
+ * `state.current_state` is still a building state (`foundation` /
+ * `story-building`), roll the state back to `ready`. This repairs the
+ * inconsistency left behind by earlier failed Starts (pre-rollback
+ * logic) so the user can press Start again without hand-editing state.
  */
 export async function stopBuild(
   projectsRoot: string,
   slug: string,
   graceMs = 5000,
-): Promise<{ ok: true; killed: 'sigint' | 'sigkill' } | { ok: false; error: string }> {
+): Promise<StopResult> {
   const projectDir = join(projectsRoot, slug)
   const info = readBuildInfo(projectDir)
   if (!info) {
-    return { ok: false, error: 'No build running for this project' }
+    const stateRolledBack = rollbackZombieBuildState(projectDir)
+    return { ok: true, alreadyStopped: true, ...(stateRolledBack ? { stateRolledBack: true } : {}) }
   }
 
   const { pid } = info
@@ -190,6 +256,29 @@ export async function stopBuild(
   await sleep(200)
   cleanupPidFile(projectDir)
   return { ok: true, killed: 'sigkill' }
+}
+
+/**
+ * If state.current_state claims the project is building but no PID file
+ * exists, flip it back to `ready`. Returns true if a rollback was
+ * performed. Caller uses this on the idempotent-stop path to recover
+ * from a half-started session.
+ */
+function rollbackZombieBuildState(projectDir: string): boolean {
+  const statePath = resolveStatePath(projectDir)
+  if (!existsSync(statePath)) return false
+  try {
+    const state = JSON.parse(readFileSync(statePath, 'utf-8'))
+    const cur = state.current_state
+    if (cur === 'foundation' || cur === 'story-building') {
+      state.current_state = 'ready'
+      writeFileSync(statePath, JSON.stringify(state, null, 2))
+      return true
+    }
+  } catch {
+    // best effort
+  }
+  return false
 }
 
 function cleanupPidFile(projectDir: string): void {

--- a/dashboard/src/components/__tests__/action-bar.test.tsx
+++ b/dashboard/src/components/__tests__/action-bar.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// Stub the bridge client so we can drive the command result paths.
+const mockSendCommand = vi.fn()
+const mockFetchBuildStatus = vi.fn()
+vi.mock('@/lib/bridge-client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/bridge-client')>()
+  return {
+    ...actual,
+    isBridgeEnabled: () => true,
+    sendCommand: (slug: string, command: string, body?: object) =>
+      mockSendCommand(slug, command, body),
+    fetchBuildStatus: (slug: string) => mockFetchBuildStatus(slug),
+  }
+})
+
+import { ActionBar } from '../action-bar'
+
+beforeEach(() => {
+  mockSendCommand.mockReset()
+  mockFetchBuildStatus.mockReset()
+  mockFetchBuildStatus.mockResolvedValue({ running: false, startedAt: null })
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('ActionBar — command result surfacing', () => {
+  it('shows an inline notice when stop succeeds on an already-stopped build', async () => {
+    const user = userEvent.setup()
+    mockSendCommand.mockResolvedValueOnce({ ok: true, alreadyStopped: true })
+
+    render(<ActionBar state="foundation" slug="alpha" />)
+
+    // Click the Stop Build button in the action bar. After click, a
+    // confirmation dialog appears with a second "Stop Build" button —
+    // click the dialog one (last in the list).
+    const stopButtons = () => screen.getAllByRole('button', { name: /^stop build$/i })
+    await user.click(stopButtons()[0])
+    await waitFor(() => expect(stopButtons().length).toBeGreaterThan(1))
+    await user.click(stopButtons().at(-1)!)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('action-bar-notice')).toBeInTheDocument()
+    })
+    expect(screen.getByTestId('action-bar-notice')).toHaveTextContent(/already stopped/i)
+    expect(screen.queryByTestId('action-bar-error')).not.toBeInTheDocument()
+  })
+
+  it('shows a stronger notice when zombie state was rolled back', async () => {
+    const user = userEvent.setup()
+    mockSendCommand.mockResolvedValueOnce({
+      ok: true,
+      alreadyStopped: true,
+      stateRolledBack: true,
+    })
+
+    render(<ActionBar state="foundation" slug="alpha" />)
+
+    const stopButton = await screen.findByRole('button', { name: /stop build/i })
+    await user.click(stopButton)
+    const confirmButton = screen.getAllByRole('button', { name: /^stop build$/i }).at(-1)!
+    await user.click(confirmButton)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('action-bar-notice')).toBeInTheDocument()
+    })
+    expect(screen.getByTestId('action-bar-notice')).toHaveTextContent(/back to Ready/i)
+  })
+
+  it('surfaces command errors inline instead of throwing to console.error', async () => {
+    const user = userEvent.setup()
+    mockSendCommand.mockRejectedValueOnce(new Error('something went wrong'))
+
+    // Spy on console.error to confirm we don't call it (which would
+    // trigger Next.js's dev overlay).
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    render(<ActionBar state="foundation" slug="alpha" />)
+
+    const stopButton = await screen.findByRole('button', { name: /stop build/i })
+    await user.click(stopButton)
+    const confirmButton = screen.getAllByRole('button', { name: /^stop build$/i }).at(-1)!
+    await user.click(confirmButton)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('action-bar-error')).toBeInTheDocument()
+    })
+    expect(screen.getByTestId('action-bar-error')).toHaveTextContent(/stop failed/i)
+    expect(screen.getByTestId('action-bar-error')).toHaveTextContent(/something went wrong/i)
+    expect(errSpy).not.toHaveBeenCalled()
+    errSpy.mockRestore()
+  })
+
+  it('shows a hint when state claims building but buildRunning poll is false', async () => {
+    render(<ActionBar state="foundation" slug="alpha" />)
+    // Poll returns running:false (default in beforeEach).
+    await waitFor(() => {
+      expect(
+        screen.getByText(/state says building but no process detected/i),
+      ).toBeInTheDocument()
+    })
+  })
+})

--- a/dashboard/src/components/action-bar.tsx
+++ b/dashboard/src/components/action-bar.tsx
@@ -21,6 +21,8 @@ export function ActionBar({ state, slug, productionUrl, escalation }: ActionBarP
   const [buildRunning, setBuildRunning] = useState(false)
   const [confirmAction, setConfirmAction] = useState<'start' | 'stop' | null>(null)
   const [buildStartedAt, setBuildStartedAt] = useState<string | null>(null)
+  const [commandError, setCommandError] = useState<string | null>(null)
+  const [commandNotice, setCommandNotice] = useState<string | null>(null)
 
   // Poll build status every 5s so the button reflects subprocess state
   // even before the Rouge loop has written its first checkpoint.
@@ -49,8 +51,19 @@ export function ActionBar({ state, slug, productionUrl, escalation }: ActionBarP
   const runCommand = useCallback(async (command: string) => {
     if (!slug || !isBridgeEnabled()) return
     setLoading(command)
+    setCommandError(null)
+    setCommandNotice(null)
     try {
-      await sendCommand(slug, command)
+      const result = await sendCommand(slug, command)
+      // Idempotent stop: surface a brief notice so the user sees the
+      // action had a useful effect even though nothing was running.
+      if (command === 'stop' && result?.alreadyStopped) {
+        if (result.stateRolledBack) {
+          setCommandNotice('Build was not running. Cleared stale state — project is back to Ready.')
+        } else {
+          setCommandNotice('Build was already stopped.')
+        }
+      }
       // Refresh build status after start/stop
       if (command === 'start' || command === 'stop') {
         try {
@@ -60,7 +73,11 @@ export function ActionBar({ state, slug, productionUrl, escalation }: ActionBarP
         } catch {}
       }
     } catch (err) {
-      console.error(`[bridge] Command "${command}" failed:`, err)
+      // Caught errors used to go through console.error, which Next.js's
+      // dev-mode overlay hooks. Show them inline next to the button
+      // instead — same information reaches the user without the red box.
+      const msg = err instanceof Error ? err.message : String(err)
+      setCommandError(`${command} failed: ${msg}`)
     } finally {
       setLoading(null)
     }
@@ -104,9 +121,25 @@ export function ActionBar({ state, slug, productionUrl, escalation }: ActionBarP
       >
         <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-2 sm:px-6 lg:px-8">
           <span className="text-xs text-muted-foreground">
-            {stateHint(state)}
+            {stateHint(state, buildRunning)}
           </span>
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-3">
+            {commandError && (
+              <span
+                className="text-xs text-red-700"
+                data-testid="action-bar-error"
+              >
+                {commandError}
+              </span>
+            )}
+            {commandNotice && !commandError && (
+              <span
+                className="text-xs text-muted-foreground"
+                data-testid="action-bar-notice"
+              >
+                {commandNotice}
+              </span>
+            )}
             {(state === 'escalation' || state === 'waiting-for-human') && escalation && (
               <Button
                 variant="outline"
@@ -197,7 +230,7 @@ function formatElapsed(startedAt: string): string {
   return `${hrs}h ${mins % 60}m`
 }
 
-function stateHint(state: ProjectState): string {
+function stateHint(state: ProjectState, buildRunning: boolean): string {
   switch (state) {
     case 'ready':
       return 'Project is specced and ready to build'
@@ -211,7 +244,12 @@ function stateHint(state: ProjectState): string {
     case 'generating-change-spec':
     case 'vision-check':
     case 'shipping':
-      return 'Build in progress'
+      // state.json says building, but no subprocess is polling as alive
+      // → half-started session. The Stop button's idempotent path will
+      // roll this back to Ready when clicked.
+      return buildRunning
+        ? 'Build in progress'
+        : 'State says building but no process detected — press Stop to clean up'
     case 'waiting-for-human':
       return 'Waiting for your input'
     case 'escalation':


### PR DESCRIPTION
Closes the Stop-button Next.js overlay symptom and the underlying state-consistency hole it pointed at. Four coordinated fixes from the post-shipping audit.

**A. startBuild rollback on failed launch** — state.current_state was flipped to 'foundation' BEFORE spawn; failures (ENOENT from pre-#160, immediate child crash, etc.) left a zombie. Now: remember prior state, wrap spawn, and settle-wait ~800ms for early exits to roll back on.

**B. Idempotent Stop** — `{ok:true, alreadyStopped:true}` when no PID exists. If state says building but PID is absent, roll back to 'ready' as a bonus. Unsticks your testimonial project on the next Stop press.

**C. Errors render inline, not via console.error** — Next.js's dev overlay hooks console.error even on caught errors. Switched to setError UI state. Also added setNotice for positive feedback on idempotent paths.

**D. State hint distinguishes real build from zombie** — 'State says building but no process detected — press Stop to clean up' instead of 'Build in progress' when the poll disagrees with state.json.

**Test plan**
- [x] build-runner: +5 (idempotent stop, zombie-foundation rollback, zombie-story-building rollback, seeding stays, stale-PID cleanup)
- [x] action-bar: +4 (alreadyStopped notice, rolled-back notice, inline error + console.error not called, zombie-state hint)
- [x] 293 dashboard tests pass (up from 284)