### PR TITLE
refactor(types): one canonical RougeEscalation in bridge/types.ts

### DIFF
--- a/dashboard/src/bridge/types.ts
+++ b/dashboard/src/bridge/types.ts
@@ -69,14 +69,19 @@ export interface EscalationHumanResponse {
 export interface RougeEscalation {
   id: string
   tier: number
-  classification: string
-  summary: string
+  classification?: string
+  summary?: string
   story_id?: string
   status: string
   created_at: string
   resolution?: string
   resolved_at?: string
   human_response?: EscalationHumanResponse
+  // Legacy fallbacks read by the bridge-mapper for state.json shapes
+  // from earlier Rouge versions that populated these fields. Canonical
+  // emitters (04-analyzing, 07-ship-promote) use `summary` + `classification`.
+  reason?: string
+  state?: string
 }
 
 // V2 project state (legacy — countdowntimer, fruit-and-veg)

--- a/dashboard/src/lib/bridge-mapper.ts
+++ b/dashboard/src/lib/bridge-mapper.ts
@@ -15,6 +15,7 @@ import type {
   SeedingDiscipline,
   DisciplineStatus,
 } from '@/lib/types'
+import type { RougeEscalation } from '@/bridge/types'
 
 interface RougeStory {
   id: string
@@ -37,20 +38,6 @@ interface RougeMilestone {
   stories: RougeStory[]
   started_at?: string
   completed_at?: string
-}
-
-interface RougeEscalation {
-  id: string
-  tier: number
-  classification?: string
-  summary?: string
-  reason?: string
-  state?: string
-  story_id?: string
-  status: string
-  created_at: string
-  resolution?: string
-  resolved_at?: string
 }
 
 interface RougeState {


### PR DESCRIPTION
## Scope

Item 2 from the post-audit follow-ups plan (`docs/plans/2026-04-18-audit-followups.md`). Type consolidation: collapse the duplicate `RougeEscalation` in `bridge-mapper.ts` into the canonical one in `bridge/types.ts`.

## Why

Two declarations had already drifted:
- `bridge/types.ts` had `classification` and `summary` as required.
- `bridge-mapper.ts` had them as optional, plus two extra fields (`reason`, `state`) for legacy state.json shapes the mapper defensively reads.

Drift-prone and avoidable. The mapper is the explicit boundary between the backend shape (`RougeEscalation`) and the UI shape (`Escalation` in `lib/types.ts`); the backend type should live in one place.

## What changed

- `bridge/types.ts` — `RougeEscalation.classification` + `.summary` are now optional; adopted `.reason` and `.state` with a comment explaining they're legacy fallbacks.
- `bridge-mapper.ts` — deleted the local duplicate; imports the canonical type from `@/bridge/types`.

## Out of scope

- `lib/types.ts Escalation` — UI layer, structurally distinct from the backend shape. Retained as-is.
- `lib/types.ts ProjectDetail` — UI layer; single declaration. Clean.
- Scanner's `RawEscalation` — already `Pick<RougeEscalation, ...>` from PR-G.

## Test plan

- [x] 371 dashboard tests pass
- [x] TypeScript compiles (enforced by vitest's vite pipeline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)