### PR TITLE
fix(audit): PR-G low — Slack retired, prompt tests (caught 2 bugs), robustness polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ rouge status
 
 The dashboard is your control plane: real-time project visibility, escalation responses, build logs, milestone progress, and seeding sessions. One process, one port, auto-opens in your browser. Start it with `rouge dashboard start` (background) or `rouge dashboard` (foreground). Global installs ship a prebuilt Next.js standalone server — cold start is ~2s, no dev toolchain required. Pass `--no-open` to skip the auto-open.
 
-For teams that already live in Slack, Rouge also supports a Slack bot as an alternative control plane — see [Slack setup](docs/how-to/slack-setup.md). The dashboard and Slack bot should not run simultaneously for the same project.
+A Slack bot integration exists in `src/slack/` but is no longer recommended — the dashboard is the supported control surface. See [docs/how-to/slack-setup.md](docs/how-to/slack-setup.md) if you're keeping a pre-existing Slack setup running.
 
 ### The loop
 
@@ -193,20 +193,9 @@ rouge secrets list
 
 Secrets stored in your OS credential store (macOS Keychain, Linux secret-service, Windows Credential Manager). Rouge never sees the values.
 
-### Alternative: Slack control plane (experimental)
+### Alternative: Slack control plane (retired)
 
-For teams that already live in Slack, Rouge can send notifications and accept commands via a Slack bot. The Slack integration is functional but secondary to the dashboard — the dashboard provides richer visibility and doesn't require external tokens.
-
-```bash
-rouge slack setup     # Prints step-by-step guide
-rouge setup slack     # Store tokens (3 required: bot, app, webhook)
-rouge slack start     # Start the bot
-rouge slack test      # Verify
-```
-
-See [docs/how-to/slack-setup.md](docs/how-to/slack-setup.md) for the full guide.
-
-> **Note:** The dashboard and Slack bot should not run simultaneously for the same project — they both write to `state.json` and can race. Use `rouge.config.json` `control_plane` field (`"frontend"` or `"slack"`) to choose one. Dashboard is the default.
+The Slack bot control plane is retired and no longer recommended. Code stays in `src/slack/` for users with existing setups; new features and bug fixes land in the dashboard only. See [docs/how-to/slack-setup.md](docs/how-to/slack-setup.md) if you're keeping a pre-existing setup.
 
 ### Build a product
 

--- a/dashboard/src/bridge/scanner.ts
+++ b/dashboard/src/bridge/scanner.ts
@@ -148,11 +148,11 @@ interface V2FeatureArea {
   status: string
 }
 
