### PR TITLE
docs: post-audit sweep — Opus default, dashboard-first, Slack retired

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Taste encoded as testable signals: "page load under 2 seconds," "core tasks in 3
 
 Rouge runs on your Claude Code subscription. Each phase consumes session time (roughly 10-20 minutes of model time). A simple product takes a few hours. A complex product might take a day or more across sessions.
 
-Rouge uses per-phase model selection: Opus for reasoning-heavy phases (analyse, architecture, backwards flow), Sonnet for mechanical phases (formatting, catalogue entry drafting, status updates). In practice this delivers a 40-50% cost reduction versus running everything on Opus.
+Rouge runs on Opus by default for every phase. One exception: `milestone-check` is a boolean "are all stories done?" bookkeeping step that runs on Sonnet. Prior versions split work more aggressively between the two models to chase cost savings, but the "mechanical" phases (foundation, shipping, story-diagnosis) turned out to be judgement-heavy in practice and the quality delta wasn't worth the 30-40% cost dip. Override per-phase via `rouge.config.json.model_overrides`.
 
 If you run via API keys, token costs apply. These are rough estimates — actual costs depend on product complexity, evaluation cycles, and how many fix stories the loop generates:
 

--- a/VISION.md
+++ b/VISION.md
@@ -59,7 +59,7 @@ Rouge itself should:
 - CLI and developer experience improvements
 - The Library (new heuristics, better calibration)
 - Decomposition improvements (better complexity detection, smarter dependency ordering)
-- Slack control plane improvements
+- Dashboard improvements (live event streaming, richer project detail, onboarding wizard, cost forecasting)
 
 ### Out of scope (for now)
 
@@ -84,6 +84,6 @@ Rouge itself should:
 | **Composable decomposition** | Complexity profiles, foundation cycles, dependency ordering, backwards flow | Can it handle complex products without wasting cycles on rework? |
 | **Integration catalogue** | Tier 1-3 entries, validation, self-growing mechanism | Are patterns practical, tested, and honest about trade-offs? |
 | **The Library** | Global heuristics, domain-specific taste, learned judgment | Does the quality bar produce good products? Does it learn? |
-| **CLI** | init, seed, build, status, cost, doctor, slack, setup | Can a new developer go from install to first build without friction? |
-| **Slack control plane** | Bot, notifications, commands, feedback ingestion | Can you monitor and control Rouge from your phone? |
-| **Safety** | Hooks, deploy restrictions, secret handling | Does Rouge prevent itself from doing damage? |
+| **CLI** | init, seed, build, status, cost, doctor, setup | Can a new developer go from install to first build without friction? |
+| **Dashboard** | Real-time visibility, escalation responses, build logs, seeding chat, aggregate spend, catalogue browser | Can you monitor and control Rouge from a browser? |
+| **Safety** | Hooks, deploy restrictions, secret handling, state locks, loopback guards, schema validation | Does Rouge prevent itself from doing damage? |

--- a/docs/how-to/setup.md
+++ b/docs/how-to/setup.md
@@ -1,6 +1,6 @@
 # The Rouge — Setup Guide
 
-> ⚠️ **Onboarding is being refactored.** The canonical path is now: run `rouge setup`, open the dashboard, click **New Project**. The Slack and CLI steps below still work but are no longer the recommended path for new users. See `docs/plans/2026-04-15-onboarding-refactor.md` for the full plan.
+> **Dashboard-first** — the fast path for new users is `rouge setup` → `rouge dashboard start` → open `http://localhost:3000` → **New Project**. The CLI steps below cover the per-integration configuration (OS keychain, Cloudflare, Supabase, Sentry, GitHub). Slack steps remain for pre-existing setups but are retired — new installs should ignore them.
 
 One-time setup for running The Rouge on your machine.
 
@@ -44,7 +44,7 @@ supabase projects list  # verify
 stripe login
 # Opens browser for pairing. One-time.
 # ⚠️ Key expires every 90 days. Check: grep test_mode_key_expires_at ~/.config/stripe/config.toml
-# The launcher checks expiry on startup and notifies via Slack.
+# The launcher checks expiry on startup and raises an escalation in the dashboard if expired.
 ```
 
 **IMPORTANT:** Rouge only uses Stripe test/sandbox keys. Never configure production keys.
@@ -62,15 +62,9 @@ gh auth login
 # One-time. Used for PRs and repo management.
 ```
 
-## 3. Slack App
+## 3. Slack App (retired — skip for new installs)
 
