### PR TITLE
Fix: carry escalation status through the mapper

### DIFF
--- a/dashboard/src/app/projects/[name]/page.tsx
+++ b/dashboard/src/app/projects/[name]/page.tsx
@@ -282,8 +282,13 @@ export default function ProjectPage({
   const activity = bridgeActivity ?? getProjectActivity(project.slug)
   const isSeeding = project.state === 'seeding'
   const isEscalation = project.state === 'escalation' || project.state === 'waiting-for-human'
+  // Only pending escalations need a drawer. Historical resolved ones
+  // stay in state.escalations as history but shouldn't render as
+  // actionable cards. Earlier iterations cast through `any` to read
+  // status which the mapper wasn't carrying through — three resolved
+  // escalations then rendered as if they were live.
   const pendingEscalations = isEscalation
-    ? project.escalations.filter((e) => (e as { status?: string }).status !== 'resolved')
+    ? project.escalations.filter((e) => e.status !== 'resolved')
     : []
 
   // Unified layout: ProjectTabs with Spec (View/Revise modes) + Build.

--- a/dashboard/src/lib/__tests__/bridge-mapper.test.ts
+++ b/dashboard/src/lib/__tests__/bridge-mapper.test.ts
@@ -45,6 +45,40 @@ describe('mapRougeStateToProjectDetail — review-loop overlay', () => {
   })
 })
 
+describe('mapRougeStateToProjectDetail — escalation status passthrough', () => {
+  // Regression: the mapper used to drop 'status' from escalations.
+  // The page-level pending filter (e.status !== 'resolved') then
+  // treated historical resolved escalations as if they were live,
+  // producing a stack of identical drawers.
+  it('carries status=resolved through for resolved escalations', () => {
+    const mapped = mapRougeStateToProjectDetail(
+      {
+        project: 'demo',
+        current_state: 'escalation',
+        escalations: [
+          { id: 'e1', tier: 1, status: 'resolved', resolved_at: '2026-04-19T15:00:00Z' },
+          { id: 'e2', tier: 1, status: 'pending' },
+        ],
+      },
+      'demo',
+    )
+    expect(mapped.escalations[0].status).toBe('resolved')
+    expect(mapped.escalations[1].status).toBe('pending')
+  })
+
+  it('defaults status=pending when the raw escalation omits it', () => {
+    const mapped = mapRougeStateToProjectDetail(
+      {
+        project: 'demo',
+        current_state: 'escalation',
+        escalations: [{ id: 'e1', tier: 1 }],
+      },
+      'demo',
+    )
+    expect(mapped.escalations[0].status).toBe('pending')
+  })
+})
+
 describe('mapRougeStateToProjectDetail — story provenance', () => {
   it('passes addedAt and addedBy through to the mapped story', () => {
     const mapped = mapRougeStateToProjectDetail(

--- a/dashboard/src/lib/bridge-mapper.ts
+++ b/dashboard/src/lib/bridge-mapper.ts
@@ -162,11 +162,18 @@ function mapMilestone(m: RougeMilestone, index: number): Milestone {
 
 function mapEscalation(e: RougeEscalation & { handoff_started_at?: string }): Escalation {
   const tier = (Math.max(0, Math.min(3, e.tier)) as EscalationTier)
+  // Preserve 'status' — consumed by the page-level filter that decides
+  // which escalations render as active drawers. Before this field was
+  // carried through, every escalation in state.escalations (including
+  // historical resolved ones) rendered as pending, so testimonial's
+  // page showed three boxes for one real issue.
+  const status = e.status === 'resolved' ? 'resolved' : 'pending'
   return {
     id: e.id,
     tier,
     reason: e.summary ?? e.reason ?? e.classification ?? 'Escalation raised',
     state: (e.state as ProjectState) ?? 'escalation',
+    status,
     createdAt: e.created_at,
     resolvedAt: e.resolved_at,
     resolution: e.resolution,

--- a/dashboard/src/lib/types.ts
+++ b/dashboard/src/lib/types.ts
@@ -134,6 +134,12 @@ export interface Escalation {
   tier: EscalationTier
   reason: string
   state: ProjectState
+  // Pipeline status. Only 'pending' escalations block the loop / need
+  // user action; 'resolved' ones are history. Previously absent from
+  // the mapped shape, which made the page-level pending filter a no-op
+  // — three resolved escalations rendered as if they were all live
+  // until this field was carried through.
+  status?: 'pending' | 'resolved'
   createdAt: string
   resolvedAt?: string
   resolution?: string


### PR DESCRIPTION
## Summary

The page-level pending filter (`e.status !== 'resolved'`) was reading a field the mapper never wrote, so every escalation in `state.escalations` — pending and resolved alike — rendered as a live drawer. Testimonial showed three boxes for one real issue (two historical resolved ones + one pending).

- `mapEscalation` now returns `status: 'pending' | 'resolved'` explicitly, normalising anything non-'resolved' to 'pending' defensively.
- `Escalation` type exports the field.
- Page filter drops the any-cast and uses the typed status.

## Tests

- Dashboard: 407 → 409 (+2 mapper regression tests)
- Launcher: 459/459 unchanged · TS 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)