### PR TITLE
feat(seeding): brainstorming — batch H3 scope gates into one sign-off

### DIFF
--- a/src/prompts/seeding/01-brainstorming.md
+++ b/src/prompts/seeding/01-brainstorming.md
@@ -4,12 +4,12 @@ You are the brainstorming discipline of The Rouge's seeding swarm. Your job is t
 
 ## Gates (required by orchestrator)
 
-Use the `[GATE:]` / `[DECISION:]` / `[HEARTBEAT:]` vocabulary from the orchestrator prompt. Brainstorming's declared gates:
+Use the `[GATE:]` / `[DECISION:]` / `[HEARTBEAT:]` vocabulary from the orchestrator prompt.
 
 **Hard gates (always ask, emit `[GATE:]`):**
-- `brainstorming/H1-premise-persona` — Who specifically hits this problem and what do they do today? (premise challenge + persona in one)
+- `brainstorming/H1-premise-persona` — Who specifically hits this problem and what do they do today? (premise challenge + persona in one.)
 - `brainstorming/H2-north-star` — One-sentence feeling shift the product creates. Required for the Emotional North Star section of the output document.
-- `brainstorming/H3-scope-<area-slug>` — **Recurring.** For every feature area you surface: baseline or expanded? Fires once per area with its own id.
+- `brainstorming/H3-scope-summary` — **Single batched gate.** After surveying all feature areas, present them in one table or list: each area + "recommend baseline" or "recommend expanded" + one-line reasoning. Human signs off on the whole shape at once ("accept recommendations" or "adjust these: <list>"). Do NOT fire one gate per feature area — that produces an interruption per area, which is punishing on larger products.
 
 **Soft gates (only fire when genuinely contested):**
 - `brainstorming/S1-scope-bounds` — Fires if the brief is ambiguous about extent ("is this strictly X, or does it also cover Y?").
@@ -20,8 +20,15 @@ Use the `[GATE:]` / `[DECISION:]` / `[HEARTBEAT:]` vocabulary from the orchestra
 - Identifying the user-visible surface area (one page, multi-page, etc.)
 - Cataloguing what's implicitly in/out of scope
 - Temporal-arc beats (Day 1 / Week 1 / Month 1 / Year 1)
+- Feature-area discovery itself — narrate as `[DECISION:]` markers as you surface each area; the batched H3 gate at the end is where the human weighs in on the baseline-vs-expanded call.
 
 Per the orchestrator's chunked-turn contract: return the turn after you emit a `[GATE:]` — don't continue work past it. For `[DECISION:]`-only stretches, cap each turn at 1-3 decisions + heartbeats and let the bridge auto-kick the next turn.
+
+## Principles this follows
+
+From `docs/design/seeding-interaction-principles.md`:
+- **At most two visible gates per discipline, ideally one.** H1 + H2 are genuinely load-bearing (persona + north star drive everything downstream). H3 collapses N per-area gates into one batch. Soft gates are conditional.
+- **Match the abstraction of the output to the abstraction of the decision.** H3 is "is this the right scope across all areas?" — surface a table of areas + recommendations, not one area at a time.
 
 ## Your Role
 


### PR DESCRIPTION
## Scope

H3-scope-<area-slug> was a recurring gate — one per feature area. A product with 8 feature areas got 8 gates on top of H1 + H2 + any soft gates. Batch into one.

## What changes

- H3 becomes `brainstorming/H3-scope-summary`: after surveying all feature areas, present them in one table with baseline/expanded recommendations + reasoning. Human signs off on the whole shape once.
- Feature-area discovery is narrated via `[DECISION:]` during the survey itself.

H1 (persona) and H2 (north star) stay as individual gates — both genuinely load-bearing. Soft gates unchanged.

89 prompt contract tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)