### PR TITLE
test: launcher coverage bundle — context-assembly + real CLI integration

### DIFF
--- a/test/integration/cli-integration.test.js
+++ b/test/integration/cli-integration.test.js
@@ -1,0 +1,102 @@
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const { spawnSync } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+// Real CLI spawn tests. Covers G6 (real rouge-cli spawn) and G10
+// (feasibility end-to-end). Unlike tests/cli.test.js (which mocks
+// execFileSync and verifies call sites), these actually invoke the
+// binary in a sandboxed tmp dir so regressions in argument parsing
+// or command dispatch get caught.
+
+const CLI = path.resolve(__dirname, '..', '..', 'src', 'launcher', 'rouge-cli.js');
+
+function runCli(args, opts = {}) {
+  const { env: extraEnv, ...rest } = opts;
+  return spawnSync('node', [CLI, ...args], {
+    encoding: 'utf8',
+    timeout: 15000,
+    ...rest,
+    env: {
+      ...process.env,
+      // Force the none-secrets backend so tests don't prompt for
+      // keychain access on CI or dev machines.
+      ROUGE_SECRETS_BACKEND: 'none',
+      ...(extraEnv || {}),
+    },
+  });
+}
+
+describe('CLI integration — real spawn', () => {
+  test('rouge --help exits 0 and mentions core commands', () => {
+    const r = runCli(['--help']);
+    // --help may exit 0 or 1 depending on implementation; what we
+    // care about is that it ran and produced structured output.
+    assert.ok(r.status === 0 || r.status === 1, `unexpected exit ${r.status}: ${r.stderr}`);
+    const combined = (r.stdout || '') + (r.stderr || '');
+    assert.match(combined, /init/);
+    assert.match(combined, /seed/);
+    assert.match(combined, /build/);
+    assert.match(combined, /status/);
+  });
+
+  test('rouge with no args prints usage', () => {
+    const r = runCli([]);
+    const combined = (r.stdout || '') + (r.stderr || '');
+    assert.ok(combined.length > 0, 'expected usage output');
+  });
+
+  test('rouge init creates a project directory at ROUGE_PROJECTS_DIR', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'rouge-cli-init-'));
+    try {
+      const r = runCli(['init', 'test-project'], {
+        cwd: tmp,
+        env: { ROUGE_PROJECTS_DIR: tmp },
+      });
+      assert.equal(r.status, 0, `init failed: ${r.stderr}`);
+      const projectDir = path.join(tmp, 'test-project');
+      assert.ok(fs.existsSync(projectDir), 'project dir not created');
+      // init itself only creates the directory + a .gitkeep; state.json
+      // appears during seeding. Just verify the dir landed at the right
+      // place with ROUGE_PROJECTS_DIR honoured.
+      const combined = (r.stdout || '') + (r.stderr || '');
+      assert.match(combined, /Project created/i);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('rouge init rejects existing project name', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'rouge-cli-init-'));
+    try {
+      const first = runCli(['init', 'dupe'], { cwd: tmp, env: { ROUGE_PROJECTS_DIR: tmp } });
+      assert.equal(first.status, 0);
+      const second = runCli(['init', 'dupe'], { cwd: tmp, env: { ROUGE_PROJECTS_DIR: tmp } });
+      assert.notEqual(second.status, 0, 'expected non-zero exit on duplicate init');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('rouge feasibility "add mapbox-geocoding" produces a structured verdict', () => {
+    const r = runCli(['feasibility', 'add mapbox geocoding for address lookup']);
+    assert.equal(r.status, 0, `feasibility failed: ${r.stderr}`);
+    const combined = (r.stdout || '') + (r.stderr || '');
+    // Verdict is one of: ready, escalate, defer
+    assert.match(combined, /proceed|escalate|defer/i);
+    // Output should include the four checks by name
+    assert.match(combined, /scope/i);
+    assert.match(combined, /knowledge/i);
+    assert.match(combined, /tools/i);
+    assert.match(combined, /testab/i);
+  });
+
+  test('rouge feasibility with --type integration is accepted', () => {
+    const r = runCli(['feasibility', '--type', 'integration', 'add resend email transactional']);
+    assert.equal(r.status, 0, `typed feasibility failed: ${r.stderr}`);
+    const combined = (r.stdout || '') + (r.stderr || '');
+    assert.match(combined, /proceed|escalate|defer/i);
+  });
+});

