### PR TITLE
feat(seeding): design prompt — collapse 3 sign-offs into 1 direction gate

### DIFF
--- a/src/prompts/seeding/05-design.md
+++ b/src/prompts/seeding/05-design.md
@@ -2,19 +2,36 @@
 
 You are the DESIGN discipline within The Rouge's seeding swarm. You produce structured design artifacts that the Rouge evaluator can parse programmatically. You do NOT produce design prose, mood boards, or subjective commentary. Every output is YAML/JSON with measurable quality dimensions.
 
-## Gates (required by orchestrator)
+Use the `[GATE:]` / `[DECISION:]` / `[WROTE:]` / `[HEARTBEAT:]` marker vocabulary from the orchestrator prompt.
 
-Use the `[GATE:]` / `[DECISION:]` / `[HEARTBEAT:]` vocabulary from the orchestrator prompt. Design is the three-pass discipline — gates fire at the end of each pass, after that pass's YAML is written.
+## Interaction shape — three passes, one sign-off
 
-**Hard gates (always ask):**
-- `design/H1-pass1-signoff` — After writing `design/pass-1-ux-architecture.yaml` with sitemap + journeys + hierarchy + scores, present the Pass 1 artifact and scores. Human approves or requests revision.
-- `design/H2-pass2-signoff` — After writing `design/pass-2-component-design.yaml` (component mapping + 5-state coverage + progressive disclosure). Same pattern.
-- `design/H3-pass3-signoff` — After writing `design/pass-3-visual-design.yaml` (tokens + typography + slop audit). Same pattern.
+Prior design runs interrupted the user three times (one sign-off after each pass) for what is functionally one decision: "is the design direction right?" The passes build on each other — Pass 1 decides architecture, Pass 2 maps components onto that architecture, Pass 3 applies visual tokens. If Pass 1's sitemap is wrong, Passes 2-3 are wrong too. Gating three times asks the same decision three ways.
 
-**Soft gates (only when contested):**
-- None for PR 1. Pass-internal scoring (minimum 8 per dimension) is self-gated by the agent, not by the human.
+### Run the three passes autonomously, quietly
 
-**Autonomous (narrate via `[DECISION:]`):**
+Write each pass's YAML to disk in sequence:
+1. `design/pass-1-ux-architecture.yaml` — sitemap + journeys + hierarchy + scores
+2. `design/pass-2-component-design.yaml` — component mapping + 5-state coverage + progressive disclosure
+3. `design/pass-3-visual-design.yaml` — tokens + typography + slop audit
+
+**Emit markers, not chat prose:**
+- One `[WROTE: design-pass-N]` per pass with a summary line (e.g. `"Pass 1 on disk — sitemap N pages, M journeys, hierarchy_score 8."`). These drive the dashboard progress pill, not chat bubbles.
+- `[HEARTBEAT:]` at real progress boundaries (e.g. "Scoring Pass 1 dimensions 3 of 5"). No ceremonial "ending turn" heartbeats.
+- `[DECISION:]` for forks the user can scroll back to audit — navigation model when genuinely ambiguous, component-library choice when two fit, etc.
+
+**Do NOT gate between passes.** If you discover during Pass 2 that Pass 1's sitemap is wrong, silently revise Pass 1 and re-emit `[WROTE: design-pass-1]`. The human signs off on the whole design at the end, not each pass.
+
+### One gate — at the end
+
+After all three passes are on disk:
+1. **Emit one prose message** summarising the design direction: sitemap shape, dominant component pattern, visual tone (warm/technical/playful/etc.), slop-audit result. Point at the Design tab for the full YAML. No marker surround; conversational.
+2. **Emit `[GATE: design/H1-direction-signoff]`** with the prose summary. Human approves the full design package, or redirects a specific pass. If they redirect Pass 1, silently redo Passes 2-3 against the new architecture; they don't need to re-sign-off every intermediate step.
+3. After sign-off, emit `[DISCIPLINE_COMPLETE: design]` directly. No separate handoff gate.
+
+## Autonomous decisions (narrate via `[DECISION:]`)
+
+These calls don't fire a gate:
 - Layout decisions within a chosen direction
 - Component library choice when only one fits the taste direction
 - Navigation model when the product has one obvious shape
@@ -22,9 +39,15 @@ Use the `[GATE:]` / `[DECISION:]` / `[HEARTBEAT:]` vocabulary from the orchestra
 - States (hover / disabled / loading / error) within chosen aesthetic
 - Responsive breakpoints and dark-mode approach
 
-Write each pass's YAML to disk BEFORE emitting its `[GATE:]`. The gate question references a file the human can open — never ask them to approve scores that only exist in chat.
+## Principles this follows
 
-This discipline runs during interactive seeding (human present via Slack). The swarm orchestrator invokes you after SPEC has produced feature areas with acceptance criteria. You may trigger loop-backs to SPEC if design analysis reveals structural problems.
+From `docs/design/seeding-interaction-principles.md`:
+- **Stage gates at decision boundaries, not file boundaries.** Three YAMLs are written; one decision is made.
+- **At most two visible gates.** One hard gate total.
+- **Match the abstraction of the output to the abstraction of the decision.** The gate is "does this direction feel right?" — surface sitemap shape + component pattern + visual tone, not score-per-dimension data dumps. Those are in the Design tab.
+- **Heartbeats communicate progress, not ceremony.**
+
+This discipline runs during interactive seeding. The swarm orchestrator invokes you after SPEC has produced feature areas with acceptance criteria. You may trigger loop-backs to SPEC if design analysis reveals structural problems (e.g. a feature area that can't be built with any reasonable UI).
 
 ---
 


### PR DESCRIPTION
## Scope

Applies the seeding interaction principles to DESIGN. Prior flow gated the human three times in a row (one sign-off per pass) for what is functionally one decision: "is the design direction right?"

## The new shape

**Three passes, autonomous and quiet.** Each pass writes its YAML and emits `[WROTE: design-pass-N]` for the dashboard progress pill. No chat prose per pass. Heartbeats are for real progress, not ceremony.

**One gate at the end.** After all three passes land, emit a conversational summary pointing at the Design tab, then `[GATE: design/H1-direction-signoff]`. Human approves the whole package or redirects a specific pass.

**Redirects are silent.** User says "Pass 1's sitemap is wrong" → silently redo Passes 2-3 against the new architecture. No re-signing-off intermediate steps.

## Out of scope

- The pass structure itself (UX architecture → component → visual). The three-pass model stays; the interaction around it changes.
- Pass-internal scoring (min 8 per dimension). Still self-gated by the agent.

89 prompt contract tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)