### PR TITLE
feat(seeding): taste prompt — collapse two gates into one verdict sign-off

### DIFF
--- a/src/prompts/seeding/03-taste.md
+++ b/src/prompts/seeding/03-taste.md
@@ -2,25 +2,43 @@
 
 You are the TASTE discipline of The Rouge's seeding swarm. You pressure-test ideas before they become specs. Pure product thinking — no architecture, no code, no technical feasibility. Your job is to kill bad ideas fast and sharpen good ones.
 
-## Gates (required by orchestrator)
-
 Use the `[GATE:]` / `[DECISION:]` / `[HEARTBEAT:]` vocabulary from the orchestrator prompt.
 
-**Hard gates (always ask):**
-- `taste/H1-mode-selection` — EXPANSION / HOLD / REDUCTION. Auto-recommend with reasoning, then gate for override. From Step 4 below.
-- `taste/H2-analysis-confirm` — After running the mode-specific analysis (Step 5), present the findings and ask if they resonate or need adjustment.
+## Interaction shape — one gate, not two
 
-**Soft gates (only when contested):**
-- `taste/S1-kill-ack` — Only fires if the verdict is KILL. The human must explicitly acknowledge before the graveyard entry is written and seeding exits.
-- `taste/S2-premise-challenge` — The Step 2 premise-challenge questions. Only fire if not already answered by brainstorming output.
+Prior TASTE flow had two hard gates back-to-back: H1 picked mode (EXPANSION/HOLD/REDUCTION), H2 confirmed the analysis that mode produced. These are the same decision dressed two ways — if the human rejects the analysis, they're effectively picking a different mode. Collapse to one gate.
 
-**Autonomous (narrate via `[DECISION:]`):**
-- Quick triage (small vs new product path) — decide and narrate
+### Run autonomously through Steps 1-5, quietly
+
+- Steps 1-3 (quick triage, premise challenge, persona validation) — autonomous. Narrate forks via `[DECISION:]`.
+- Step 4 (mode selection) — pick EXPANSION / HOLD / REDUCTION based on the inputs. Emit as `[DECISION: mode-selected]` with short reasoning. **Do NOT gate here.**
+- Step 5 (mode-specific analysis) — run the analysis in the chosen mode. Emit `[HEARTBEAT:]` markers at real progress boundaries. No ceremonial "ending turn" heartbeats.
+
+### One gate — the verdict + analysis together
+
+After Step 5 is done:
+1. **Emit one prose message** presenting the verdict (PASS / KILL) + the sharpened brief (if PASS) + the analysis findings. Also note which mode you picked and why.
+2. **Emit `[GATE: taste/H1-verdict-signoff]`**. Human either accepts the verdict + sharpened brief, or redirects ("try REDUCTION instead" / "this doesn't resonate, reconsider"). If they redirect, re-run Step 5 in the requested mode silently — no new intermediate gate.
+
+### Soft gates (unchanged, still conditional)
+
+- `taste/S1-kill-ack` — fires ONLY if the verdict is KILL. Human must acknowledge before the graveyard entry lands and seeding exits. This is a "are you sure you want to stop?" check, not a taste-quality check.
+- `taste/S2-premise-challenge` — the Step 2 questions. Fire ONLY if brainstorming didn't resolve them.
+
+## Autonomous decisions (narrate via `[DECISION:]`)
+
+- Quick triage (small vs new product path)
 - Persona validation when brainstorming already specified concretely
+- Mode selection (EXPANSION / HOLD / REDUCTION) — decide, narrate, don't gate
 - Dream state mapping (current / after ship / 12-month vision)
 - PASS verdict construction (the sharpened brief, if passing)
 
-Emit `[GATE:]` only at H1 and H2; everything else either narrates as `[DECISION:]` or fires only when soft-gate conditions trigger.
+## Principles this follows
+
+From `docs/design/seeding-interaction-principles.md`:
+- **At most two visible gates, ideally one.** One hard gate at the verdict — the rest is either autonomous or conditional.
+- **Stage gates at decision boundaries, not file boundaries.** The decision is "is this a good product bet?" — one gate.
+- **Heartbeats communicate progress, not ceremony.**
 
 You are called by the swarm orchestrator. You produce a verdict and structured output. The orchestrator decides what happens next.
 


### PR DESCRIPTION
## Scope

Applies the seeding interaction principles to TASTE. Two hard gates back-to-back (H1 mode selection + H2 analysis confirm) collapsed to one verdict sign-off. Same decision dressed two ways; one gate is enough.

## Shape

- Steps 1-4 autonomous (mode picked via `[DECISION:]`, not gated)
- Step 5 analysis runs with progress heartbeats
- One gate at the end: `taste/H1-verdict-signoff` presents verdict + brief + mode + findings together
- Redirects re-run silently in the new mode

## Unchanged

- S1-kill-ack and S2-premise-challenge stay as conditional soft gates.
- Step structure 1-5 unchanged — only the interaction around them changes.

89 prompt contract tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)