--- a/test/launcher/context-assembly.test.js
+++ b/test/launcher/context-assembly.test.js
@@ -1,0 +1,101 @@
+const { test, describe, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  assembleStoryContext,
+  assembleMilestoneContext,
+  assembleFixStoryContext,
+} = require('../../src/launcher/context-assembly.js');
+
+describe('context-assembly', () => {
+  let dir;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ctx-assembly-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  function writeCtx(data) {
+    fs.writeFileSync(path.join(dir, 'cycle_context.json'), JSON.stringify(data));
+  }
+
+  test('assembleStoryContext throws when story ID not found in state', () => {
+    writeCtx({ vision: { product_name: 'test', one_liner: 'x' } });
+    const state = {
+      current_milestone: 'ms-1',
+      current_story: 'missing-story',
+      milestones: [{ name: 'ms-1', stories: [{ id: 's1', name: 'a' }] }],
+    };
+    assert.throws(() => assembleStoryContext(dir, state, null), /missing-story/);
+  });
+
+  test('assembleStoryContext produces a story_context.json with the expected shape', () => {
+    writeCtx({
+      vision: {
+        product_name: 'test',
+        one_liner: 'one liner',
+        target_audience: { primary: 'dev' },
+        deploy_model: 'vercel',
+      },
+      product_standard: { tone: 'neutral' },
+      library_heuristics: ['heuristic-1'],
+    });
+    const state = {
+      current_milestone: 'ms-1',
+      current_story: 's1',
+      milestones: [{
+        name: 'ms-1',
+        stories: [{ id: 's1', name: 'add auth', status: 'in-progress' }],
+      }],
+      fix_patterns: {},
+      shipped_insights: [],
+    };
+    const outPath = assembleStoryContext(dir, state, { id: 's1', name: 'add auth' });
+    assert.ok(fs.existsSync(outPath));
+    const out = JSON.parse(fs.readFileSync(outPath, 'utf8'));
+    assert.equal(out._type, 'story_context');
+    assert.equal(out.story.id, 's1');
+    assert.match(out.vision_summary, /test.*one liner/);
+    assert.ok(out.product_standard);
+  });
+
+  test('assembleMilestoneContext produces a milestone_context.json', () => {
+    writeCtx({ vision: { product_name: 'test' } });
+    const state = {
+      current_milestone: 'ms-1',
+      milestones: [{
+        name: 'ms-1',
+        status: 'in-progress',
+        stories: [
+          { id: 's1', name: 'a', status: 'done' },
+          { id: 's2', name: 'b', status: 'done' },
+        ],
+      }],
+    };
+    const outPath = assembleMilestoneContext(dir, state);
+    assert.ok(fs.existsSync(outPath));
+    const out = JSON.parse(fs.readFileSync(outPath, 'utf8'));
+    assert.equal(out._type, 'milestone_context');
+  });
+
+  test('assembleFixStoryContext writes fix_story_context.json', () => {
+    writeCtx({ vision: { product_name: 'test' } });
+    const state = {
+      current_milestone: 'ms-1',
+      current_story: 's1',
+      milestones: [{
+        name: 'ms-1',
+        stories: [{ id: 's1', name: 'a', status: 'blocked', attempts: 1 }],
+      }],
+      fix_memory: { s1: [{ attempt: 1, outcome: 'failed' }] },
+    };
+    const outPath = assembleFixStoryContext(dir, state);
+    assert.ok(fs.existsSync(outPath));
+  });
+});


### PR DESCRIPTION
## Scope

Item 4 from the post-audit follow-ups plan. Closes G3 (partial), G6, and G10 from the original audit.

## What this adds

- **`test/launcher/context-assembly.test.js`** — 4 tests covering `assembleStoryContext` / `assembleMilestoneContext` / `assembleFixStoryContext`.
- **`test/integration/cli-integration.test.js`** — 6 real-spawn tests. Unlike the existing mocked `cli.test.js`, these actually invoke `node rouge-cli.js` in a sandboxed tmp dir. Catches regressions in argument parsing, env var honouring (ROUGE_PROJECTS_DIR), command dispatch.

## Deferred

- `provision-infrastructure.js` — CLI script with no exports (just `main()`). Testing requires heavy subprocess mocking of cloudflare + supabase. Own PR.

## Test plan

- [x] 397 launcher tests pass (10 new)
- [x] 371 dashboard tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)