### PR TITLE
feat(dashboard): liveness chip + discipline gate indicators (gated-autonomy plumbing)

### DIFF
--- a/dashboard/src/app/api/projects/[name]/route.ts
+++ b/dashboard/src/app/api/projects/[name]/route.ts
@@ -5,6 +5,7 @@ import { loadServerConfig } from "@/lib/server-config";
 import { statePath, writeStateJson } from "@/bridge/state-path";
 import { withStateLock } from "@/bridge/state-lock";
 import { readBuildInfo } from "@/bridge/build-runner";
+import { safeReadJson } from "@/lib/safe-read-json";
 import { guardMutation } from "@/lib/route-guards";
 import { sanitizedErrorResponse } from "@/lib/error-response";
 import { isPlaceholderSlug, slugify, uniqueSlug } from "@/bridge/slug";
@@ -53,6 +54,18 @@ export async function GET(
   // itself; `null` means nothing is running. See audit E9.
   const build = readBuildInfo(projectDir);
 
+  // Gated-autonomy signals from seeding-state so the detail page can
+  // surface a "Rouge is waiting on X" indicator without needing a
+  // second fetch. Matches the shape the scanner already exposes for
+  // project cards.
+  const seeding = safeReadJson<{
+    mode?: string;
+    pending_gate?: { discipline?: string };
+    last_heartbeat_at?: string;
+  } | null>(join(projectDir, "seeding-state.json"), null, {
+    context: `detail:gated-autonomy:${name}`,
+  });
+
   return NextResponse.json({
     slug: name,
     ...merged,
@@ -65,6 +78,9 @@ export async function GET(
     buildRunning: !!build,
     buildPid: build?.pid,
     buildStartedAt: build?.startedAt,
+    awaitingGate: seeding?.mode === "awaiting_gate",
+    pendingGateDiscipline: seeding?.pending_gate?.discipline,
+    lastHeartbeatAt: seeding?.last_heartbeat_at,
   });
 }
 

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -60,6 +60,9 @@ function mapBridgeProjects(data: Record<string, unknown>[]): ProjectSummary[] {
       firstMessagePreview: typeof p.firstMessagePreview === 'string' ? p.firstMessagePreview : undefined,
       archived: Boolean(p.archived),
       archivedAt: typeof p.archivedAt === 'string' ? p.archivedAt : undefined,
+      awaitingGate: p.awaitingGate === true ? true : undefined,
+      pendingGateDiscipline: typeof p.pendingGateDiscipline === 'string' ? p.pendingGateDiscipline : undefined,
+      lastHeartbeatAt: typeof p.lastHeartbeatAt === 'string' ? p.lastHeartbeatAt : undefined,
     }
   })
 }

--- a/dashboard/src/app/projects/[name]/page.tsx
+++ b/dashboard/src/app/projects/[name]/page.tsx
@@ -376,6 +376,7 @@ export default function ProjectPage({
               onSelectDiscipline={setSelectedDiscipline}
               reviseLocked={buildRunning}
               reviseLockReason="Stop the build to revise the spec"
+              pendingGateDiscipline={project.pendingGateDiscipline}
             />
           }
           buildContent={buildContent}

--- a/dashboard/src/bridge/scanner.ts
+++ b/dashboard/src/bridge/scanner.ts
@@ -286,6 +286,28 @@ function readLastCheckpoint(projectDir: string): { costUsd?: number; timestamp?:
   } catch { return {} }
 }
 