-interface RawEscalation {
-  tier: number
-  summary: string
-  status: string
-}
+// Narrow alias of the canonical RougeEscalation shape for scanner's
+// internal summary computation. Keep in sync by structurally pulling
+// the fields we actually read — TypeScript complains if bridge/types.ts
+// drops any of these.
+type RawEscalation = Pick<import('./types').RougeEscalation, 'tier' | 'summary' | 'status'>
 
 interface CycleContext {
   infrastructure?: {

--- a/dashboard/src/components/activity-log.tsx
+++ b/dashboard/src/components/activity-log.tsx
@@ -267,8 +267,11 @@ function ToggleHeader({
         type="button"
         onClick={() => onToggleVerbose(!verbose)}
         className="text-xs font-medium text-blue-600 hover:text-blue-800"
+        title={verbose
+          ? 'Collapse back to critical events (milestones, escalations, deploys)'
+          : 'Include every checkpoint alongside critical events'}
       >
-        {verbose ? 'Show critical' : 'Show all'}
+        {verbose ? 'Show critical only' : 'Show all events'}
       </button>
     </div>
   )

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -1,6 +1,6 @@
 # The Rouge — Technical Architecture
 
-> ⚠️ **Onboarding sections are being refactored.** The canonical user-facing path is now dashboard-first: run `rouge setup`, open the dashboard, click **New Project**. Sections below describing Slack-based seeding as the primary entry point are out of date. See `docs/plans/2026-04-15-onboarding-refactor.md`.
+> ⚠️ **V2 document retained as architectural record.** This describes the V2 state machine (qa-gate, po-reviewing, feature_areas, etc). V3 replaced those states with a richer evaluation sub-phase chain (02a test-integrity → 02c code-review → 02d product-walk → 02e evaluation), dual-ledger task tracking (`task_ledger.json` + `checkpoints.jsonl`), and dashboard-first onboarding. Cross-reference `src/launcher/rouge-loop.js` `STATE_TO_PROMPT` for the live state map and `CLAUDE.md` for the current loop-phase contract. This doc is NOT updated as the state machine evolves; treat it as an explanatory snapshot of the original design.
 
 **Date:** 2026-03-17
 **Status:** Approved (explore session complete, pending spec update)

--- a/docs/how-to/slack-setup.md
+++ b/docs/how-to/slack-setup.md
@@ -1,6 +1,10 @@
 # Slack Setup Guide
 
-> 🧪 **Experimental.** Slack as a full control plane is no longer the recommended path. The dashboard is now the primary control surface; Slack is being repositioned as notifications + lightweight remote commands. See `docs/plans/2026-04-15-onboarding-refactor.md`. This guide still works if you want it, but expect the setup flow to move into a dashboard wizard in an upcoming phase.
+> ⚠️ **Retired.** The Slack control plane is no longer recommended and is not covered by ongoing maintenance. The dashboard at `http://localhost:3000` is the supported control surface for seeding, monitoring, and responding to escalations. The Slack integration code remains in `src/slack/` for users who had it wired up before this change, but expect feature parity with the dashboard to drift. New features land in the dashboard only.
+>
+> If you're setting up Rouge for the first time, skip this document and use the dashboard — `rouge init` then open the URL it prints.
+>
+> If you had the Slack bot running and want to keep it, the original setup instructions remain below for reference. Report issues, but don't expect active development.
 
 Connect Rouge to Slack so you can seed products via conversation, monitor autonomous builds, and control everything with slash commands.
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "scripts": {
     "test": "node tests/secrets.test.js && node tests/cli.test.js && node tests/self-improve.test.js && node tests/auth-mode.test.js && node --test test/launcher/*.test.js test/prompts/*.test.js test/integration/*.test.js",
+    "test:all": "npm test && npm run dashboard:test",
     "dashboard": "cd dashboard && npm run dev",
     "dashboard:install": "cd dashboard && npm install",
     "dashboard:build": "cd dashboard && npm ci --include=dev && npm run build && node ../scripts/stage-standalone.js",

--- a/src/launcher/preamble-injector.js
+++ b/src/launcher/preamble-injector.js
@@ -42,11 +42,18 @@ function buildPreamble({ phaseName, phaseDescription, modelName, requiredOutputK
     preamble = preamble.replace('{{required_output_keys}}', '(none specified)');
   }
 
-  // Learnings
+  // Learnings — escape `{{` / `}}` in the user-supplied content so
+  // literal mustache-looking text in learnings.md doesn't accidentally
+  // collide with preamble template placeholders on the next pass.
+  // Audit G9.
   if (learningsContent && learningsContent.trim()) {
+    const safeLearnings = learningsContent
+      .trim()
+      .replace(/\{\{/g, '\\{\\{')
+      .replace(/\}\}/g, '\\}\\}');
     preamble = preamble.replace(
       '{{learnings_section}}',
-      `### Project learnings\n${learningsContent.trim()}`
+      `### Project learnings\n${safeLearnings}`
     );
   } else {
     preamble = preamble.replace('{{learnings_section}}', '');

--- a/src/launcher/secrets.js
+++ b/src/launcher/secrets.js
@@ -314,10 +314,20 @@ const windows = {
   },
 
   get(service, key) {
+    // Pipe stderr so PowerShell errors (permissions, CredRead P/Invoke
+    // failures) surface in the log. Exit code 1 with empty stderr means
+    // "credential not found" — silent null is correct. Anything else
+    // is a real failure the operator needs to see. Audit G13.
     const r = winSpawn('get', service, key, {
-      stdio: ['ignore', 'pipe', 'ignore'],
+      stdio: ['ignore', 'pipe', 'pipe'],
     });
-    if (r.status !== 0) return null;
+    if (r.status !== 0) {
+      const err = (r.stderr || '').trim();
+      if (err) {
+        console.warn(`[secrets:windows] get ${service}/${key} failed (status ${r.status}): ${err.slice(0, 400)}`);
+      }
+      return null;
+    }
     return r.stdout || null;
   },
 
@@ -339,8 +349,17 @@ const windows = {
   },
 
   delete(service, key) {
-    const r = winSpawn('delete', service, key, { stdio: 'ignore' });
-    return r.status === 0;
+    const r = winSpawn('delete', service, key, {
+      stdio: ['ignore', 'ignore', 'pipe'],
+    });
+    if (r.status !== 0) {
+      const err = (r.stderr || '').trim();
+      if (err) {
+        console.warn(`[secrets:windows] delete ${service}/${key} failed (status ${r.status}): ${err.slice(0, 400)}`);
+      }
+      return false;
+    }
+    return true;
   },
 };
 

--- a/src/prompts/seeding/06-legal-privacy.md
+++ b/src/prompts/seeding/06-legal-privacy.md
@@ -197,3 +197,15 @@ When complete, produce a legal status object and pass it to the orchestrator:
 **If `regulated_domain_flags` is non-empty or `trademark_status` is BLOCKED**, the orchestrator must loop back to TASTE for scope adjustment before proceeding.
 
 **If `blocking_issues` is non-empty**, seeding cannot proceed until the human resolves them.
+
+---
+
+## Discipline complete
+
+When every artifact in `files_written` is on disk and no `blocking_issues` remain, emit:
+
+```
+[DISCIPLINE_COMPLETE: legal-privacy]
+```
+
+The handler verifies the files are present before advancing to MARKETING.

--- a/src/prompts/seeding/07-marketing.md
+++ b/src/prompts/seeding/07-marketing.md
@@ -256,3 +256,15 @@ When complete, report to the orchestrator:
 - You do not generate images, screenshots, or visual assets. You describe what should be captured.
 - You do not write code beyond the HTML scaffold. Engineering builds the real page.
 - You do not invent metrics, user counts, or testimonials. Placeholders only.
+
+---
+
+## Discipline complete
+
+When every marketing artifact is on disk (at minimum: positioning/narrative + hook + scaffold or launch brief), emit:
+
+```
+[DISCIPLINE_COMPLETE: marketing]
+```
+
+The handler verifies the files are present before advancing to INFRASTRUCTURE (or, if infrastructure is skipped, finalising seeding).

--- a/test/prompts/seeding-contract.test.js
+++ b/test/prompts/seeding-contract.test.js
@@ -1,0 +1,64 @@
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+
+// Seeding prompts run during the interactive swarm phase. They have
+// different expectations than loop prompts — they converse with the
+// user, emit [GATE:] / [DECISION:] / [HEARTBEAT:] markers, and write
+// discipline artifacts to disk. This suite covers the contract that
+// the dashboard + orchestrator rely on.
+
+const SEEDING_DIR = path.join(__dirname, '../../src/prompts/seeding');
+const SEEDING_FILES = fs.readdirSync(SEEDING_DIR)
+  .filter((f) => f.endsWith('.md') && !f.startsWith('_') && !f.startsWith('00-swarm'))
+  .sort();
+
+describe('Seeding prompt contract', () => {
+  test('all discipline prompts present', () => {
+    // Eight disciplines + conditional infrastructure. If a new one
+    // appears, the orchestrator DISCIPLINE_SEQUENCE needs updating too.
+    assert.ok(SEEDING_FILES.length >= 8, `Expected at least 8 discipline prompts, found ${SEEDING_FILES.length}: ${SEEDING_FILES.join(', ')}`);
+  });
+
+  for (const file of SEEDING_FILES) {
+    describe(file, () => {
+      const content = fs.readFileSync(path.join(SEEDING_DIR, file), 'utf8');
+
+      test('declares at least one hard gate', () => {
+        // Each discipline needs a hard-gate checkpoint so Rouge pauses
+        // for the human before finalising. Found via the [GATE:] marker
+        // convention or an explicit "H1 / H2" hard-gate header.
+        const hasMarker = /\[GATE:\s*H\d/i.test(content);
+        const hasHeader = /^##\s*H\d[\s\.:]/m.test(content);
+        const hasHardGateSection = /hard gate/i.test(content);
+        // Infrastructure is conditional — if it mentions "conditional"
+        // or "skipped", a missing gate is acceptable.
+        const isConditional = /conditional|skipped when|opt[- ]out/i.test(content);
+        assert.ok(
+          hasMarker || hasHeader || hasHardGateSection || isConditional,
+          `${file} has no visible hard-gate checkpoint`,
+        );
+      });
+
+      test('writes a discipline artifact', () => {
+        // Every discipline produces at least one file on disk for the
+        // next phase to read. This test only checks that the prompt
+        // explicitly mentions writing something — it doesn't verify
+        // the file path matches.
+        const writes = /write|produce|emit|save|output/i.test(content);
+        assert.ok(writes, `${file} never mentions writing output`);
+      });
+
+      test('emits DISCIPLINE_COMPLETE marker at end', () => {
+        // The handler watches for [DISCIPLINE_COMPLETE: <name>] to
+        // advance state. Missing this marker means the discipline
+        // never finishes from the dashboard's perspective.
+        assert.ok(
+          /\[DISCIPLINE_COMPLETE:/i.test(content),
+          `${file} missing [DISCIPLINE_COMPLETE:] marker`,
+        );
+      });
+    });
+  }
+});


### PR DESCRIPTION
## Scope

Fourth and final PR from the 2026-04-18 full-codebase audit. Follows PR-D (#164), PR-E (#164), PR-F (#165). Low-severity long-tail items.

Four sub-commits on `fix/audit-low`:
- d19d397 — G.docs (G4, G8, G11, G15)
- eb0d897 — G.robustness (G9, G12, G13, G14)
- 74eab37 — G.tests (G1, G5)
- [this PR includes] G.dashboard scoping + G-final

## What's in this PR

### G.docs (d19d397)

- **G8 Slack retired** — control plane officially not recommended. README collapses the "Alternative control plane" section to a single sentence, `docs/how-to/slack-setup.md` opens with a ⚠️ Retired banner. Code stays in `src/slack/` for pre-existing setups.
- **G11 toggle label** — activity "Show all" → "Show all events" / "Show critical only" with a tooltip.
- **G4 architecture.md** — the V2 doc gets a clear pointer to V3 authority (`rouge-loop.js STATE_TO_PROMPT` + `CLAUDE.md`).
- **G15 prompt link rot** — delegated scan across all 27 loop + seeding prompts confirmed zero broken file references.

### G.robustness (eb0d897)

- **G9** — `preamble-injector` escapes `{{` / `}}` in `learningsContent` before injection.
- **G12** — not reproducible. `deployWithRetry` returns `{ url: null, blocked: true }` on exhaust; every callsite gates on `shouldBlockMilestoneCheck`. Already correct.
- **G13** — Windows secrets backend pipes stderr on `get()` + `delete()` and logs PowerShell failures when stderr is non-empty.
- **G14** — scanner's local `RawEscalation` is now `Pick<RougeEscalation, 'tier' | 'summary' | 'status'>`. Full `ProjectDetail` / `Escalation` consolidation across `lib/` vs `bridge/` is deferred — those are legitimately different layers (UI vs backend) and warrant their own PR.

### G.tests (74eab37)

- **G1 seeding prompt contract** — `test/prompts/seeding-contract.test.js` covers all 8 discipline prompts. Each must declare a hard gate, write an artifact, and emit `[DISCIPLINE_COMPLETE: <name>]`. **Caught two real bugs**: `06-legal-privacy.md` and `07-marketing.md` were both missing the `DISCIPLINE_COMPLETE` marker — seeding would have stalled indefinitely on either discipline. Both fixed.
- **G5 root test orchestrator** — `npm run test:all` runs launcher + dashboard suites sequentially.

### G.dashboard scoping

Audit G2 flagged 8 missing dashboard affordances. Discovery: 2 already exist.

| # | Widget | Status |
|---|---|---|
| 1 | Self-improvement loop status widget | Deferred — needs a new backend endpoint reading `prompt_improvement_proposals` |
| 2 | Linked projects / dependency graph viewer | Deferred — needs `registry.json` reader + graph component |
| 3 | Library / catalogue browser | **Present** (`/catalogue`) |
| 4 | Milestone tagging / custom workflows | Deferred — larger product feature |
| 5 | Aggregate spending dashboard | **Present** (`/platform` shows totalSpend + cap usage) |
| 6 | Spec diff viewer (revise mode) | Deferred — git-style diff component |
| 7 | Liveness chip on project cards | Partial — state badge shows, `awaiting_gate` indicator deferred (needs plumbing through scanner → bridge-types → mapper → card) |
| 8 | Discipline gating indicators in spec-tab-content | Deferred |

Six of the eight are new-feature work; committing thin placeholders without backend support would be cosmetic theatre. Each deserves its own PR with real data flow, so they're flagged as follow-ups rather than half-shipped here.

## Deferred from PR-G

- **G3** launcher test coverage (`provision-infrastructure`, `deploy-blocking`, `context-assembly`) — individually non-trivial; each deserves its own PR with real fixtures.
- **G6** real CLI integration test — requires sandboxed `rouge-cli` spawn + fake project dir.
- **G7** catalogue manifest schema enforcement — needs ajv + schema authoring (blocked by E7).
- **G10** feasibility end-to-end — `feasibility.js` already has 27 unit tests passing; CLI-spawn integration is nice-to-have.
- **G2** six of eight dashboard affordances (see table above).
- **Full `ProjectDetail` / `Escalation` type consolidation** across `lib/` vs `bridge/` (G14 partial).

All deferred items logged for future PRs.

## Test plan

- [x] Dashboard: 371 tests pass (49 suites)
- [x] Launcher: 381 tests pass (up from 356 — 25 new from seeding contract)
- [x] Pre-existing `allowed-tools-behavior.test.js` passed on this run; was previously flaky
- [x] `npm run test:all` succeeds

## The audit is done

With this PR merged, all ~120 findings from the 2026-04-18 full-codebase audit are either shipped, documented as not-needed, or explicitly deferred to named follow-up PRs with scope. The living plan (`docs/plans/2026-04-18-full-codebase-audit.md` — gitignored, local-only) has the complete status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)