### PR TITLE
Story-scoped live feed inside active story cards

### DIFF
--- a/dashboard/src/app/api/projects/[name]/phase-events/route.ts
+++ b/dashboard/src/app/api/projects/[name]/phase-events/route.ts
@@ -16,9 +16,16 @@ export async function GET(
   if (!existsSync(projectDir)) {
     return NextResponse.json({ error: "Project not found" }, { status: 404 });
   }
-  const tailParam = new URL(request.url).searchParams.get("tail");
+  const url = new URL(request.url);
+  const tailParam = url.searchParams.get("tail");
   const tail = tailParam
     ? Math.max(1, Math.min(500, parseInt(tailParam, 10) || 100))
     : 100;
-  return NextResponse.json(readPhaseEvents(projectDir, tail));
+  // `story_id` filter: scopes the feed to events stamped with a
+  // specific current_story at phase-start. Used by the in-story feed
+  // inside the active story card so each card shows only its own
+  // tool calls — project-level phases (foundation, analyzing) don't
+  // leak into story cards.
+  const storyId = url.searchParams.get("story_id") ?? undefined;
+  return NextResponse.json(readPhaseEvents(projectDir, { tailCount: tail, storyId }));
 }

--- a/dashboard/src/app/projects/[name]/page.tsx
+++ b/dashboard/src/app/projects/[name]/page.tsx
@@ -346,7 +346,13 @@ export default function ProjectPage({
               onSelect={setSelectedMilestoneId}
             />
             <div className="mt-4 border-t border-gray-200 pt-4">
-              <StoryList milestones={project.milestones} selectedMilestoneId={selectedMilestoneId} enrichment={storyEnrichment} />
+              <StoryList
+                milestones={project.milestones}
+                selectedMilestoneId={selectedMilestoneId}
+                enrichment={storyEnrichment}
+                slug={project.slug}
+                buildRunning={buildRunning}
+              />
             </div>
           </CardContent>
         </Card>

--- a/dashboard/src/bridge/__tests__/phase-events-reader.test.ts
+++ b/dashboard/src/bridge/__tests__/phase-events-reader.test.ts
@@ -74,4 +74,30 @@ describe('readPhaseEvents', () => {
     expect(r.events).toEqual([])
     expect(r.sizeBytes).toBe(0)
   })
+
+  it('filters by storyId when provided — applies before tail slice', () => {
+    const events = [
+      { ts: '1', type: 'tool_use', name: 'Edit', summary: '/a.ts', story_id: 's1' },
+      { ts: '2', type: 'tool_use', name: 'Edit', summary: '/b.ts', story_id: 's2' },
+      { ts: '3', type: 'tool_use', name: 'Edit', summary: '/c.ts', story_id: 's1' },
+      { ts: '4', type: 'tool_use', name: 'Edit', summary: '/d.ts' }, // unstamped
+    ]
+    writeFileSync(
+      join(projectDir, EVENTS_FILENAME),
+      events.map((e) => JSON.stringify(e)).join('\n') + '\n',
+    )
+    const r = readPhaseEvents(projectDir, { storyId: 's1' })
+    expect(r.events).toHaveLength(2)
+    expect(r.events.every((e) => e.story_id === 's1')).toBe(true)
+    expect(r.totalCount).toBe(2)
+  })
+
+  it('accepts a positional tailCount for backwards compatibility', () => {
+    const events = Array.from({ length: 5 }, (_, i) =>
+      JSON.stringify({ ts: String(i), type: 'tool_use', name: 'Edit', summary: `/f${i}` }),
+    )
+    writeFileSync(join(projectDir, EVENTS_FILENAME), events.join('\n') + '\n')
+    const r = readPhaseEvents(projectDir, 3)
+    expect(r.events).toHaveLength(3)
+  })
 })