+function readGatedAutonomySignals(projectDir: string): {
+  awaitingGate?: boolean
+  pendingGateDiscipline?: string
+  lastHeartbeatAt?: string
+} {
+  const seedingPath = join(projectDir, 'seeding-state.json')
+  if (!existsSync(seedingPath)) return {}
+  const seeding = safeReadJson<{
+    mode?: string
+    pending_gate?: { discipline?: string }
+    last_heartbeat_at?: string
+  } | null>(seedingPath, null, {
+    context: `scanner:gated-autonomy:${projectDir.split('/').pop()}`,
+  })
+  if (!seeding) return {}
+  return {
+    awaitingGate: seeding.mode === 'awaiting_gate',
+    pendingGateDiscipline: seeding.pending_gate?.discipline,
+    lastHeartbeatAt: seeding.last_heartbeat_at,
+  }
+}
+
 function normalizeProject(
   slug: string,
   raw: Record<string, unknown>,
@@ -348,6 +370,8 @@ function normalizeProject(
   // no turns).
   const lastActivityAt = computeLastActivity(projectDir, lastCheckpoint.timestamp)
 
+  const gateSignals = readGatedAutonomySignals(projectDir)
+
   return {
     name,
     slug,
@@ -371,5 +395,6 @@ function normalizeProject(
     hasStateFile: true,
     providers,
     deploymentUrl,
+    ...gateSignals,
   }
 }

--- a/dashboard/src/bridge/types.ts
+++ b/dashboard/src/bridge/types.ts
@@ -125,6 +125,15 @@ export interface BridgeProjectSummary {
   isPlaceholderName?: boolean
   archived?: boolean
   archivedAt?: string
+  // Gated-autonomy signals for the dashboard "awaiting you" chip.
+  // Populated from seeding-state.json while the project is seeding;
+  // all three are optional because legacy projects (or non-seeding
+  // states) won't carry them. `awaitingGate` is the primary signal;
+  // the other two let the UI explain *what* is being waited on and
+  // *how stale* the last autonomous beat is.
+  awaitingGate?: boolean
+  pendingGateDiscipline?: string
+  lastHeartbeatAt?: string
 }
 
 // ─── Seeding chat log ────────────────────────────────────────────────

--- a/dashboard/src/components/discipline-stepper.tsx
+++ b/dashboard/src/components/discipline-stepper.tsx
@@ -79,6 +79,9 @@ interface DisciplineStepperProps {
   currentDiscipline?: SeedingDiscipline
   selectedDiscipline?: SeedingDiscipline
   onSelectDiscipline?: (discipline: SeedingDiscipline) => void
+  // When set, the matching discipline gets an amber "awaiting you"
+  // dot so users see which discipline is blocked on their input.
+  pendingGateDiscipline?: SeedingDiscipline
 }
 
 export function DisciplineStepper({
@@ -86,6 +89,7 @@ export function DisciplineStepper({
   currentDiscipline,
   selectedDiscipline,
   onSelectDiscipline,
+  pendingGateDiscipline,
 }: DisciplineStepperProps) {
   const statusMap = new Map(
     disciplines.map((d) => [d.discipline, d.status])
@@ -167,7 +171,7 @@ export function DisciplineStepper({
             {/* Label */}
             <div
               className={cn(
-                'pb-3 text-sm leading-6',
+                'pb-3 text-sm leading-6 flex items-center gap-1.5',
                 isSelected
                   ? 'font-semibold text-foreground'
                   : isCurrent
@@ -177,7 +181,14 @@ export function DisciplineStepper({
                       : 'text-muted-foreground/60'
               )}
             >
-              {DISCIPLINE_LABELS[discipline]}
+              <span>{DISCIPLINE_LABELS[discipline]}</span>
+              {discipline === pendingGateDiscipline && (
+                <span
+                  className="inline-flex h-1.5 w-1.5 rounded-full bg-amber-500"
+                  aria-label="Awaiting your answer"
+                  title="Rouge is waiting on your answer for this discipline"
+                />
+              )}
             </div>
           </button>
         )

--- a/dashboard/src/components/project-card.tsx
+++ b/dashboard/src/components/project-card.tsx
@@ -113,13 +113,26 @@ export function ProjectCard({ project }: { project: ProjectSummary }) {
     >
       <Card className="h-full border border-gray-200 bg-gray-50 shadow-sm transition-all hover:shadow-md hover:-translate-y-0.5">
         <CardContent className="flex flex-col gap-4 p-6">
-          {/* Header: name + state pill */}
+          {/* Header: name + state pill + liveness chip */}
           <div className="flex items-start justify-between gap-3">
             <div className="min-w-0 flex-1">
               <h3 className="text-lg font-semibold text-gray-900 truncate">{project.name}</h3>
               <p className="mt-0.5 text-sm text-gray-500 truncate">{project.description}</p>
             </div>
-            <StateBadge state={project.state} size="lg" />
+            <div className="flex flex-col items-end gap-1">
+              <StateBadge state={project.state} size="lg" />
+              {project.awaitingGate && (
+                <span
+                  className="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-medium text-amber-900 ring-1 ring-amber-300"
+                  title={project.pendingGateDiscipline
+                    ? `Waiting on your answer for ${project.pendingGateDiscipline}`
+                    : 'Waiting on your input'}
+                >
+                  <span className="h-1.5 w-1.5 rounded-full bg-amber-500" />
+                  awaiting you
+                </span>
+              )}
+            </div>
           </div>
 
           {/* Escalation alert — inline when present */}

--- a/dashboard/src/components/spec-tab-content.tsx
+++ b/dashboard/src/components/spec-tab-content.tsx
@@ -21,6 +21,10 @@ interface SpecTabContentProps {
   // spec would cause drift between the running loop and updated artifacts).
   reviseLocked?: boolean
   reviseLockReason?: string
+  // Surfaced from scanner/seeding-state. When set, DisciplineStepper
+  // renders an "awaiting you" badge next to that discipline so users
+  // see which discipline is blocking.
+  pendingGateDiscipline?: SeedingDiscipline
 }
 
 export function SpecTabContent({
@@ -32,6 +36,7 @@ export function SpecTabContent({
   onSelectDiscipline,
   reviseLocked = false,
   reviseLockReason,
+  pendingGateDiscipline,
 }: SpecTabContentProps) {
   const hasAnySpecContent = !!(
     spec?.hasVision || spec?.hasMilestones || spec?.hasLegacySpec
@@ -156,6 +161,7 @@ function SeedingLayout({
             currentDiscipline={seedingProgress.currentDiscipline}
             selectedDiscipline={selectedDiscipline}
             onSelectDiscipline={onSelectDiscipline}
+            pendingGateDiscipline={pendingGateDiscipline}
           />
         </div>
       </div>

--- a/dashboard/src/lib/bridge-mapper.ts
+++ b/dashboard/src/lib/bridge-mapper.ts
@@ -73,6 +73,14 @@ interface RougeState {
   // before reaching this mapper.
   stagingUrl?: string
   productionUrl?: string
+  // Build subprocess state + gated-autonomy signals. Populated by
+  // the detail API route before this mapper sees the payload.
+  buildRunning?: boolean
+  buildPid?: number
+  buildStartedAt?: string
+  awaitingGate?: boolean
+  pendingGateDiscipline?: string
+  lastHeartbeatAt?: string
 }
 
 function mapSeedingProgress(raw: RougeState['seedingProgress']): SeedingProgress | undefined {
@@ -260,6 +268,12 @@ export function mapRougeStateToProjectDetail(raw: unknown, slug: string): Projec
     // the page header can render an "Open staging" affordance.
     stagingUrl: state.stagingUrl ?? undefined,
     productionUrl: state.productionUrl ?? undefined,
+    buildRunning: state.buildRunning,
+    buildPid: state.buildPid,
+    buildStartedAt: state.buildStartedAt,
+    awaitingGate: state.awaitingGate,
+    pendingGateDiscipline: state.pendingGateDiscipline as SeedingDiscipline | undefined,
+    lastHeartbeatAt: state.lastHeartbeatAt,
     createdAt: now,
     updatedAt: now,
     archived: state.archived === true,

--- a/dashboard/src/lib/types.ts
+++ b/dashboard/src/lib/types.ts
@@ -191,6 +191,12 @@ export interface ProjectSummary {
   firstMessagePreview?: string
   archived?: boolean
   archivedAt?: string
+  // Gated-autonomy signals. Populated from seeding-state.json while
+  // the project is seeding; drive the "awaiting you" chip on the
+  // project card and the discipline-gate indicator in spec-tab-content.
+  awaitingGate?: boolean
+  pendingGateDiscipline?: string
+  lastHeartbeatAt?: string
 }
 
 /** Full detail for war room / project deep dive */
@@ -227,6 +233,12 @@ export interface ProjectDetail {
   buildRunning?: boolean
   buildPid?: number
   buildStartedAt?: string
+  // Gated-autonomy signals (mirrors ProjectSummary). When set, the
+  // SpecTabContent highlights the discipline Rouge is blocked on and
+  // the project header shows the "awaiting you" chip.
+  awaitingGate?: boolean
+  pendingGateDiscipline?: SeedingDiscipline
+  lastHeartbeatAt?: string
   createdAt: string
   updatedAt: string
   archived?: boolean


### PR DESCRIPTION
## Scope

Item 5 from the post-audit follow-ups plan. Surfaces gated-autonomy signals (`mode`, `pending_gate`, `last_heartbeat_at`) from `seeding-state.json` through scanner → bridge-types → mapper → UI, so users can see at a glance which project is blocked on their input and which specific discipline is waiting.

## What this adds

**Liveness chip on project cards** — amber "awaiting you" pill next to the state badge when `mode === 'awaiting_gate'`. Tooltip names the blocked discipline.

**Discipline gate indicator in spec-tab-content** — amber dot next to the pending discipline in the stepper. Users know at a glance which question they need to answer.

## Files touched

- `bridge/types.ts` — 3 fields on `BridgeProjectSummary`
- `bridge/scanner.ts` — new `readGatedAutonomySignals` helper
- `app/api/projects/[name]/route.ts` — detail GET reads seeding-state
- `lib/types.ts` — both `ProjectSummary` and `ProjectDetail` carry the signals
- `lib/bridge-mapper.ts` — threads fields through
- `app/page.tsx` + `archived/page.tsx` — `mapBridgeProjects` extended
- `components/project-card.tsx` — amber chip UI
- `components/discipline-stepper.tsx` — amber dot + prop
- `components/spec-tab-content.tsx` — prop threaded

## Test plan

- [x] 371 dashboard tests pass
- [x] No state-machine behaviour changes — pure read-side surfacing of existing signals

🤖 Generated with [Claude Code](https://claude.com/claude-code)