-1. Go to [api.slack.com/apps](https://api.slack.com/apps) and create a new app
-2. Enable **Socket Mode** (Settings > Socket Mode > toggle on)
-3. Create an **App-Level Token** with `connections:write` scope → save as `SLACK_APP_TOKEN`
-4. Add **Bot Token Scopes**: `chat:write`, `channels:history`, `app_mentions:read`, `channels:read`
-5. Enable **Event Subscriptions**: `app_mention`, `message.channels`
-6. Install to workspace → save Bot Token as `SLACK_BOT_TOKEN`
-7. Create an **Incoming Webhook** → save URL as `ROUGE_SLACK_WEBHOOK`
+The Slack bot control plane is retired. If you already have a working Slack setup and want to keep it, see [slack-setup.md](./slack-setup.md). Otherwise skip this section — the dashboard covers everything Slack did and more.
 
 ## 4. Secrets Management
 
@@ -79,10 +73,10 @@ Rouge stores secrets in the OS credential store (macOS Keychain, Linux secret-se
 Use the interactive setup command for each integration:
 
 ```bash
-rouge setup slack       # Stores SLACK_BOT_TOKEN, SLACK_APP_TOKEN, ROUGE_SLACK_WEBHOOK
 rouge setup stripe      # Stores STRIPE_SECRET_KEY, STRIPE_PUBLISHABLE_KEY
 rouge setup supabase    # Stores SUPABASE_URL, SUPABASE_ANON_KEY, SUPABASE_SERVICE_KEY
 rouge setup cloudflare  # Stores CLOUDFLARE_API_TOKEN, CLOUDFLARE_ACCOUNT_ID
+# rouge setup slack     # Retired — only run if migrating a pre-existing setup
 ```
 
 Verify what's stored:
@@ -94,22 +88,26 @@ rouge doctor           # Shows which integrations are configured
 ## 5. Start The Rouge
 
 ```bash
-# Start the Slack bot (loads tokens from secrets store)
-rouge slack start
+# Start the dashboard (your control plane — auto-opens http://localhost:3000)
+rouge dashboard start       # Background mode, survives terminal close
+# or: rouge dashboard       # Foreground (for debugging)
 
-# In another terminal: start the build loop
-rouge build <project-name>
+# From the dashboard: click New Project → spec → build.
+# Or from the CLI:
+rouge init <project-name>
+rouge seed <project-name>   # Interactive seeding
+rouge build <project-name>  # Kick off the autonomous loop
 ```
 
-> **Important:** Do NOT run `cd src/slack && node bot.js` directly — it will crash with `AppInitializationError` because tokens are not loaded. Always use `rouge slack start`, which loads tokens from the secrets store before starting the bot.
+Global installs ship a prebuilt Next.js standalone server — no dev toolchain needed. Pass `--no-open` to skip the auto-open on `rouge dashboard start`.
 
-## 6. Dashboard (Optional)
+### Dashboard from source (dev-only)
 
-The dashboard is integrated into the repo at `dashboard/`. To set it up:
+Only needed if you're developing Rouge itself:
 
 ```bash
-npm run dashboard:install   # Install dashboard dependencies
-rouge dashboard             # Start the dashboard dev server
+npm run dashboard:install   # Install dashboard dependencies once
+npm run dashboard           # Dev server with HMR
 ```
 
 ## 7. Morning Briefing (Optional)

--- a/docs/how-to/troubleshooting.md
+++ b/docs/how-to/troubleshooting.md
@@ -21,8 +21,8 @@ PolyForm Noncommercial for personal use. [$100/month Commercial tier](https://gi
 **How do I contribute?**
 See [CONTRIBUTING.md](../../CONTRIBUTING.md).
 
-**Can I use Rouge without Slack?**
-Yes. You lose notifications and the control plane (start, pause, feedback from your phone). Without Slack, you monitor via `rouge status` and stop/start from the terminal.
+**Do I need Slack?**
+No — it's retired and no longer recommended. The dashboard (`rouge dashboard start`, opens at `http://localhost:3000`) is the supported control surface: start/stop, pause, seeding chat, escalation responses, build logs, aggregate spend. Slack code remains in `src/slack/` for pre-existing setups; new features land in the dashboard.
 
 ---
 

--- a/docs/tutorials/quickstart.md
+++ b/docs/tutorials/quickstart.md
@@ -40,16 +40,9 @@ Get from zero to your first Rouge-built product in 5 minutes.
    rouge dashboard start   # Background mode — survives terminal close
    ```
 
-   The dashboard is your primary control plane: real-time project visibility, escalation responses, build logs, and milestone progress. Open [http://localhost:3001](http://localhost:3001) after starting.
+   The dashboard is your control plane: real-time project visibility, escalation responses, build logs, seeding chat, milestone progress, and aggregate spend. It auto-opens in your browser at [http://localhost:3000](http://localhost:3000) on first start. Pass `--no-open` to skip the auto-open.
 
-5. (Optional) Set up Slack:
-
-   ```bash
-   rouge setup slack       # Interactive — stores tokens in OS keychain
-   rouge slack start       # Start the Slack bot
-   ```
-
-   Slack is an alternative control plane for teams that already live there. The dashboard provides richer visibility and doesn't require external tokens.
+5. (Optional, legacy) Slack bot setup is retired — `src/slack/` remains for pre-existing installs but isn't recommended. Use the dashboard.
 
 ## Your First Product
 

--- a/docs/tutorials/your-first-product.md
+++ b/docs/tutorials/your-first-product.md
@@ -15,7 +15,7 @@ Run `rouge doctor` and make sure everything is green. If anything is red, fix it
 
 **Start simple.** Your first Rouge product should not be a fleet management SaaS with 5 feature areas and a map integration. Pick something with 2-3 features. A recipe organiser. A habit tracker. A reading list. You want to learn the loop, not stress-test it.
 
-**Set up Slack.** Seriously. The whole point of autonomous building is that you walk away and check your phone. If Slack isn't set up, you're staring at a terminal. See [slack-setup.md](../how-to/slack-setup.md).
+**Start the dashboard.** `rouge dashboard start` opens a browser window at `http://localhost:3000`. That's your cockpit: live build logs, escalation responses, seeding chat, and project status. The whole point of autonomous building is that you walk away and check back — the dashboard keeps the state visible without needing you at a terminal.
 
 ## Initialise
 
@@ -67,9 +67,9 @@ In Slack, you'll see:
 
 > **Rouge:** Building my-first-app — story "add-task-list" (milestone: core-features)
 
-You can walk away now. Check `rouge status` whenever you're curious. Or watch the Slack channel from your phone. The loop runs until it's done or it needs you.
+You can walk away now. Check `rouge status` whenever you're curious, or watch the dashboard at `http://localhost:3000`. The loop runs until it's done or it hits an escalation that needs you.
 
-How long? For a simple product, expect 2-4 hours of session time. Most stories take 20-40 minutes. The per-phase model selection uses Opus for building and reasoning, Sonnet for mechanical evaluation work — so costs are lower than you'd expect.
+How long? For a simple product, expect 2-4 hours of session time. Most stories take 20-40 minutes. Rouge runs on Opus for every phase by default except `milestone-check` (a boolean "are all stories done?" bookkeeping step, which uses Sonnet).
 
 ## What happens during the loop
 


### PR DESCRIPTION
## Scope

First follow-up from the post-audit plan (`docs/plans/2026-04-18-audit-followups.md`, gitignored local doc). Six docs files brought into alignment with the state of the codebase after PR-D/E/F/G merged (#164 / #165 / #166).

## What this fixes

Three themes drifting through the docs:

1. **Opus-default model policy** (F3 in PR-F). README and tutorials claimed an aggressive Opus/Sonnet split with 40-50% cost savings. That split got reversed — Opus is now default for every phase except `milestone-check` (a boolean bookkeeping step). The old framing misled readers about cost.

2. **Dashboard-first onboarding** (shipped over several PRs; documented inconsistently). Setup.md, quickstart, and the first-product tutorial all still framed Slack as the primary control plane with dashboard as the alternative. Reversed.

3. **Slack retirement** (G8 in PR-G). The setup wizard step for Slack, the Slack feature-area row in VISION, and the "Can I use Rouge without Slack?" FAQ all implied Slack was still a supported path. Collapsed to pointers for pre-existing installs.

## Files touched

- `README.md` — Economics section rewritten (Opus default).
- `VISION.md` — In-scope items + feature areas updated; Slack row swapped for Dashboard.
- `docs/how-to/setup.md` — Dashboard-first; Slack section collapsed; port fixed (3000 not 3001); Stripe expiry escalation via dashboard.
- `docs/how-to/troubleshooting.md` — "Do I need Slack?" answer inverted.
- `docs/tutorials/quickstart.md` — Step 5 collapsed; URL fixed; control-plane framing reversed.
- `docs/tutorials/your-first-product.md` — "Set up Slack. Seriously." → "Start the dashboard."; model paragraph updated.

## Out of scope

- `docs/explanation/architecture.md` — V2 snapshot, retained with deprecation banner from PR-G.
- Plans/research/session-log docs — known to drift by design.
- CLI reference regeneration — separate follow-up.

## Test plan

- [x] 381 launcher tests pass
- [x] 371 dashboard tests pass
- [x] No state-machine behaviour changed; no behavioural tests needed for docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)