### PR TITLE
feat(dashboard): self-improvement status widget on /platform (makes F17 visible)

### DIFF
--- a/dashboard/src/app/api/system/self-improve/route.ts
+++ b/dashboard/src/app/api/system/self-improve/route.ts
@@ -1,0 +1,69 @@
+import { NextResponse } from "next/server";
+import { execSync } from "node:child_process";
+import { assertLoopback } from "@/lib/localhost-guard";
+import { sanitizedErrorResponse } from "@/lib/error-response";
+
+export const dynamic = "force-dynamic";
+
+// The launcher's F17 wiring drops self-improvement proposals as gh
+// issues with the `self-improvement` label. This endpoint surfaces
+// them in the dashboard so users can see Rouge's proposed changes to
+// itself — a visible counter + the five most recent issues with
+// titles + URLs.
+//
+// Cached in-process for 60s so rapid page refreshes don't pound the
+// gh CLI. A zero-cost miss just means the card renders empty, which
+// is fine for the "nothing yet" case.
+
+interface ImproveIssue {
+  number: number;
+  title: string;
+  url: string;
+  createdAt: string;
+  state: string;
+}
+
+interface ImproveCache {
+  at: number;
+  data: { total: number; recent: ImproveIssue[] };
+}
+
+const g = globalThis as unknown as { __rougeImproveCache?: ImproveCache };
+const CACHE_MS = 60_000;
+
+function fetchIssues(): { total: number; recent: ImproveIssue[] } {
+  try {
+    const stdout = execSync(
+      `gh issue list --label self-improvement --state all --limit 50 --json number,title,url,createdAt,state`,
+      { encoding: "utf8", timeout: 5000, stdio: ["ignore", "pipe", "pipe"] },
+    );
+    const all = JSON.parse(stdout) as ImproveIssue[];
+    return {
+      total: all.length,
+      recent: all.slice(0, 5),
+    };
+  } catch (err) {
+    // gh not authenticated, network down, or no issues — treat as empty.
+    console.warn(
+      `[self-improve] gh issue list failed: ${err instanceof Error ? err.message.slice(0, 200) : String(err)}`,
+    );
+    return { total: 0, recent: [] };
+  }
+}
+
+export async function GET() {
+  const forbidden = await assertLoopback();
+  if (forbidden) return forbidden;
+
+  try {
+    const cached = g.__rougeImproveCache;
+    if (cached && Date.now() - cached.at < CACHE_MS) {
+      return NextResponse.json(cached.data);
+    }
+    const data = fetchIssues();
+    g.__rougeImproveCache = { at: Date.now(), data };
+    return NextResponse.json(data);
+  } catch (err) {
+    return sanitizedErrorResponse(err, "system/self-improve GET");
+  }
+}

--- a/dashboard/src/app/platform/page.tsx
+++ b/dashboard/src/app/platform/page.tsx
@@ -1,6 +1,7 @@
 import { fetchBridgePlatform, isBridgeEnabled } from '@/lib/bridge-client'
 import { ProviderSlotCard } from '@/components/provider-slot-card'
 import { LiveRefresh } from '@/components/live-refresh'
+import { SelfImproveStatus } from '@/components/self-improve-status'
 
 // This page shows live project state — it must render per-request so the
 // same-origin /api/platform fetch actually resolves. Without this, Next
@@ -109,6 +110,10 @@ export default async function PlatformPage() {
                 limit={q.limit}
               />
             ))}
+          </div>
+
+          <div className="mt-8">
+            <SelfImproveStatus />
           </div>
         </>
       )}

--- a/dashboard/src/components/self-improve-status.tsx
+++ b/dashboard/src/components/self-improve-status.tsx
@@ -1,0 +1,111 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Sparkles } from 'lucide-react'
+
+// Self-improvement loop status card. Polls /api/system/self-improve
+// which wraps `gh issue list --label self-improvement`. Renders
+// a total count + the five most recent issues with titles + links
+// to GitHub. Gracefully degrades to "no proposals yet" when gh is
+// unavailable or no issues exist.
+
+interface ImproveIssue {
+  number: number
+  title: string
+  url: string
+  createdAt: string
+  state: string
+}
+
+interface ImproveData {
+  total: number
+  recent: ImproveIssue[]
+}
+
+export function SelfImproveStatus() {
+  const [data, setData] = useState<ImproveData | null>(null)
+  const [loaded, setLoaded] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    fetch('/api/system/self-improve')
+      .then((r) => r.ok ? r.json() as Promise<ImproveData> : null)
+      .then((d) => {
+        if (!cancelled && d) {
+          setData(d)
+          setLoaded(true)
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setLoaded(true)
+      })
+    return () => { cancelled = true }
+  }, [])
+
+  if (!loaded) {
+    return (
+      <div className="rounded-lg border border-border bg-muted/20 p-5">
+        <div className="h-4 w-32 rounded bg-muted animate-pulse" />
+      </div>
+    )
+  }
+
+  if (!data || data.total === 0) {
+    return (
+      <div className="rounded-lg border border-border bg-muted/20 p-5">
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Sparkles className="h-4 w-4" />
+          <span>No self-improvement proposals yet.</span>
+        </div>
+        <p className="mt-1 text-xs text-muted-foreground/80">
+          Rouge drafts improvement issues after each product completes. They'll land here tagged{' '}
+          <code className="text-[10px]">self-improvement</code>.
+        </p>
+      </div>
+    )
+  }
+
+  const open = data.recent.filter((i) => i.state === 'OPEN').length
+  const closed = data.total - open
+
+  return (
+    <div className="rounded-lg border border-border bg-gray-50 p-5">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <div className="flex items-center gap-2 text-sm font-medium">
+            <Sparkles className="h-4 w-4 text-amber-500" />
+            Self-improvement proposals
+          </div>
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            {data.total} total — {open} open, {closed} closed
+          </p>
+        </div>
+        <a
+          href="https://github.com/gregario/the-rouge/issues?q=label%3Aself-improvement"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-xs text-muted-foreground underline underline-offset-4 hover:text-foreground"
+        >
+          View all
+        </a>
+      </div>
+      <ul className="mt-3 space-y-1.5">
+        {data.recent.map((issue) => (
+          <li key={issue.number} className="text-xs">
+            <a
+              href={issue.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-gray-700 hover:text-gray-900"
+            >
+              <span className="font-mono text-[10px] text-gray-400">#{issue.number}</span>{' '}
+              <span className={issue.state === 'OPEN' ? 'text-gray-900' : 'text-gray-500 line-through'}>
+                {issue.title}
+              </span>
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}


### PR DESCRIPTION
## Scope

Item 6 from the post-audit follow-ups plan. Surfaces the F17 wiring (self-improve-safety + gh issue creation) in the dashboard so users can see what Rouge has proposed for itself.

## What this adds

- **`GET /api/system/self-improve`** — wraps `gh issue list --label self-improvement --state all --limit 50`. 60s in-process cache. Returns `{ total, recent[5] }`. Degrades gracefully when gh is unavailable.
- **`SelfImproveStatus` card** — rendered on `/platform`. Total count, open/closed split, 5 most recent issues with titles linking to GitHub. Empty state explains where proposals will appear.

## Why

F17 wired the safety guard + issue creation but nothing surfaced it. You had to open GitHub to see improvement proposals. This closes that loop.

## Test plan

- [x] 371 dashboard tests pass
- [x] Works with no issues (empty state)
- [x] Works without gh authenticated (logs warn, returns empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)