### PR TITLE
feat(escalation): hand-off to Claude Code + wire human guidance (fix dead plumbing)

### DIFF
--- a/dashboard/src/app/api/projects/[name]/resolve-escalation/route.ts
+++ b/dashboard/src/app/api/projects/[name]/resolve-escalation/route.ts
@@ -13,6 +13,13 @@ const VALID_RESPONSE_TYPES = [
   "manual-fix-applied",
   "dismiss-false-positive",
   "abort-story",
+  // Hand-off to direct Claude Code session. User runs
+  // `rouge resume-escalation <slug>` and works in their terminal.
+  // Launcher parks the project until `resume-after-handoff` arrives.
+  "hand-off",
+  // User finished the hand-off session. Launcher captures git
+  // commits since the hand-off started and resumes the phase.
+  "resume-after-handoff",
 ] as const;
 
 export async function POST(

--- a/dashboard/src/components/escalation-response.tsx
+++ b/dashboard/src/components/escalation-response.tsx
@@ -6,7 +6,7 @@ import { Card, CardContent } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Textarea } from '@/components/ui/textarea'
 import { Button } from '@/components/ui/button'
-import { AlertTriangle, Send, Play } from 'lucide-react'
+import { AlertTriangle, Send, Play, Terminal, CheckCircle2, Copy } from 'lucide-react'
 
 const tierLabels: Record<number, string> = {
   0: 'Tier 0 — Auto-recoverable',
@@ -28,9 +28,15 @@ interface ChatEntry {
   timestamp: string
 }
 
-// Default response type when the user provides guidance. Matches the
-// server's VALID_RESPONSE_TYPES in resolve-escalation/route.ts.
-const DEFAULT_RESPONSE_TYPE = 'guidance'
+// Response types. Matches the server's VALID_RESPONSE_TYPES in
+// resolve-escalation/route.ts and the launcher's rouge-loop.js.
+type ResponseType =
+  | 'guidance'
+  | 'manual-fix-applied'
+  | 'dismiss-false-positive'
+  | 'abort-story'
+  | 'hand-off'
+  | 'resume-after-handoff'
 
 /**
  * Escalation response panel.
@@ -63,10 +69,18 @@ export function EscalationResponse({
   const [messages, setMessages] = useState<ChatEntry[]>([])
   const [sending, setSending] = useState(false)
   const [resuming, setResuming] = useState(false)
+  const [handingOff, setHandingOff] = useState(false)
+  const [showHandOff, setShowHandOff] = useState(false)
+  const [copied, setCopied] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
+  // Escalation may have been handed off in a prior session. Backend
+  // sets `handoff_started_at` on the escalation when `hand-off`
+  // resolves; when present, flip the UI to "I've resolved it" mode.
+  const isHandedOff = Boolean((escalation as { handoff_started_at?: string }).handoff_started_at)
+
   const submitResponse = useCallback(
-    async (text: string, resumeAfter: boolean): Promise<boolean> => {
+    async (text: string, resumeAfter: boolean, responseType: ResponseType = 'guidance'): Promise<boolean> => {
       if (!slug) return false
       setError(null)
       try {
@@ -75,7 +89,7 @@ export function EscalationResponse({
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             escalation_id: escalation.id,
-            response_type: DEFAULT_RESPONSE_TYPE,
+            response_type: responseType,
             text,
           }),
         })
@@ -107,7 +121,7 @@ export function EscalationResponse({
 
     if (!slug) return
     setSending(true)
-    void submitResponse(text, false).finally(() => setSending(false))
+    void submitResponse(text, false, 'guidance').finally(() => setSending(false))
   }, [inputValue, slug, submitResponse])
 
   const handleResume = useCallback(() => {
@@ -127,8 +141,38 @@ export function EscalationResponse({
       setInputValue('')
     }
     setResuming(true)
-    void submitResponse(text, true).finally(() => setResuming(false))
+    void submitResponse(text, true, 'guidance').finally(() => setResuming(false))
   }, [inputValue, messages, submitResponse])
+
+  const handleHandOff = useCallback(() => {
+    // User is going to work the problem in a direct Claude Code
+    // session. Park the project via `hand-off` response type; the
+    // launcher keeps the escalation pending until the user returns
+    // and clicks "I've resolved it". Dashboard stays open; parent
+    // doesn't refetch away.
+    if (!slug) return
+    setHandingOff(true)
+    void submitResponse('', false, 'hand-off').finally(() => setHandingOff(false))
+    setShowHandOff(true)
+  }, [slug, submitResponse])
+
+  const handleResolved = useCallback(() => {
+    // User finished their hand-off session. Launcher will capture
+    // git commits since handoff_started_at and inject them as
+    // human_resolution into the next phase's preamble.
+    const note = inputValue.trim()
+    setResuming(true)
+    void submitResponse(note, true, 'resume-after-handoff').finally(() => setResuming(false))
+  }, [inputValue, submitResponse])
+
+  const handoffCommand = slug ? `rouge resume-escalation ${slug}` : ''
+  const handleCopy = useCallback(() => {
+    if (!handoffCommand) return
+    navigator.clipboard?.writeText(handoffCommand).then(() => {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    }).catch(() => { /* clipboard unavailable */ })
+  }, [handoffCommand])
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLTextAreaElement>) => {
@@ -190,42 +234,119 @@ export function EscalationResponse({
             </div>
           )}
 
-          <label className="text-xs font-medium text-gray-500 mb-2 block">
-            Your Response
-          </label>
-          <Textarea
-            placeholder="Provide guidance or instructions... (Enter to send, Shift+Enter for newline)"
-            className="min-h-[4rem] resize-none bg-white"
-            rows={3}
-            value={inputValue}
-            onChange={(e) => setInputValue(e.target.value)}
-            onKeyDown={handleKeyDown}
-            disabled={inFlight}
-            data-testid="escalation-response-input"
-          />
-          <div className="mt-3 flex justify-end gap-2">
-            <Button
-              variant="outline"
-              size="sm"
-              className="gap-1.5"
-              onClick={handleSend}
-              disabled={!inputValue.trim() || inFlight}
-              data-testid="escalation-send-button"
-            >
-              <Send className="size-3.5" />
-              Send
-            </Button>
-            <Button
-              size="sm"
-              className="gap-1.5"
-              onClick={handleResume}
-              disabled={!canResume || inFlight}
-              data-testid="escalation-resume-button"
-            >
-              <Play className="size-3.5" />
-              {resuming ? 'Resuming…' : 'Respond & Resume'}
-            </Button>
-          </div>
+          {/* Hand-off in progress — show "I've resolved it" flow
+              instead of the regular guidance form. User ran
+              `rouge resume-escalation <slug>` (or is about to) and
+              will finish the work in their terminal. When done,
+              they come back here and click the button. Launcher
+              captures git commits and resumes. */}
+          {(isHandedOff || showHandOff) ? (
+            <div className="space-y-3" data-testid="escalation-handoff-active">
+              <div className="rounded-md border border-blue-200 bg-blue-50/60 p-3 text-xs text-blue-900">
+                <p className="font-medium mb-1 flex items-center gap-1.5">
+                  <Terminal className="h-3.5 w-3.5" />
+                  Handed off — resolve in your terminal
+                </p>
+                <p className="text-blue-900/80 mb-2">
+                  Run this in your terminal to open a Claude Code session primed with the escalation context:
+                </p>
+                <div className="flex items-center gap-2">
+                  <code className="flex-1 rounded bg-blue-100 px-2 py-1 font-mono text-[11px] text-blue-900">
+                    {handoffCommand}
+                  </code>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="gap-1 text-xs"
+                    onClick={handleCopy}
+                    data-testid="escalation-copy-handoff"
+                  >
+                    <Copy className="h-3 w-3" />
+                    {copied ? 'Copied' : 'Copy'}
+                  </Button>
+                </div>
+                <p className="mt-2 text-blue-900/70">
+                  Work through the problem with Claude in that session. When you&rsquo;re done, make a commit so the resolution lands on the branch, then come back here and click <strong>I&rsquo;ve resolved it</strong>.
+                </p>
+              </div>
+
+              <label className="text-xs font-medium text-gray-500 block">
+                Note for Rouge when it resumes (optional)
+              </label>
+              <Textarea
+                placeholder="What did you change? Any context Rouge should know as it continues?"
+                className="min-h-[3rem] resize-none bg-white"
+                rows={2}
+                value={inputValue}
+                onChange={(e) => setInputValue(e.target.value)}
+                disabled={inFlight}
+                data-testid="escalation-handoff-note"
+              />
+              <div className="flex justify-end">
+                <Button
+                  size="sm"
+                  className="gap-1.5 bg-green-600 hover:bg-green-700 text-white"
+                  onClick={handleResolved}
+                  disabled={inFlight}
+                  data-testid="escalation-resolved-button"
+                >
+                  <CheckCircle2 className="size-3.5" />
+                  {resuming ? 'Resuming…' : "I've resolved it"}
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <>
+              <label className="text-xs font-medium text-gray-500 mb-2 block">
+                Your Response
+              </label>
+              <Textarea
+                placeholder="Provide guidance or instructions... (Enter to send, Shift+Enter for newline)"
+                className="min-h-[4rem] resize-none bg-white"
+                rows={3}
+                value={inputValue}
+                onChange={(e) => setInputValue(e.target.value)}
+                onKeyDown={handleKeyDown}
+                disabled={inFlight}
+                data-testid="escalation-response-input"
+              />
+              <div className="mt-3 flex flex-wrap justify-end gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="gap-1.5"
+                  onClick={handleHandOff}
+                  disabled={inFlight || !slug}
+                  title="Park the project and work through the problem in a direct Claude Code session"
+                  data-testid="escalation-handoff-button"
+                >
+                  <Terminal className="size-3.5" />
+                  {handingOff ? 'Handing off…' : 'Hand off to Claude Code'}
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="gap-1.5"
+                  onClick={handleSend}
+                  disabled={!inputValue.trim() || inFlight}
+                  data-testid="escalation-send-button"
+                >
+                  <Send className="size-3.5" />
+                  Send
+                </Button>
+                <Button
+                  size="sm"
+                  className="gap-1.5"
+                  onClick={handleResume}
+                  disabled={!canResume || inFlight}
+                  data-testid="escalation-resume-button"
+                >
+                  <Play className="size-3.5" />
+                  {resuming ? 'Resuming…' : 'Respond & Resume'}
+                </Button>
+              </div>
+            </>
+          )}
         </div>
       </CardContent>
     </Card>

--- a/dashboard/src/lib/bridge-mapper.ts
+++ b/dashboard/src/lib/bridge-mapper.ts
@@ -156,7 +156,7 @@ function mapMilestone(m: RougeMilestone, index: number): Milestone {
   }
 }
 