--- a/dashboard/src/bridge/phase-events-reader.ts
+++ b/dashboard/src/bridge/phase-events-reader.ts
@@ -23,6 +23,11 @@ export interface PhaseEvent {
   status?: 'ok' | 'error'
   exit_code?: number | null
   duration_ms?: number
+  // Story/milestone context stamped by the launcher at writer creation
+  // time so the dashboard can scope a feed per story. Absent for
+  // project-level phases (foundation, analyzing, shipping).
+  story_id?: string
+  milestone_name?: string
 }
 
 export interface PhaseEventsTail {
@@ -52,7 +57,23 @@ function emptyTail(): PhaseEventsTail {
  * case). If we start seeing MB-scale files in practice, switch to a
  * read-from-end strategy.
  */
-export function readPhaseEvents(projectDir: string, tailCount = 100): PhaseEventsTail {
+export interface ReadPhaseEventsOptions {
+  tailCount?: number
+  // Filter to events stamped with this story_id. Applied BEFORE the
+  // tail slice so tailCount = N returns the last N events *for this
+  // story*, not the last N overall that happen to include this story.
+  // Matches nothing when no events carry story_id (e.g. a project
+  // whose only phase run was foundation).
+  storyId?: string
+}
+
+export function readPhaseEvents(projectDir: string, optsOrTail: ReadPhaseEventsOptions | number = {}): PhaseEventsTail {
+  const opts: ReadPhaseEventsOptions = typeof optsOrTail === 'number'
+    ? { tailCount: optsOrTail }
+    : optsOrTail
+  const tailCount = opts.tailCount ?? 100
+  const storyId = opts.storyId
+
   const path = join(projectDir, EVENTS_FILENAME)
   if (!existsSync(path)) return emptyTail()
   try {
@@ -71,6 +92,7 @@ export function readPhaseEvents(projectDir: string, tailCount = 100): PhaseEvent
       try {
         const obj = JSON.parse(line)
         if (obj && typeof obj === 'object' && typeof obj.ts === 'string' && typeof obj.type === 'string') {
+          if (storyId && obj.story_id !== storyId) continue
           parsed.push(obj as PhaseEvent)
         }
       } catch {

--- a/dashboard/src/components/phase-events-feed.tsx
+++ b/dashboard/src/components/phase-events-feed.tsx
@@ -10,6 +10,13 @@ interface PhaseEventsFeedProps {
   // When true, polls every 1.5s. When false, fetches once (post-phase view).
   live?: boolean
   tail?: number
+  // Optional filter: only show events stamped with this story_id. Used
+  // by the per-story feed inside active story cards so each card shows
+  // its own tool calls, not the full project-wide stream.
+  storyId?: string
+  // Compact layout — used inside story cards where the full panel
+  // header + "N events" counter would be visual noise.
+  compact?: boolean
 }
 
 function formatTime(ts: string): string {
@@ -112,14 +119,20 @@ function EventRow({ ev }: { ev: PhaseEventPayload }) {
  * launcher, or no build has ever run), renders a short explanatory
  * empty state.
  */
-export function PhaseEventsFeed({ slug, live = false, tail = 100 }: PhaseEventsFeedProps) {
+export function PhaseEventsFeed({
+  slug,
+  live = false,
+  tail = 100,
+  storyId,
+  compact = false,
+}: PhaseEventsFeedProps) {
   const [payload, setPayload] = useState<PhaseEventsPayload | null>(null)
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
     let cancelled = false
     const load = () => {
-      fetchBridgePhaseEvents(slug, tail)
+      fetchBridgePhaseEvents(slug, tail, { storyId })
         .then((data) => {
           if (!cancelled) {
             setPayload(data)
@@ -136,7 +149,7 @@ export function PhaseEventsFeed({ slug, live = false, tail = 100 }: PhaseEventsF
       return () => { cancelled = true; clearInterval(i) }
     }
     return () => { cancelled = true }
-  }, [slug, live, tail])
+  }, [slug, live, tail, storyId])
 
   if (error) {
     return (
@@ -155,6 +168,20 @@ export function PhaseEventsFeed({ slug, live = false, tail = 100 }: PhaseEventsF
   }
 
   if (!payload.exists || payload.events.length === 0) {
+    // Compact empty state — used inside story cards where the longer
+    // explanatory text would be noisy. Stories that haven't been
+    // actively built yet just get a short waiting line.
+    if (compact) {
+      return (
+        <p className="text-xs text-gray-500">
+          {live
+            ? storyId
+              ? 'Waiting for Rouge to act on this story…'
+              : 'Waiting for the first event…'
+            : 'No activity recorded for this story yet.'}
+        </p>
+      )
+    }
     return (
       <div className="rounded-lg border border-dashed border-gray-200 bg-gray-50/50 p-6 text-center">
         <p className="text-sm text-gray-500">
@@ -165,6 +192,18 @@ export function PhaseEventsFeed({ slug, live = false, tail = 100 }: PhaseEventsF
         <p className="mt-1 text-xs text-gray-400">
           Event capture requires stream-json output — available on rouge-loop runs started after this feature shipped.
         </p>
+      </div>
+    )
+  }
+
+  if (compact) {
+    // Bare list — no outer chrome. The host container (the story
+    // card) already provides a heading + frame.
+    return (
+      <div className="max-h-48 overflow-auto">
+        {payload.events.map((ev, i) => (
+          <EventRow key={`${ev.ts}-${ev.id ?? i}-${i}`} ev={ev} />
+        ))}
       </div>
     )
   }

--- a/dashboard/src/components/story-list.tsx
+++ b/dashboard/src/components/story-list.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/components/ui/accordion'
 import { cn } from '@/lib/utils'
 import { Check, Circle, Loader2, SkipForward, X, ChevronDown, ChevronRight, FileCode, TestTube2, AlertTriangle, ListChecks, Sparkles } from 'lucide-react'
+import { PhaseEventsFeed } from '@/components/phase-events-feed'
 
 // Stories stamped with `addedAt` within this window are labelled
 // "Added by Rouge". After 24h they blend back into the plan — the
@@ -239,9 +240,15 @@ interface StoryListProps {
   milestones: Milestone[]
   selectedMilestoneId?: string
   enrichment?: StoryEnrichmentMap | null
+  // Project slug + live-build hint enable the per-story live feed
+  // that renders inside the active story's expanded card. Omit both
+  // (the default) for mock/offline rendering paths that don't have a
+  // bridge backing them.
+  slug?: string
+  buildRunning?: boolean
 }
 
-export function StoryList({ milestones, selectedMilestoneId, enrichment }: StoryListProps) {
+export function StoryList({ milestones, selectedMilestoneId, enrichment, slug, buildRunning }: StoryListProps) {
   // Use selectedMilestoneId if provided, otherwise fall back to current milestone logic
   const currentMilestone = selectedMilestoneId
     ? milestones.find((m) => m.id === selectedMilestoneId)
@@ -320,6 +327,29 @@ export function StoryList({ milestones, selectedMilestoneId, enrichment }: Story
               </AccordionTrigger>
               <AccordionContent>
                 <div className="flex flex-col gap-2 pl-2">
+                  {/* Live activity — in-progress stories render a
+                      compact phase-events feed scoped to this
+                      story_id. Moves the "what's Rouge doing for
+                      this specific story" signal from the project
+                      hero INTO the story card it's talking about,
+                      so cause and effect are co-located. Only
+                      mounts for in-progress stories to avoid
+                      polling for every expanded done card. */}
+                  {slug && story.status === 'in-progress' && (
+                    <div className="mb-1 rounded-md border border-blue-200 bg-blue-50/50 p-2">
+                      <p className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-blue-700">
+                        Live activity
+                      </p>
+                      <PhaseEventsFeed
+                        slug={slug}
+                        live={!!buildRunning}
+                        storyId={story.id}
+                        tail={30}
+                        compact
+                      />
+                    </div>
+                  )}
+
                   {/* Acceptance criteria (always shown) */}
                   {story.acceptanceCriteria.length > 0 && (
                     <>

--- a/dashboard/src/lib/bridge-client.ts
+++ b/dashboard/src/lib/bridge-client.ts
@@ -104,8 +104,14 @@ export interface PhaseEventsPayload {
   exists: boolean
 }
 
-export async function fetchBridgePhaseEvents(name: string, tail = 100): Promise<PhaseEventsPayload> {
-  const res = await fetch(`${BRIDGE_URL}/api/projects/${name}/phase-events?tail=${tail}`)
+export async function fetchBridgePhaseEvents(
+  name: string,
+  tail = 100,
+  options: { storyId?: string } = {},
+): Promise<PhaseEventsPayload> {
+  const qs = new URLSearchParams({ tail: String(tail) })
+  if (options.storyId) qs.set('story_id', options.storyId)
+  const res = await fetch(`${BRIDGE_URL}/api/projects/${name}/phase-events?${qs.toString()}`)
   if (!res.ok) throw new Error(`Bridge error: ${res.status}`)
   return res.json()
 }


### PR DESCRIPTION
## Summary

Follow-up to #183. Every phase event now carries `story_id`, so the per-story feed can live where the user looks for "what's Rouge doing on this story" — inside the card itself — not only in the project hero.

## Changes

- `phase-events-reader.ts` — accepts `{ storyId }` filter; applies before tail slice so `tailCount` returns the last N events for this story, not the last N overall. Positional `tailCount` still works for backwards compatibility.
- `/api/projects/[name]/phase-events` route — threads `story_id` query param through.
- `bridge-client.fetchBridgePhaseEvents` — optional `storyId` option.
- `PhaseEventsFeed` — new `storyId` + `compact` props. Compact mode drops the panel chrome (border, header, event counter) and tightens the scroll container; suitable for inline use inside a story card.
- `StoryList` — for in-progress stories, renders a compact scoped feed inside the expanded Accordion content, framed in a small "Live activity" blue sub-card so the scoping is visually obvious. Passes `slug` + `buildRunning` through from the project page.

## Tests

- +2 reader cases (storyId filter, backwards-compat positional signature)
- Dashboard: 405 → 407 · 0 TS errors · launcher unchanged (459 total, the one fail is the pre-existing empirical `claude -p` flake)

## Test plan

- [x] `npx vitest run` — 407/407 pass
- [x] `npx tsc --noEmit` — 0 errors
- [ ] Manually: expand an in-progress story card; confirm the "Live activity" sub-card renders only events stamped with that story's ID
- [ ] Manually: confirm non-in-progress cards don't mount the feed (no needless polling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)