### PR TITLE
Fix duplicate escalation hero, stale-dismiss 404, and unspecified story-building escalations

### DIFF
--- a/dashboard/src/components/__tests__/current-focus-card.test.tsx
+++ b/dashboard/src/components/__tests__/current-focus-card.test.tsx
@@ -3,20 +3,20 @@ import { describe, it, expect } from 'vitest'
 import { CurrentFocusCard } from '../current-focus-card'
 
 describe('CurrentFocusCard', () => {
-  it('shows the escalation band when state is escalation', () => {
-    render(
-      <CurrentFocusCard
-        state="escalation"
-        escalationSummary="Deploy target was never set"
-      />,
+  it('returns null for escalation state — escalation drawer above the tabs owns that surface', () => {
+    // Previously the hero rendered a full amber box on top of the
+    // drawer, which looked like duplicate warnings. The state badge
+    // in the project header still carries the "Needs your input"
+    // label for at-a-glance visibility.
+    const { container } = render(
+      <CurrentFocusCard state="escalation" escalationSummary="Deploy target was never set" />,
     )
-    expect(screen.getByTestId('current-focus-escalation')).toBeInTheDocument()
-    expect(screen.getByText(/Deploy target was never set/)).toBeInTheDocument()
+    expect(container).toBeEmptyDOMElement()
   })
 
-  it('falls back to a generic message when escalation has no summary', () => {
-    render(<CurrentFocusCard state="escalation" />)
-    expect(screen.getByText(/Open the escalation below/)).toBeInTheDocument()
+  it('returns null for waiting-for-human state too', () => {
+    const { container } = render(<CurrentFocusCard state="waiting-for-human" />)
+    expect(container).toBeEmptyDOMElement()
   })
 
   it('shows the shipped band when state is complete', () => {

--- a/dashboard/src/components/current-focus-card.tsx
+++ b/dashboard/src/components/current-focus-card.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react'
 import type { ProjectState } from '@/lib/types'
 import type { StoryContext } from '@/bridge/story-context-reader'
 import { phaseLabel, phaseGloss } from '@/lib/phase-labels'
-import { Loader2, Flag, CheckCircle2, AlertTriangle } from 'lucide-react'
+import { Loader2, Flag, CheckCircle2 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 
 interface CurrentFocusCardProps {
@@ -63,24 +63,14 @@ export function CurrentFocusCard({
     return () => clearInterval(interval)
   }, [buildRunning])
 
-  // Escalation mode — overrides everything else.
+  // Escalation mode — previously rendered a full amber box here, but
+  // the actionable escalation drawer is already pinned above the tabs
+  // with the same title + summary + tier badge. Two boxes saying the
+  // same thing confused users. Return null so the drawer is the only
+  // surface for escalation state; the StateBadge in the header keeps
+  // the "Needs your input" label visible at a glance.
   if (state === 'escalation' || state === 'waiting-for-human') {
-    return (
-      <div
-        className="flex items-start gap-3 rounded-lg border-2 border-amber-300 bg-amber-50 px-4 py-3"
-        data-testid="current-focus-escalation"
-      >
-        <AlertTriangle className="mt-0.5 size-5 shrink-0 text-amber-600" />
-        <div className="min-w-0 flex-1">
-          <div className="text-sm font-semibold text-amber-900">
-            {phaseLabel(state)}
-          </div>
-          <div className="mt-0.5 truncate text-xs text-amber-900/80">
-            {escalationSummary ?? "Open the escalation below to respond."}
-          </div>
-        </div>
-      </div>
-    )
+    return null
   }
 
   if (state === 'complete') {

--- a/dashboard/src/components/escalation-response.tsx
+++ b/dashboard/src/components/escalation-response.tsx
@@ -95,6 +95,16 @@ export function EscalationResponse({
         })
         if (!res.ok) {
           const body = (await res.json().catch(() => ({}))) as { error?: string }
+          // A 404 "No pending escalation found" means the escalation
+          // has already been resolved server-side — commonly the loop
+          // processed a prior resolution and the dashboard's cached
+          // state lagged behind. Treat as "stale view, refresh" rather
+          // than an error the user needs to act on. The parent's
+          // onResolved refetch clears the stale card.
+          if (res.status === 404 && /no pending escalation/i.test(body.error ?? '')) {
+            onResolved?.()
+            return true
+          }
           setError(body.error ?? `HTTP ${res.status}`)
           return false
         }

--- a/src/launcher/rouge-loop.js
+++ b/src/launcher/rouge-loop.js
@@ -835,9 +835,38 @@ async function advanceState(projectDir) {
     case 'story-building': {
       const ctx = readJson(contextFile);
       const milestone = (state.milestones || []).find(m => m.name === state.current_milestone);
-      if (!milestone) { next = 'escalation'; break; }
+      if (!milestone) {
+        // Happens when a story completed on the previous tick but the
+        // current_milestone pointer now references something that's
+        // been removed or renamed. Escalate with a concrete reason so
+        // the user sees what went wrong instead of a generic
+        // placeholder synthesized by the dispatcher fallback.
+        next = escalate(state, {
+          id: `esc-story-building-missing-milestone-${Date.now()}`,
+          tier: 1,
+          classification: 'state-drift',
+          summary: `story-building entered but current_milestone='${state.current_milestone}' is not in state.milestones. Possible state corruption; reset to Ready and re-run.`,
+        });
+        break;
+      }
       const story = (milestone.stories || []).find(s => s.id === state.current_story);
-      if (!story) { next = 'escalation'; break; }
+      if (!story) {
+        // Testimonial's symptom at 15:34:14: story M1-S1.1 completed
+        // successfully (+87 files), pre-dispatch advanced current_story
+        // to the next pending id, then story-building re-entered
+        // without claude producing a story_result — resulting in
+        // "milestone found, next-story pointer valid, but the named
+        // story wasn't in milestone.stories" for some timing window.
+        // Escalate with context rather than silently advancing to an
+        // unspecified escalation placeholder.
+        next = escalate(state, {
+          id: `esc-story-building-missing-story-${Date.now()}`,
+          tier: 1,
+          classification: 'state-drift',
+          summary: `story-building entered but current_story='${state.current_story}' is not in milestone '${state.current_milestone}'. Possible pre-dispatch advance race; reset to Ready and re-run.`,
+        });
+        break;
+      }
 
       const result = ctx?.story_result || {};
       const outcome = result.outcome || 'pass';


### PR DESCRIPTION
## Summary

Three related fixes surfaced on testimonial this afternoon.

### 1. Hero + drawer both rendered for escalation
The Current Focus hero and the EscalationResponse drawer each showed an amber escalation band — two boxes with overlapping content. The drawer above the tabs is the actionable one; the hero returns `null` for `escalation` / `waiting-for-human` state now. The `StateBadge` in the project header keeps the "Needs your input" label visible at a glance.

### 2. Dismissing an already-resolved escalation showed a red error
If the launcher resolved an escalation between the dashboard's last fetch and the user's click, `/resolve-escalation` returned 404 "No pending escalation found" and the UI showed it as an error. The client now treats that specific 404 as "stale cached view — refetch" and calls `onResolved` so the card clears without a scary message. Meaningful 4xx / 5xx errors still surface.

### 3. story-building had two silent-escalation paths
When the case handler couldn't find `current_milestone` or `current_story` in `state.milestones`, it set `next = 'escalation'` without pushing a specific escalation object. Testimonial hit this after story M1-S1.1 completed (+87 files); the dispatcher self-heal had to synthesise a generic "unspecified-from-story-building" placeholder. Both guards now go through `escalate()` with a `state-drift` classification and a specific summary telling the user what happened and what to do (reset to Ready, re-run). The dispatcher self-heal stays in place as a backstop, not the primary error path.

## Tests

- Launcher: 459/459
- Dashboard: 407/407 (current-focus-card tests updated for the null-on-escalation behaviour)
- 0 TypeScript errors

## Test plan

- [x] `npm test` · `npx vitest run` · `npx tsc --noEmit`
- [ ] Manually: trigger an escalation and confirm exactly one box (the drawer) renders
- [ ] Manually: have the loop resolve an escalation then click Dismiss on the stale card — should refresh silently, no error

🤖 Generated with [Claude Code](https://claude.com/claude-code)