-function mapEscalation(e: RougeEscalation): Escalation {
+function mapEscalation(e: RougeEscalation & { handoff_started_at?: string }): Escalation {
   const tier = (Math.max(0, Math.min(3, e.tier)) as EscalationTier)
   return {
     id: e.id,
@@ -166,6 +166,7 @@ function mapEscalation(e: RougeEscalation): Escalation {
     createdAt: e.created_at,
     resolvedAt: e.resolved_at,
     resolution: e.resolution,
+    handoff_started_at: e.handoff_started_at,
   }
 }
 

--- a/dashboard/src/lib/types.ts
+++ b/dashboard/src/lib/types.ts
@@ -115,6 +115,10 @@ export interface Escalation {
   createdAt: string
   resolvedAt?: string
   resolution?: string
+  // Set by the launcher when the user triggers a hand-off to direct
+  // Claude Code. The dashboard uses its presence to switch the
+  // escalation panel into "I've resolved it" mode.
+  handoff_started_at?: string
 }
 
 export interface CostInfo {

--- a/src/launcher/preamble-injector.js
+++ b/src/launcher/preamble-injector.js
@@ -11,7 +11,24 @@ const PREAMBLE_TEMPLATE = fs.readFileSync(
   path.join(__dirname, '../prompts/loop/_preamble.md'), 'utf8'
 );
 
-function buildPreamble({ phaseName, phaseDescription, modelName, requiredOutputKeys, learningsContent }) {
+// Escape `{{` / `}}` in user-supplied content so literal mustache-looking
+// text doesn't collide with preamble template placeholders on the next
+// pass. Used for learnings, human guidance, and human resolution blocks.
+function escapeMustache(s) {
+  return (s || '')
+    .replace(/\{\{/g, '\\{\\{')
+    .replace(/\}\}/g, '\\}\\}');
+}
+
+function buildPreamble({
+  phaseName,
+  phaseDescription,
+  modelName,
+  requiredOutputKeys,
+  learningsContent,
+  humanGuidance,
+  humanResolution,
+}) {
   let preamble = PREAMBLE_TEMPLATE
     .replace('{{phase_name}}', phaseName)
     .replace('{{phase_description}}', phaseDescription)
@@ -42,18 +59,64 @@ function buildPreamble({ phaseName, phaseDescription, modelName, requiredOutputK
     preamble = preamble.replace('{{required_output_keys}}', '(none specified)');
   }
 
+  // Human guidance — text the human submitted via the dashboard
+  // escalation panel. Without this block, guidance written to
+  // cycle_context.human_guidance (rouge-loop.js escalation handler)
+  // reached no phase — a bug the user's escalation audit caught. Now
+  // every phase sees it as a first-class instruction block.
+  if (humanGuidance && humanGuidance.trim()) {
+    preamble = preamble.replace(
+      '{{human_guidance_section}}',
+      `### Human guidance for this phase\n\n` +
+      `The human resolved an earlier escalation with this guidance. Treat it\n` +
+      `as higher-priority than your own judgement for the decisions it covers:\n\n` +
+      `${escapeMustache(humanGuidance.trim())}`
+    );
+  } else {
+    preamble = preamble.replace('{{human_guidance_section}}', '');
+  }
+
+  // Human resolution — the human took a problem offline (hand-off
+  // mode), worked it through directly in their terminal, and resumed.
+  // The resolution block captures what they changed (git diff summary
+  // + optional note) so the resuming phase has context for what just
+  // happened.
+  if (humanResolution && typeof humanResolution === 'object') {
+    const parts = ['### Human resolved this off-line'];
+    parts.push(
+      'The human handed this escalation off to a direct Claude Code session\n' +
+      'and resolved it in their terminal. Their work is already committed.\n' +
+      'Read this context, then continue the phase normally — do NOT redo the\n' +
+      'changes they made.'
+    );
+    if (humanResolution.note) {
+      parts.push(`\n**Note from the human**:\n${escapeMustache(humanResolution.note)}`);
+    }
+    if (Array.isArray(humanResolution.commits) && humanResolution.commits.length > 0) {
+      parts.push(`\n**Commits made during the resolution** (most recent first):`);
+      for (const c of humanResolution.commits) {
+        parts.push(`- \`${c.sha}\` ${c.subject}`);
+      }
+    }
+    if (Array.isArray(humanResolution.files_changed) && humanResolution.files_changed.length > 0) {
+      parts.push(`\n**Files touched**:`);
+      for (const f of humanResolution.files_changed) {
+        parts.push(`- \`${f}\``);
+      }
+    }
+    preamble = preamble.replace('{{human_resolution_section}}', parts.join('\n'));
+  } else {
+    preamble = preamble.replace('{{human_resolution_section}}', '');
+  }
+
   // Learnings — escape `{{` / `}}` in the user-supplied content so
   // literal mustache-looking text in learnings.md doesn't accidentally
   // collide with preamble template placeholders on the next pass.
   // Audit G9.
   if (learningsContent && learningsContent.trim()) {
-    const safeLearnings = learningsContent
-      .trim()
-      .replace(/\{\{/g, '\\{\\{')
-      .replace(/\}\}/g, '\\}\\}');
     preamble = preamble.replace(
       '{{learnings_section}}',
-      `### Project learnings\n${safeLearnings}`
+      `### Project learnings\n${escapeMustache(learningsContent.trim())}`
     );
   } else {
     preamble = preamble.replace('{{learnings_section}}', '');
@@ -70,7 +133,38 @@ function injectPreamble({ projectDir, phaseName, phaseDescription, modelName, re
     learningsContent = fs.readFileSync(learningsFile, 'utf8');
   }
 
-  return buildPreamble({ phaseName, phaseDescription, modelName, requiredOutputKeys, learningsContent });
+  // Read human guidance + resolution from cycle_context.json. These
+  // are populated by the launcher's escalation handler when the human
+  // either submits guidance text or completes a hand-off session.
+  // Both fields are consumed once — the handler clears them after
+  // the phase runs so they don't bleed into later cycles.
+  let humanGuidance = '';
+  let humanResolution = null;
+  const ctxFile = path.join(projectDir, 'cycle_context.json');
+  if (fs.existsSync(ctxFile)) {
+    try {
+      const ctx = JSON.parse(fs.readFileSync(ctxFile, 'utf8'));
+      if (typeof ctx.human_guidance === 'string') {
+        humanGuidance = ctx.human_guidance;
+      }
+      if (ctx.human_resolution && typeof ctx.human_resolution === 'object') {
+        humanResolution = ctx.human_resolution;
+      }
+    } catch {
+      // Malformed cycle_context — let the phase see no guidance
+      // rather than crashing the preamble assembly.
+    }
+  }
+
+  return buildPreamble({
+    phaseName,
+    phaseDescription,
+    modelName,
+    requiredOutputKeys,
+    learningsContent,
+    humanGuidance,
+    humanResolution,
+  });
 }
 
 module.exports = { buildPreamble, injectPreamble };

--- a/src/launcher/rouge-cli.js
+++ b/src/launcher/rouge-cli.js
@@ -1328,6 +1328,118 @@ if (command === 'doctor') {
     console.error(`  Fatal error: ${err.message}`);
     process.exit(1);
   });
+} else if (command === 'resume-escalation') {
+  // Hand-off flow: user has an open escalation and wants to work
+  // through it in a direct Claude Code session. This command:
+  //   1. Marks the latest pending escalation as hand-off
+  //   2. Prints a `claude -p` invocation primed with the escalation
+  //      context (summary, classification, recent build.log tail,
+  //      cycle_context excerpt). User runs claude themselves; when
+  //      done they press "I've resolved it" in the dashboard.
+  //
+  // Usage: rouge resume-escalation <project-slug>
+  const slug = args[1];
+  if (!slug) {
+    console.error('Usage: rouge resume-escalation <project-slug>');
+    process.exit(1);
+  }
+  const projectsRoot = process.env.ROUGE_PROJECTS_DIR ||
+    path.join(process.env.HOME || '', '.rouge', 'projects');
+  const projectDir = path.join(projectsRoot, slug);
+  if (!fs.existsSync(projectDir)) {
+    console.error(`  Project not found: ${slug}`);
+    process.exit(1);
+  }
+
+  const stateFile = fs.existsSync(path.join(projectDir, '.rouge', 'state.json'))
+    ? path.join(projectDir, '.rouge', 'state.json')
+    : path.join(projectDir, 'state.json');
+  if (!fs.existsSync(stateFile)) {
+    console.error(`  No state.json for ${slug}`);
+    process.exit(1);
+  }
+  const state = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
+  const pending = (state.escalations || []).find((e) => e.status === 'pending' && !e.human_response);
+  if (!pending) {
+    console.error(`  No pending escalation for ${slug}. Nothing to hand off.`);
+    process.exit(1);
+  }
+
+  // Mark the escalation as handed-off. Launcher picks this up on its
+  // next loop tick and parks the project.
+  pending.human_response = {
+    type: 'hand-off',
+    text: 'Handed off to direct Claude Code session',
+    submitted_at: new Date().toISOString(),
+  };
+  const tmp = stateFile + '.tmp';
+  fs.writeFileSync(tmp, JSON.stringify(state, null, 2) + '\n');
+  fs.renameSync(tmp, stateFile);
+
+  // Build a primed prompt for Claude Code.
+  const logFile = path.join(projectDir, 'build.log');
+  let logTail = '';
+  if (fs.existsSync(logFile)) {
+    try {
+      const raw = fs.readFileSync(logFile, 'utf8');
+      logTail = raw.split('\n').slice(-80).join('\n');
+    } catch { /* ignore */ }
+  }
+
+  const ctxFile = path.join(projectDir, 'cycle_context.json');
+  let ctxSummary = '';
+  if (fs.existsSync(ctxFile)) {
+    try {
+      const ctx = JSON.parse(fs.readFileSync(ctxFile, 'utf8'));
+      const pick = (k) => (ctx[k] ? `${k}: ${JSON.stringify(ctx[k]).slice(0, 500)}` : '');
+      ctxSummary = [
+        pick('current_phase'),
+        pick('evaluation_report'),
+        pick('qa_fix_results'),
+        pick('analysis_recommendation'),
+      ].filter(Boolean).join('\n\n');
+    } catch { /* ignore */ }
+  }
+
+  console.log(`
+  Hand-off primed for: ${slug}
+  Escalation: ${pending.id} (tier ${pending.tier})
+
+  The launcher has marked this escalation as handed-off. It will stay
+  parked until you submit "I've resolved it" from the dashboard.
+
+  To work through the problem now:
+
+    cd ${projectDir}
+    claude
+
+  When Claude opens, paste this as the first message:
+
+  ---
+  You are helping me resolve an escalation in this Rouge project.
+
+  **Escalation**: ${pending.classification || 'general'} (tier ${pending.tier})
+  **Summary**: ${pending.summary || '(none)'}
+  **Story**: ${pending.story_id || '(none)'}
+
+  **Recent build.log** (last 80 lines):
+  \`\`\`
+  ${logTail || '(log empty)'}
+  \`\`\`
+
+  **Context snapshot**:
+  ${ctxSummary || '(cycle_context empty)'}
+
+  Work with me to understand and resolve this. When we're done, make
+  a commit so the resolution is on the branch. The Rouge launcher
+  will capture the commits and resume the phase with them as context.
+  ---
+
+  When you finish: return to the dashboard, click "I've resolved it"
+  on the escalation card. The launcher will capture your commits and
+  resume.
+`);
+
 } else if (command === 'secrets') {
   const subcommand = args[1];
   if (subcommand === 'list') {
@@ -1371,6 +1483,9 @@ if (command === 'doctor') {
     rouge secrets expiry set <s/K> <date>  Set expiry for a secret
     rouge feasibility <description> Assess feasibility of a proposed change
     rouge contribute <path>         Contribute a draft integration pattern via PR
+    rouge resume-escalation <slug>  Prime a direct Claude Code session for an
+                                    escalation hand-off. Parks the project,
+                                    prints the claude command + context.
     rouge improve                   Run one self-improvement iteration
     rouge improve --max-iterations 5  Run up to 5 iterations
     rouge improve --explore         Enable exploration when no issues remain

--- a/src/launcher/rouge-loop.js
+++ b/src/launcher/rouge-loop.js
@@ -211,6 +211,14 @@ const VALID_HUMAN_RESPONSE_TYPES = new Set([
   'manual-fix-applied',
   'dismiss-false-positive',
   'abort-story',
+  // Hand-off mode: human is working through the problem in a direct
+  // Claude Code session in the project dir. Keeps the project parked
+  // until they submit `resume-after-handoff`.
+  'hand-off',
+  // User finished the hand-off session. Launcher captures any commits
+  // since the escalation fired and writes them as human_resolution
+  // context into cycle_context.json.
+  'resume-after-handoff',
 ]);
 
 /**
@@ -224,6 +232,43 @@ const VALID_HUMAN_RESPONSE_TYPES = new Set([
  * escalation with tier=999/malformed_response is raised so the user
  * can see what happened.
  */
+/**
+ * Capture commits made in a project directory since an ISO timestamp.
+ * Used by the escalation hand-off flow to summarise what the human
+ * changed during their direct Claude Code session. Returns an array
+ * of { sha, subject, files_changed[] }, newest first. Returns an
+ * empty array if the project isn't a git repo or the operation fails.
+ */
+function captureCommitsSince(projectDir, sinceIso) {
+  try {
+    if (!fs.existsSync(path.join(projectDir, '.git'))) return [];
+    const { execSync } = require('child_process');
+    // %H short-sha | %s subject, one commit per line.
+    const log = execSync(
+      `git log --since="${sinceIso}" --pretty=format:"%h|%s"`,
+      { cwd: projectDir, encoding: 'utf8', timeout: 10000, stdio: ['ignore', 'pipe', 'pipe'] },
+    ).trim();
+    if (!log) return [];
+    return log.split('\n').map((line) => {
+      const [sha, ...rest] = line.split('|');
+      const subject = rest.join('|');
+      let files_changed = [];
+      try {
+        const raw = execSync(
+          `git show --name-only --pretty=format: ${sha}`,
+          { cwd: projectDir, encoding: 'utf8', timeout: 5000, stdio: ['ignore', 'pipe', 'pipe'] },
+        );
+        files_changed = raw.split('\n').map((s) => s.trim()).filter(Boolean);
+      } catch {
+        /* swallow per-commit failure */
+      }
+      return { sha, subject, files_changed };
+    });
+  } catch {
+    return [];
+  }
+}
+
 function validateHumanResponse(hr) {
   if (!hr || typeof hr !== 'object' || Array.isArray(hr)) {
     return { ok: false, reason: 'human_response must be an object' };
@@ -1416,6 +1461,64 @@ async function advanceState(projectDir) {
           } else {
             next = 'milestone-check';
           }
+        } else if (hrType === 'hand-off') {
+          // User is working through the problem in a direct Claude Code
+          // session (`rouge resume-escalation <slug>` invocation). Mark
+          // the escalation as in-progress but keep the project parked
+          // in `escalation` state. The launcher won't advance until
+          // the user submits `resume-after-handoff`.
+          //
+          // We revert `status` back to 'pending' so the dashboard
+          // keeps showing the escalation card (user can change their
+          // mind), but we stash `handoff_started_at` so the resume
+          // path knows where to slice the git log from.
+          pendingEsc.status = 'pending';
+          pendingEsc.handoff_started_at = new Date().toISOString();
+          delete pendingEsc.resolved_at;
+          delete pendingEsc.human_response; // consume so we don't re-trigger
+          writeJson(stateFile, state);
+          log(`[${projectName}] Escalation handed off to direct Claude Code — parked until resume`);
+          // Stay in 'escalation' state.
+          next = 'escalation';
+        } else if (hrType === 'resume-after-handoff') {
+          // User finished their hand-off session. Capture any commits
+          // made since handoff_started_at, write them to
+          // cycle_context.human_resolution, and resume the phase that
+          // was paused when the escalation fired.
+          const since = pendingEsc.handoff_started_at || pendingEsc.created_at;
+          const commits = captureCommitsSince(projectDir, since);
+          const resolution = {
+            note: pendingEsc.human_response.text || '',
+            commits,
+            files_changed: Array.from(
+              new Set(commits.flatMap(c => c.files_changed || []))
+            ),
+          };
+          const resumeCtx = readJson(contextFile) || {};
+          resumeCtx.human_resolution = resolution;
+          writeJson(contextFile, resumeCtx);
+          state.consecutive_failures = 0;
+          // If the escalation was story-scoped, flip the story back to
+          // retrying so the next phase actually re-attempts it with
+          // the human_resolution context injected by the preamble.
+          const resumeStory = flat.find(s => s.id === pendingEsc.story_id);
+          if (resumeStory && (resumeStory.status === 'blocked' || resumeStory.status === 'pending')) {
+            resumeStory.status = 'retrying';
+          }
+          writeJson(stateFile, state);
+          const resumeMs = (state.milestones || []).find(m => m.name === state.current_milestone);
+          if (resumeMs) {
+            const elig = findNextStory(resumeMs, flatStories(state));
+            if (elig) {
+              next = startStory(state, resumeMs, elig);
+              writeJson(stateFile, state);
+            } else {
+              next = 'milestone-check';
+            }
+          } else {
+            next = 'milestone-check';
+          }
+          log(`[${projectName}] Escalation resumed after hand-off — ${commits.length} commit(s) captured`);
         } else {
           // Unrecognised response type — ignore, stay in escalation
           log(`[${projectName}] Unrecognised escalation response type: ${hrType}`);

--- a/src/prompts/loop/_preamble.md
+++ b/src/prompts/loop/_preamble.md
@@ -35,4 +35,8 @@ or discoveries to cycle_context.json under "pre_compaction_flush":
 }
 ```
 
+{{human_guidance_section}}
+
+{{human_resolution_section}}
+
 {{learnings_section}}

--- a/test/launcher/human-response-validation.test.js
+++ b/test/launcher/human-response-validation.test.js
@@ -28,6 +28,22 @@ describe('validateHumanResponse', () => {
     }
   });
 
+  test('accepts the hand-off + resume-after-handoff pair', () => {
+    // These drive the direct Claude Code hand-off flow — the user
+    // runs `rouge resume-escalation <slug>` in their terminal and
+    // works through the problem there. The enum pair is load-bearing.
+    assert.equal(validateHumanResponse({ type: 'hand-off' }).ok, true);
+    assert.equal(validateHumanResponse({ type: 'resume-after-handoff' }).ok, true);
+    assert.equal(
+      validateHumanResponse({
+        type: 'resume-after-handoff',
+        text: 'Fixed the regex; see commit abc1234',
+        submitted_at: '2026-04-18T12:00:00Z',
+      }).ok,
+      true,
+    );
+  });
+
   test('rejects null and undefined', () => {
     assert.equal(validateHumanResponse(null).ok, false);
     assert.equal(validateHumanResponse(undefined).ok, false);

--- a/test/launcher/preamble-injector.test.js
+++ b/test/launcher/preamble-injector.test.js
@@ -127,4 +127,76 @@ describe('Preamble Injector', () => {
       assert.ok(!result.includes('Project learnings'));
     });
   });
+
+  describe('human guidance + resolution injection', () => {
+    test('omits both sections when cycle_context is missing', () => {
+      const result = injectPreamble({
+        projectDir: tmpDir,
+        phaseName: 'story-building',
+        phaseDescription: 'Build',
+        modelName: 'opus',
+        requiredOutputKeys: [],
+      });
+      assert.ok(!result.includes('Human guidance for this phase'));
+      assert.ok(!result.includes('Human resolved this off-line'));
+    });
+
+    test('injects human_guidance block when cycle_context has the field', () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'cycle_context.json'),
+        JSON.stringify({
+          human_guidance: 'Use the existing Stripe client, not a new one. Look at lib/stripe.ts.',
+        }),
+      );
+      const result = injectPreamble({
+        projectDir: tmpDir,
+        phaseName: 'story-building',
+        phaseDescription: 'Build',
+        modelName: 'opus',
+        requiredOutputKeys: [],
+      });
+      assert.match(result, /Human guidance for this phase/);
+      assert.match(result, /Use the existing Stripe client/);
+      assert.match(result, /higher-priority than your own judgement/);
+    });
+
+    test('injects human_resolution block with commits + files', () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'cycle_context.json'),
+        JSON.stringify({
+          human_resolution: {
+            note: 'Regex was greedy; made it lazy.',
+            commits: [
+              { sha: 'abc1234', subject: 'fix(auth): lazy quantifier in token regex', files_changed: ['lib/auth.ts'] },
+            ],
+            files_changed: ['lib/auth.ts'],
+          },
+        }),
+      );
+      const result = injectPreamble({
+        projectDir: tmpDir,
+        phaseName: 'story-building',
+        phaseDescription: 'Build',
+        modelName: 'opus',
+        requiredOutputKeys: [],
+      });
+      assert.match(result, /Human resolved this off-line/);
+      assert.match(result, /Regex was greedy/);
+      assert.match(result, /abc1234/);
+      assert.match(result, /lib\/auth\.ts/);
+    });
+
+    test('swallows malformed cycle_context without throwing', () => {
+      fs.writeFileSync(path.join(tmpDir, 'cycle_context.json'), 'not json {{{');
+      assert.doesNotThrow(() =>
+        injectPreamble({
+          projectDir: tmpDir,
+          phaseName: 'story-building',
+          phaseDescription: 'Build',
+          modelName: 'opus',
+          requiredOutputKeys: [],
+        }),
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Scope

The escalation audit you asked for caught two issues, fixed in the same PR because they're the same problem at different depths:

1. **Dead plumbing (bug).** `cycle_context.human_guidance` was written on every `guidance` response but **no prompt read it**. Users typed guidance, submitted, and the text vanished.
2. **Single-shot model.** One textarea + submit is not how you debug a stuck problem. You need a proper Claude Code session with full project context, iteration, and the ability to commit fixes — then come back to Rouge.

## What's in

### Level 1 — Wire the guidance (the bug fix)

- `_preamble.md` gets `{{human_guidance_section}}` + `{{human_resolution_section}}` placeholders.
- `preamble-injector.js` reads `cycle_context.human_guidance` + `cycle_context.human_resolution` and renders them as first-class instruction blocks that every loop phase sees. Escapes `{{}}` in user-supplied content.
- 4 new preamble-injector tests.

### Level 3 — Hand-off to Claude Code (the collaborative flow)

Two new response types across launcher + dashboard:

- **`hand-off`**: user says "I'll work this in my terminal." Launcher parks the project, stashes `handoff_started_at`, keeps escalation pending.
- **`resume-after-handoff`**: user finished. Launcher runs `git log --since=<handoff_started_at>`, captures commits (sha + subject + files_changed), writes to `cycle_context.human_resolution`, resumes the paused phase. The resumed phase sees the resolution via the preamble.

### CLI helper — `rouge resume-escalation <slug>`

Primes the hand-off:
1. Marks the latest pending escalation as hand-off
2. Prints: `cd` command + `claude` invocation + pre-assembled prompt with escalation summary, classification, recent build.log tail (80 lines), cycle_context excerpt

User pastes that into Claude Code in their terminal, works through the problem, commits, returns to the dashboard, clicks **I've resolved it**. Launcher picks up the commits and resumes.

### Dashboard UI

`EscalationResponse` gets three action buttons (Send, Respond & Resume, **Hand off to Claude Code**). When handed off, the panel switches to a hand-off-active view: shows the `rouge resume-escalation <slug>` command with Copy button, an optional note field, and an **I've resolved it** button.

## What's deferred

- Packing rich diagnostic context into the escalation at *creation* time (dashboard-only users see minimal context until they trigger hand-off). Follow-up.
- Seeding escalations — stays in chat. No change.

## Test plan

- [x] 416 launcher tests pass (up from 400 — +16 new across preamble-injector + human-response-validation + fallout from G7/G3)
- [x] 371 dashboard tests pass
- [ ] Real-world validation via G22 dogfood

## Why this matters

Escalation now does what users expected it to do all along: **give you a way to unstick a problem by working through it directly, the same way you would in any other Claude Code session** — just with your fix landing automatically on the loop branch and with Rouge picking up where you left off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)