### PR TITLE
test(launcher): provision-infrastructure coverage (closes G3 gap)

### DIFF
--- a/src/launcher/provision-infrastructure.js
+++ b/src/launcher/provision-infrastructure.js
@@ -6,7 +6,12 @@
  * Usage: node provision-infrastructure.js <project-dir>
  */
 
-const { execSync, execFileSync } = require('child_process');
+// Named import (not destructured) so tests can mock execSync via
+// t.mock.method(child_process, 'execSync', ...). Destructuring
+// captures the function reference at require time, which defeats
+// property-level mocking from a test.
+const child_process = require('child_process');
+const { execFileSync } = child_process;
 const fs = require('fs');
 const path = require('path');
 const { log: logLine } = require('./logger.js');
@@ -30,7 +35,7 @@ function log(msg) {
 
 function run(cmd, opts = {}) {
   log(`  $ ${cmd}`);
-  return execSync(cmd, { encoding: 'utf8', timeout: 60000, stdio: ['pipe', 'pipe', 'pipe'], ...opts });
+  return child_process.execSync(cmd, { encoding: 'utf8', timeout: 60000, stdio: ['pipe', 'pipe', 'pipe'], ...opts });
 }
 
 // --- Cloudflare Workers setup ---
@@ -148,7 +153,7 @@ function getSupabaseToken() {
   // Keychain stores: "go-keyring-base64:<base64-encoded-token>"
   // Strip prefix, base64 decode to get the actual token (sbp_...)
   try {
-    const raw = execSync('security find-generic-password -s "Supabase CLI" -w', { encoding: 'utf8', timeout: 5000 }).trim();
+    const raw = child_process.execSync('security find-generic-password -s "Supabase CLI" -w', { encoding: 'utf8', timeout: 5000 }).trim();
     const b64 = raw.replace('go-keyring-base64:', '');
     return Buffer.from(b64, 'base64').toString('utf8');
   } catch {}
@@ -158,7 +163,7 @@ function getSupabaseToken() {
 
 function supabaseApi(method, path, token) {
   const cmd = `curl -s -X ${method} "https://api.supabase.com/v1${path}" -H "Authorization: Bearer ${token}" -H "Content-Type: application/json"`;
-  return JSON.parse(execSync(cmd, { encoding: 'utf8', timeout: 30000 }));
+  return JSON.parse(child_process.execSync(cmd, { encoding: 'utf8', timeout: 30000 }));
 }
 
 function provisionSupabase(projectDir, projectName) {
@@ -180,7 +185,7 @@ function provisionSupabase(projectDir, projectName) {
   let projects;
   try {
     projects = JSON.parse(
-      execSync(`curl -s "https://api.supabase.com/v1/projects" -H "Authorization: Bearer ${token}"`, { encoding: 'utf8', timeout: 30000 })
+      child_process.execSync(`curl -s "https://api.supabase.com/v1/projects" -H "Authorization: Bearer ${token}"`, { encoding: 'utf8', timeout: 30000 })
     );
   } catch (err) {
     log(`Supabase: failed to list projects: ${err.message.slice(0, 200)}`);
@@ -223,7 +228,7 @@ function provisionSupabase(projectDir, projectName) {
       log(`Supabase: 2/2 slots used — pausing idle project: ${toPause.name} (${toPause.ref})`);
 
       try {
-        execSync(
+        child_process.execSync(
           `curl -s -X POST "https://api.supabase.com/v1/projects/${toPause.ref}/pause" -H "Authorization: Bearer ${token}" -H "Content-Type: application/json"`,
           { encoding: 'utf8', timeout: 30000 }
         );
@@ -231,11 +236,11 @@ function provisionSupabase(projectDir, projectName) {
         // Wait for pause to complete (poll every 10s, max 3 min)
         for (let i = 0; i < 18; i++) {
           const status = JSON.parse(
-            execSync(`curl -s "https://api.supabase.com/v1/projects/${toPause.ref}" -H "Authorization: Bearer ${token}"`, { encoding: 'utf8', timeout: 10000 })
+            child_process.execSync(`curl -s "https://api.supabase.com/v1/projects/${toPause.ref}" -H "Authorization: Bearer ${token}"`, { encoding: 'utf8', timeout: 10000 })
           ).status;
           log(`Supabase: ${toPause.name} status: ${status}`);
           if (status === 'INACTIVE') break;
-          execSync('sleep 10');
+          child_process.execSync('sleep 10');
         }
         log(`Supabase: ${toPause.name} paused — slot freed`);
       } catch (err) {
@@ -252,7 +257,7 @@ function provisionSupabase(projectDir, projectName) {
   // Create new project
   log(`Supabase: creating project "${projectName}"`);
   try {
-    const password = execSync('openssl rand -base64 24', { encoding: 'utf8' }).trim();
+    const password = child_process.execSync('openssl rand -base64 24', { encoding: 'utf8' }).trim();
     const result = run(`supabase projects create "${projectName}" --org-id ${projects[0]?.organization_id || ''} --db-password "${password}" --region eu-west-1`, {
       timeout: 60000,
     });
@@ -437,4 +442,17 @@ function main() {
   log(`  supabase_ref: ${ctx.supabase?.project_ref || 'none'}`);
 }
 
-main();
+// Export internals for testing. Only run main() when invoked as a
+// CLI script so `require('./provision-infrastructure.js')` from a
+// test file can import the helpers without triggering the
+// subprocess calls main() makes.
+module.exports = {
+  provisionCloudflare,
+  provisionSupabase,
+  getSupabaseToken,
+  supabaseApi,
+};
+
+if (require.main === module) {
+  main();
+}

--- a/test/launcher/provision-infrastructure.test.js
+++ b/test/launcher/provision-infrastructure.test.js
@@ -1,0 +1,237 @@
+const { test, describe, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const child_process = require('child_process');
+
+const {
+  provisionCloudflare,
+  provisionSupabase,
+  getSupabaseToken,
+  supabaseApi,
+} = require('../../src/launcher/provision-infrastructure.js');
+
+// These tests validate the file-writing + decision logic of the
+// provisioning functions without hitting real Cloudflare / Supabase
+// APIs. `execSync` is mocked per-test via node:test's t.mock API.
+// The intent: catch regressions in the gate-and-write paths that
+// happen before (or instead of) subprocess calls, since those paths
+// are where real-world bugs have landed (wrong project name in
+// wrangler.toml, missing env var in readiness detection, etc.).
+
+function makeProject(files = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'provision-test-'));
+  for (const [name, content] of Object.entries(files)) {
+    const p = path.join(dir, name);
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, typeof content === 'string' ? content : JSON.stringify(content));
+  }
+  return dir;
+}
+
+function cleanup(dir) {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+describe('provision-infrastructure', () => {
+  // ── provisionCloudflare: file-writing paths ──
+
+  describe('provisionCloudflare', () => {
+    let projectDir;
+
+    beforeEach(() => {
+      projectDir = makeProject({
+        'package.json': {
+          name: 'test-product',
+          devDependencies: { '@opennextjs/cloudflare': '^1.0.0' },
+        },
+      });
+    });
+
+    afterEach(() => cleanup(projectDir));
+
+    test('writes wrangler.toml with correct project name when absent', (t) => {
+      t.mock.method(child_process, 'execSync', () => ''); // mock the build call
+
+      provisionCloudflare(projectDir, 'test-product');
+
+      const wrangler = fs.readFileSync(path.join(projectDir, 'wrangler.toml'), 'utf8');
+      assert.match(wrangler, /name = "test-product"/);
+      assert.match(wrangler, /main = "\.open-next\/worker\.js"/);
+      assert.match(wrangler, /\[env\.staging\]/);
+      assert.match(wrangler, /name = "test-product-staging"/);
+    });
+
+    test('writes open-next.config.ts with cloudflare-node wrapper', (t) => {
+      t.mock.method(child_process, 'execSync', () => '');
+
+      provisionCloudflare(projectDir, 'test-product');
+
+      const cfg = fs.readFileSync(path.join(projectDir, 'open-next.config.ts'), 'utf8');
+      assert.match(cfg, /cloudflare-node/);
+      assert.match(cfg, /cloudflare-edge/);
+      assert.match(cfg, /edgeExternals: \['node:crypto'\]/);
+    });
+
+    test('does not overwrite an existing wrangler.toml', (t) => {
+      fs.writeFileSync(
+        path.join(projectDir, 'wrangler.toml'),
+        'name = "custom-name"\ncompatibility_date = "2024-01-01"\n',
+      );
+      t.mock.method(child_process, 'execSync', () => '');
+
+      provisionCloudflare(projectDir, 'whatever');
+
+      const wrangler = fs.readFileSync(path.join(projectDir, 'wrangler.toml'), 'utf8');
+      assert.match(wrangler, /name = "custom-name"/);
+      assert.doesNotMatch(wrangler, /name = "whatever"/);
+    });
+
+    test('installs @opennextjs/cloudflare when package.json lacks it', (t) => {
+      // Overwrite with a package.json that has no OpenNext dep
+      fs.writeFileSync(
+        path.join(projectDir, 'package.json'),
+        JSON.stringify({ name: 'test-product' }),
+      );
+      const calls = [];
+      t.mock.method(child_process, 'execSync', (cmd) => {
+        calls.push(cmd);
+        return '';
+      });
+
+      provisionCloudflare(projectDir, 'test-product');
+
+      assert.ok(
+        calls.some((c) => /npm install -D @opennextjs\/cloudflare/.test(c)),
+        `expected install call, got: ${calls.join(' | ')}`,
+      );
+    });
+
+    test('skips install when @opennextjs/cloudflare already in devDependencies', (t) => {
+      const calls = [];
+      t.mock.method(child_process, 'execSync', (cmd) => {
+        calls.push(cmd);
+        return '';
+      });
+
+      provisionCloudflare(projectDir, 'test-product');
+
+      assert.ok(
+        !calls.some((c) => /npm install -D @opennextjs\/cloudflare/.test(c)),
+        'did not expect install call when dep is already present',
+      );
+    });
+
+    test('runs @opennextjs/cloudflare build after setup', (t) => {
+      const calls = [];
+      t.mock.method(child_process, 'execSync', (cmd) => {
+        calls.push(cmd);
+        return '';
+      });
+
+      provisionCloudflare(projectDir, 'test-product');
+
+      assert.ok(
+        calls.some((c) => /@opennextjs\/cloudflare build/.test(c)),
+        `expected build call, got: ${calls.join(' | ')}`,
+      );
+    });
+  });
+
+  // ── getSupabaseToken: env fallback when keychain fails ──
+
+  describe('getSupabaseToken', () => {
+    test('falls back to SUPABASE_ACCESS_TOKEN env var when keychain fails', (t) => {
+      // Mock the keychain lookup to throw (simulating no macOS keychain
+      // entry). That forces getSupabaseToken to the env fallback path.
+      t.mock.method(child_process, 'execSync', () => {
+        throw new Error('security: The specified item could not be found');
+      });
+      const prior = process.env.SUPABASE_ACCESS_TOKEN;
+      process.env.SUPABASE_ACCESS_TOKEN = 'sbp_test_token';
+      try {
+        const tok = getSupabaseToken();
+        assert.equal(tok, 'sbp_test_token');
+      } finally {
+        if (prior === undefined) delete process.env.SUPABASE_ACCESS_TOKEN;
+        else process.env.SUPABASE_ACCESS_TOKEN = prior;
+      }
+    });
+
+    test('returns null when keychain fails AND env var missing', (t) => {
+      t.mock.method(child_process, 'execSync', () => {
+        throw new Error('no keychain entry');
+      });
+      const prior = process.env.SUPABASE_ACCESS_TOKEN;
+      delete process.env.SUPABASE_ACCESS_TOKEN;
+      try {
+        assert.equal(getSupabaseToken(), null);
+      } finally {
+        if (prior !== undefined) process.env.SUPABASE_ACCESS_TOKEN = prior;
+      }
+    });
+  });
+
+  // ── supabaseApi: URL construction ──
+
+  describe('supabaseApi', () => {
+    test('constructs the correct curl command with auth + content-type', (t) => {
+      let capturedCmd = '';
+      t.mock.method(child_process, 'execSync', (cmd) => {
+        capturedCmd = cmd;
+        return '{"ok":true}';
+      });
+
+      const result = supabaseApi('GET', '/projects', 'sbp_abc123');
+
+      assert.match(capturedCmd, /curl -s -X GET/);
+      assert.match(capturedCmd, /https:\/\/api\.supabase\.com\/v1\/projects/);
+      assert.match(capturedCmd, /Authorization: Bearer sbp_abc123/);
+      assert.match(capturedCmd, /Content-Type: application\/json/);
+      assert.deepEqual(result, { ok: true });
+    });
+
+    test('throws when curl output is not JSON (upstream contract)', (t) => {
+      // Documented behaviour: supabaseApi trusts the Supabase API to
+      // return JSON on 2xx. A non-JSON response means something's
+      // very wrong (DNS failure, proxy HTML, etc.) — throwing here is
+      // the right signal to the caller. Test pins that contract.
+      t.mock.method(child_process, 'execSync', () => 'not json at all');
+      assert.throws(() => supabaseApi('GET', '/projects', 'token'), /Unexpected token/);
+    });
+  });
+
+  // ── provisionSupabase: context gate ──
+
+  describe('provisionSupabase', () => {
+    let projectDir;
+
+    beforeEach(() => {
+      projectDir = makeProject({
+        'cycle_context.json': {
+          infrastructure: { services: ['supabase'] },
+        },
+      });
+    });
+
+    afterEach(() => cleanup(projectDir));
+
+    test('no-op when no SUPABASE token available', (t) => {
+      const prior = process.env.SUPABASE_ACCESS_TOKEN;
+      delete process.env.SUPABASE_ACCESS_TOKEN;
+      // Mock execSync to always throw — simulates keychain lookup
+      // failing, which forces getSupabaseToken down the env path,
+      // which returns null since we unset it. No network call can
+      // happen because provisionSupabase returns early.
+      t.mock.method(child_process, 'execSync', () => {
+        throw new Error('keychain lookup failed in test');
+      });
+      try {
+        assert.doesNotThrow(() => provisionSupabase(projectDir, 'test-product'));
+      } finally {
+        if (prior !== undefined) process.env.SUPABASE_ACCESS_TOKEN = prior;
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Scope

11 new tests for `provision-infrastructure.js` — the launcher module that wires Cloudflare Workers + Supabase during foundation. Closes the G3 coverage gap that was explicitly deferred from PR-G (#170) because the module needed a mock seam before tests could work.

## Source change

Minimal — destructured `const { execSync } = require('child_process')` → named `const child_process = require('child_process')`. Destructuring captured the function reference at require time, defeating `t.mock.method`. All call sites now route through `child_process.execSync(...)`. No behaviour change.

Exports the four key functions + wraps `main()` in `require.main === module` so importing for tests doesn't trigger real provisioning.

## Test coverage

- **provisionCloudflare** (6): wrangler.toml write + content, open-next.config.ts write, no-overwrite-existing, install-when-missing, skip-install-when-present, build-runs-after-setup.
- **getSupabaseToken** (2): env fallback when keychain throws, null when both absent.
- **supabaseApi** (2): curl command construction, throws on non-JSON.
- **provisionSupabase** (1): no-op when no token.

## What's not covered

- Vercel — already in `deploy-to-staging.test.js` (10+ tests covering handler routing).
- Full happy-path Supabase project creation (would need extensive API mocking).
- Real network integration (these are unit tests, not smoke tests).

411 launcher tests pass (410 new suite + 1 pre-existing allowed-tools flake unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)