### PR TITLE
feat(dashboard): seeding progress indicator above chat input

### DIFF
--- a/dashboard/src/components/chat-panel.tsx
+++ b/dashboard/src/components/chat-panel.tsx
@@ -10,6 +10,7 @@ import { Play, Send, ChevronDown, ChevronRight, Check, Loader2 } from 'lucide-re
 import { cn } from '@/lib/utils'
 import { isBridgeEnabled } from '@/lib/bridge-client'
 import { useSeeding } from '@/lib/use-seeding'
+import { SeedingProgressIndicator } from '@/components/seeding-progress-indicator'
 
 // Rough per-discipline expected durations for an agent turn, derived
 // from observed runs. Used to give the elapsed-time display a baseline
@@ -324,6 +325,13 @@ export function ChatPanel({
       {/* Input area */}
       {!disabled && (
         <div className="border-t border-gray-200 p-3">
+          {bridgeActive && (
+            <SeedingProgressIndicator
+              messages={seeding.messages}
+              currentDiscipline={currentDiscipline}
+              isActive={seeding.isSending}
+            />
+          )}
           {bridgeActive && seeding.error && (
             <div className="mx-3 mb-2 rounded-md border border-red-300 bg-red-50 px-3 py-2 text-xs text-red-800">
               {seeding.error}

--- a/dashboard/src/components/seeding-progress-indicator.tsx
+++ b/dashboard/src/components/seeding-progress-indicator.tsx
@@ -1,0 +1,82 @@
+'use client'
+
+import { Activity } from 'lucide-react'
+import type { SeedingChatMessage } from '@/bridge/types'
+
+interface SeedingProgressIndicatorProps {
+  messages: SeedingChatMessage[]
+  currentDiscipline?: string
+  // When true, we're actively waiting on Rouge — indicator renders
+  // even if the most recent marker is slightly stale. When false,
+  // we only show the indicator if there's fresh work (last marker
+  // within 5 min).
+  isActive: boolean
+}
+
+const FRESH_WINDOW_MS = 5 * 60 * 1000
+
+/**
+ * Compact progress line shown above the chat input while Rouge is
+ * in deep autonomous work. Reads the [WROTE:] and [HEARTBEAT:] marker
+ * stream and distills it to one line: "Writing specs — 4 of 8 done"
+ * or "FA5 on disk — complex tier, 31 ACs".
+ *
+ * The design principle: during deep work, chat bubbles get noisy
+ * (one card per file, heartbeats every few minutes). The progress
+ * indicator carries the "still alive, making progress" signal in
+ * one quiet line, leaving chat bubbles for narrative + gates.
+ * See docs/design/seeding-interaction-principles.md (principle 4 +
+ * principle 6) + the audit doc for the broader rationale.
+ */
+export function SeedingProgressIndicator({
+  messages,
+  currentDiscipline,
+  isActive,
+}: SeedingProgressIndicatorProps) {
+  // Filter to autonomous markers in the current discipline. Ignore
+  // older disciplines — their writes aren't "in flight" any more.
+  const relevant = messages.filter((m) => {
+    if (m.role !== 'rouge') return false
+    if (m.kind !== 'wrote_artifact' && m.kind !== 'heartbeat') return false
+    if (currentDiscipline && m.metadata?.discipline && m.metadata.discipline !== currentDiscipline) {
+      return false
+    }
+    return true
+  })
+
+  if (relevant.length === 0) return null
+
+  const latest = relevant[relevant.length - 1]
+  const latestTs = new Date(latest.timestamp).getTime()
+  const isStale = !isActive && Date.now() - latestTs > FRESH_WINDOW_MS
+  if (isStale) return null
+
+  const wroteCount = relevant.filter((m) => m.kind === 'wrote_artifact').length
+  const latestSummary = firstLine(latest.content)
+
+  return (
+    <div
+      className="mx-3 mb-2 flex items-center gap-2 rounded-md border border-blue-200 bg-blue-50/50 px-3 py-1.5 text-xs text-blue-900"
+      data-testid="seeding-progress-indicator"
+      aria-live="polite"
+    >
+      <Activity className="h-3.5 w-3.5 shrink-0" />
+      <span className="truncate">
+        {latest.kind === 'wrote_artifact' && wroteCount > 1 && (
+          <span className="mr-1.5 rounded bg-blue-100 px-1.5 py-0.5 text-[10px] font-medium">
+            {wroteCount} artifacts
+          </span>
+        )}
+        {latestSummary}
+      </span>
+    </div>
+  )
+}
+
+function firstLine(content: string): string {
+  const trimmed = (content || '').trim()
+  if (!trimmed) return 'Working…'
+  const nl = trimmed.indexOf('\n')
+  const line = nl === -1 ? trimmed : trimmed.slice(0, nl)
+  return line.length > 120 ? line.slice(0, 117) + '…' : line
+}


### PR DESCRIPTION
## Scope

Answers Q2 from the seeding interaction principles: chat bubbles stay conversational; a compact progress pill above the input carries the "still alive, making progress" signal during deep autonomous work.

Prerequisite for the spec / design prompt rewrites — once those land, chat bubble volume drops dramatically, and users need a channel for progress signal that isn't a wall of per-file cards.

## What

- `components/seeding-progress-indicator.tsx` (NEW) — compact line reading `wrote_artifact` + `heartbeat` markers from the current discipline. Shows latest marker's first line + a badge when multiple artifacts have landed.
- `components/chat-panel.tsx` — renders it above the input when bridge is active.

## Behaviour

- Only shows during active seeding (sending, or marker within the last 5 min).
- Scopes to current discipline.
- Fails quiet when no markers exist.

## Test plan

- [x] 371 dashboard tests pass
- [x] No behaviour change in the chat message list itself — purely additive UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)