### PR TITLE
Build view trust sweep: single source of truth, no lying fallbacks

### DIFF
--- a/dashboard/src/app/projects/[name]/page.tsx
+++ b/dashboard/src/app/projects/[name]/page.tsx
@@ -301,13 +301,12 @@ export default function ProjectPage({
   const defaultTab: 'spec' | 'build' = buildDisabled ? 'spec' : 'build'
   // Spec defaults to Revise during active seeding, View once past seeding.
   const defaultSpecMode: 'view' | 'revise' = isSeeding ? 'revise' : 'view'
-  // Pull the most actionable escalation summary into the hero so the
-  // user sees *why* Rouge stopped without scrolling down to the drawer.
-  const topEscalationSummary = pendingEscalations[0]
-    ? ((pendingEscalations[0] as { summary?: string; reason?: string }).summary
-      ?? (pendingEscalations[0] as { summary?: string; reason?: string }).reason
-      ?? undefined)
-    : undefined
+  // Escalation summary for the hero. Escalation.reason is the
+  // mapper's canonical text field (summary / reason / classification
+  // / placeholder, in order of preference) so no unsafe cast is
+  // needed — and no conflicting `summary` field exists on the mapped
+  // shape to trip over.
+  const topEscalationSummary = pendingEscalations[0]?.reason
 
   // Derive a short "latest tool call" line for the hero from the
   // polled phase events. `tool_use` events carry the tool name + a
@@ -363,8 +362,11 @@ export default function ProjectPage({
         </Card>
       )}
 
-      {/* Build cost progress bar for BUILDING projects */}
-      {project.state !== 'complete' && project.cost.budgetCap > 0 && project.cost.totalSpend > 0 && (
+      {/* Build cost progress bar for BUILDING projects. Renders even
+          at $0 spent so the user has forward visibility into available
+          budget; previously hidden until the first token charge which
+          made new builds look unbudgeted. */}
+      {project.state !== 'complete' && project.cost.budgetCap > 0 && (
         <div className="mt-6 rounded-lg border border-gray-200 bg-gray-50 p-4">
           <div className="flex items-center justify-between mb-2">
             <span className="text-xs font-medium text-gray-500">Build Cost</span>
@@ -460,9 +462,9 @@ export default function ProjectPage({
               {pendingEscalations.length} escalations pending — resolve each one below.
             </p>
           )}
-          {pendingEscalations.map((esc, i) => (
+          {pendingEscalations.map((esc) => (
             <EscalationResponse
-              key={(esc as { id?: string }).id ?? i}
+              key={esc.id}
               escalation={esc}
               slug={project.slug}
               onResolved={refetch}
@@ -499,6 +501,8 @@ export default function ProjectPage({
         productionUrl={project.productionUrl}
         escalation={project.escalations[0]}
         onCommandComplete={refetch}
+        buildRunning={buildRunning}
+        buildStartedAt={project.buildStartedAt}
       />
     </div>
   )

--- a/dashboard/src/components/__tests__/action-bar.test.tsx
+++ b/dashboard/src/components/__tests__/action-bar.test.tsx
@@ -35,7 +35,7 @@ describe('ActionBar — mid-phase zombie (state says building, no live PID)', ()
   // / vision-check is gone — see build-runner rollback allowlist gap.
 
   it('renders Resume + Reset when state is mid-phase and no process is alive', async () => {
-    render(<ActionBar state="foundation-eval" slug="alpha" />)
+    render(<ActionBar state="foundation-eval" slug="alpha" buildRunning={false} />)
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /^resume build$/i })).toBeInTheDocument()
       expect(screen.getByRole('button', { name: /^reset to ready$/i })).toBeInTheDocument()
@@ -47,7 +47,7 @@ describe('ActionBar — mid-phase zombie (state says building, no live PID)', ()
     const user = userEvent.setup()
     mockSendCommand.mockResolvedValueOnce({ ok: true, pid: 123 })
 
-    render(<ActionBar state="foundation-eval" slug="alpha" />)
+    render(<ActionBar state="foundation-eval" slug="alpha" buildRunning={false} />)
     await user.click(await screen.findByRole('button', { name: /^resume build$/i }))
 
     await waitFor(() => expect(mockSendCommand).toHaveBeenCalledWith('alpha', 'start', undefined))
@@ -60,7 +60,7 @@ describe('ActionBar — mid-phase zombie (state says building, no live PID)', ()
     const user = userEvent.setup()
     mockSendCommand.mockResolvedValueOnce({ ok: true, priorState: 'foundation-eval' })
 
-    render(<ActionBar state="foundation-eval" slug="alpha" />)
+    render(<ActionBar state="foundation-eval" slug="alpha" buildRunning={false} />)
     await user.click(await screen.findByRole('button', { name: /^reset to ready$/i }))
 
     // Dialog renders a second "Reset to Ready" button — click it.
@@ -72,7 +72,7 @@ describe('ActionBar — mid-phase zombie (state says building, no live PID)', ()
   })
 
   it('surfaces a hint explaining the Resume/Reset choice', async () => {
-    render(<ActionBar state="foundation-eval" slug="alpha" />)
+    render(<ActionBar state="foundation-eval" slug="alpha" buildRunning={false} />)
     await waitFor(() => {
       expect(
         screen.getByText(/build stopped at foundation-eval/i),
@@ -85,7 +85,7 @@ describe('ActionBar — mid-phase zombie (state says building, no live PID)', ()
     mockSendCommand.mockRejectedValueOnce(new Error('state locked'))
     const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
-    render(<ActionBar state="foundation-eval" slug="alpha" />)
+    render(<ActionBar state="foundation-eval" slug="alpha" buildRunning={false} />)
     await user.click(await screen.findByRole('button', { name: /^reset to ready$/i }))
     const buttons = screen.getAllByRole('button', { name: /^reset to ready$/i })
     await user.click(buttons.at(-1)!)
@@ -101,19 +101,15 @@ describe('ActionBar — mid-phase zombie (state says building, no live PID)', ()
 })
 
 describe('ActionBar — Stop Build (live process)', () => {
-  // When buildRunning is true, Stop is the only action shown. These
-  // tests lock in the confirmation + notice paths for that case.
+  // When buildRunning is true, Stop is the only action shown. The
+  // prop is now a parent-owned snapshot (previously an internal 5 s
+  // poll) — tests pass it explicitly.
 
   it('shows an inline notice when stop succeeds on an already-stopped build', async () => {
     const user = userEvent.setup()
-    // Initial poll says running; after stop the follow-up status poll
-    // returns not running. sendCommand responds with alreadyStopped.
-    mockFetchBuildStatus
-      .mockResolvedValueOnce({ running: true, startedAt: new Date().toISOString() })
-      .mockResolvedValue({ running: false, startedAt: null })
     mockSendCommand.mockResolvedValueOnce({ ok: true, alreadyStopped: true })
 
-    render(<ActionBar state="foundation" slug="alpha" />)
+    render(<ActionBar state="foundation" slug="alpha" buildRunning={true} buildStartedAt={new Date().toISOString()} />)
 
     const topStop = await screen.findByRole('button', { name: /^stop build$/i })
     await user.click(topStop)
@@ -129,13 +125,10 @@ describe('ActionBar — Stop Build (live process)', () => {
 
   it('surfaces command errors inline instead of throwing to console.error', async () => {
     const user = userEvent.setup()
-    mockFetchBuildStatus
-      .mockResolvedValueOnce({ running: true, startedAt: new Date().toISOString() })
-      .mockResolvedValue({ running: false, startedAt: null })
     mockSendCommand.mockRejectedValueOnce(new Error('something went wrong'))
     const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
-    render(<ActionBar state="foundation" slug="alpha" />)
+    render(<ActionBar state="foundation" slug="alpha" buildRunning={true} buildStartedAt={new Date().toISOString()} />)
 
     const topStop = await screen.findByRole('button', { name: /^stop build$/i })
     await user.click(topStop)

--- a/dashboard/src/components/__tests__/current-focus-card.test.tsx
+++ b/dashboard/src/components/__tests__/current-focus-card.test.tsx
@@ -3,20 +3,19 @@ import { describe, it, expect } from 'vitest'
 import { CurrentFocusCard } from '../current-focus-card'
 
 describe('CurrentFocusCard', () => {
-  it('returns null for escalation state — escalation drawer above the tabs owns that surface', () => {
-    // Previously the hero rendered a full amber box on top of the
-    // drawer, which looked like duplicate warnings. The state badge
-    // in the project header still carries the "Needs your input"
-    // label for at-a-glance visibility.
-    const { container } = render(
-      <CurrentFocusCard state="escalation" escalationSummary="Deploy target was never set" />,
-    )
-    expect(container).toBeEmptyDOMElement()
+  it('renders a thin nudge to the escalation banner above the tabs', () => {
+    // Previously rendered a full amber box duplicating the drawer,
+    // then briefly returned null (which made the hero disappear and
+    // broke the page narrative). Settled on a single-line nudge that
+    // points to the drawer without restating its contents.
+    render(<CurrentFocusCard state="escalation" escalationSummary="Deploy target was never set" />)
+    expect(screen.getByTestId('current-focus-escalation-nudge')).toBeInTheDocument()
+    expect(screen.getByText(/respond in the banner above/i)).toBeInTheDocument()
   })
 
-  it('returns null for waiting-for-human state too', () => {
-    const { container } = render(<CurrentFocusCard state="waiting-for-human" />)
-    expect(container).toBeEmptyDOMElement()
+  it('shows the same nudge for waiting-for-human', () => {
+    render(<CurrentFocusCard state="waiting-for-human" />)
+    expect(screen.getByTestId('current-focus-escalation-nudge')).toBeInTheDocument()
   })
 
   it('shows the shipped band when state is complete', () => {

--- a/dashboard/src/components/__tests__/escalation-drawer.test.tsx
+++ b/dashboard/src/components/__tests__/escalation-drawer.test.tsx
@@ -8,6 +8,7 @@ const escalation: Escalation = {
   tier: 1,
   reason: 'Staging deploy failed — bundle size exceeds 1MB Workers limit.',
   state: 'escalation',
+  status: 'pending',
   createdAt: '2026-03-30T16:20:00Z',
 }
 

--- a/dashboard/src/components/action-bar.tsx
+++ b/dashboard/src/components/action-bar.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import type { Escalation, ProjectState } from '@/lib/types'
-import { useState, useCallback, useEffect } from 'react'
-import { isBridgeEnabled, sendCommand, fetchBuildStatus } from '@/lib/bridge-client'
+import { useState, useCallback } from 'react'
+import { isBridgeEnabled, sendCommand } from '@/lib/bridge-client'
 import { Button } from '@/components/ui/button'
 import { EscalationDrawer } from '@/components/escalation-drawer'
 import { ConfirmDialog } from '@/components/confirm-dialog'
@@ -35,40 +35,29 @@ interface ActionBarProps {
   productionUrl?: string
   escalation?: Escalation
   onCommandComplete?: () => void
+  // Parent-owned build-status snapshot — the page reads it from the
+  // project payload (PID liveness + startedAt) and keeps it fresh via
+  // SSE + post-mutation refetch. ActionBar used to run its own 5 s
+  // poll, which drifted against the page by up to 5 s and made the
+  // Stop button flicker for users. Single source of truth now.
+  buildRunning: boolean
+  buildStartedAt?: string | null
 }
 
-export function ActionBar({ state, slug, productionUrl, escalation, onCommandComplete }: ActionBarProps) {
+export function ActionBar({
+  state,
+  slug,
+  productionUrl,
+  escalation,
+  onCommandComplete,
+  buildRunning,
+  buildStartedAt,
+}: ActionBarProps) {
   const [drawerOpen, setDrawerOpen] = useState(false)
   const [loading, setLoading] = useState<string | null>(null)
-  const [buildRunning, setBuildRunning] = useState(false)
   const [confirmAction, setConfirmAction] = useState<'start' | 'stop' | 'reset' | null>(null)
-  const [buildStartedAt, setBuildStartedAt] = useState<string | null>(null)
   const [commandError, setCommandError] = useState<string | null>(null)
   const [commandNotice, setCommandNotice] = useState<string | null>(null)
-
-  // Poll build status every 5s so the button reflects subprocess state
-  // even before the Rouge loop has written its first checkpoint.
-  useEffect(() => {
-    if (!slug || !isBridgeEnabled()) return
-    let cancelled = false
-    const check = async () => {
-      try {
-        const status = await fetchBuildStatus(slug)
-        if (!cancelled) {
-          setBuildRunning(status.running)
-          setBuildStartedAt(status.startedAt ?? null)
-        }
-      } catch {
-        // Silent — status poll is best-effort
-      }
-    }
-    check()
-    const interval = setInterval(check, 5000)
-    return () => {
-      cancelled = true
-      clearInterval(interval)
-    }
-  }, [slug])
 
   const runCommand = useCallback(async (command: string) => {
     if (!slug || !isBridgeEnabled()) return
@@ -86,20 +75,11 @@ export function ActionBar({ state, slug, productionUrl, escalation, onCommandCom
           setCommandNotice('Build was already stopped.')
         }
       }
-      // Refresh build status + page data after any command that can
-      // change state or process liveness. Reset flips state back to
-      // Ready without touching the subprocess (there shouldn't be one
-      // if Reset succeeded); Start/Stop obviously change both.
+      // Trigger parent refetch so `project.state` + `project.buildRunning`
+      // + `project.buildStartedAt` all update in lockstep. The parent
+      // reads build status from the project GET (PID liveness included)
+      // so we don't need a separate call here.
       if (command === 'start' || command === 'stop' || command === 'reset') {
-        try {
-          const status = await fetchBuildStatus(slug)
-          setBuildRunning(status.running)
-          setBuildStartedAt(status.startedAt ?? null)
-        } catch {}
-        // Trigger parent refetch so `project.state` reflects the server-side
-        // transition (ready → foundation on start, etc.) without waiting for
-        // the SSE state-change event, which can lag or drop. Without this,
-        // the Build tab stays disabled until the user manually refreshes.
         onCommandComplete?.()
       }
     } catch (err) {
@@ -202,6 +182,7 @@ export function ActionBar({ state, slug, productionUrl, escalation, onCommandCom
           escalation={escalation}
           projectState={state}
           slug={slug}
+          onResolved={onCommandComplete}
         />
       )}
 

--- a/dashboard/src/components/build-log-tail.tsx
+++ b/dashboard/src/components/build-log-tail.tsx
@@ -68,7 +68,17 @@ export function BuildLogTail({ slug, live = false, tail = 50 }: BuildLogTailProp
     )
   }
 
-  if (!log) return null
+  if (!log) {
+    // Previously returned null here, which rendered a blank space in
+    // the diagnostics footer during the first poll. A tiny "fetching"
+    // placeholder makes it clear the panel is alive but waiting on
+    // data rather than broken.
+    return (
+      <div className="rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 text-xs text-gray-500">
+        Fetching raw log…
+      </div>
+    )
+  }
 
   const empty = log.totalLines === 0
   // Call this section "Raw Log" regardless of source — it's the secondary,

--- a/dashboard/src/components/current-focus-card.tsx
+++ b/dashboard/src/components/current-focus-card.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react'
 import type { ProjectState } from '@/lib/types'
 import type { StoryContext } from '@/bridge/story-context-reader'
 import { phaseLabel, phaseGloss } from '@/lib/phase-labels'
-import { Loader2, Flag, CheckCircle2 } from 'lucide-react'
+import { Loader2, Flag, CheckCircle2, ArrowDown } from 'lucide-react'
 import { cn } from '@/lib/utils'
 
 interface CurrentFocusCardProps {
@@ -63,14 +63,22 @@ export function CurrentFocusCard({
     return () => clearInterval(interval)
   }, [buildRunning])
 
-  // Escalation mode — previously rendered a full amber box here, but
-  // the actionable escalation drawer is already pinned above the tabs
-  // with the same title + summary + tier badge. Two boxes saying the
-  // same thing confused users. Return null so the drawer is the only
-  // surface for escalation state; the StateBadge in the header keeps
-  // the "Needs your input" label visible at a glance.
+  // Escalation mode — a thin pointer to the drawer above. Previously
+  // rendered a full amber box (duplicating the drawer's content), then
+  // returned null (which made the hero vanish and broke the page's
+  // "what's happening" narrative). The current shape — a single-line
+  // nudge with an arrow — keeps the hero present without re-stating
+  // the full escalation.
   if (state === 'escalation' || state === 'waiting-for-human') {
-    return null
+    return (
+      <div
+        className="flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50/60 px-4 py-2 text-xs text-amber-900"
+        data-testid="current-focus-escalation-nudge"
+      >
+        <ArrowDown className="size-3.5 shrink-0" />
+        <span>Escalation pending — respond in the banner above.</span>
+      </div>
+    )
   }
 
   if (state === 'complete') {

--- a/dashboard/src/components/escalation-drawer.tsx
+++ b/dashboard/src/components/escalation-drawer.tsx
@@ -39,6 +39,11 @@ interface EscalationDrawerProps {
   projectState: ProjectState
   slug?: string
   affectedStory?: string
+  // Called after the server confirms a Resume / Skip / feedback command,
+  // so the parent page can refetch and drop the escalation card instead
+  // of waiting for the SSE state-change event (which can lag 1–2 s). The
+  // audit flagged this as a P0 reactivity gap.
+  onResolved?: () => void
 }
 
 export function EscalationDrawer({
@@ -48,6 +53,7 @@ export function EscalationDrawer({
   projectState,
   slug,
   affectedStory,
+  onResolved,
 }: EscalationDrawerProps) {
   const [loading, setLoading] = useState<string | null>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
@@ -62,12 +68,13 @@ export function EscalationDrawer({
       }
       await sendCommand(slug, command)
       onOpenChange(false)
+      onResolved?.()
     } catch (err) {
       console.error(`[bridge] Escalation command "${command}" failed:`, err)
     } finally {
       setLoading(null)
     }
-  }, [slug, onOpenChange])
+  }, [slug, onOpenChange, onResolved])
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>

--- a/dashboard/src/components/project-card.tsx
+++ b/dashboard/src/components/project-card.tsx
@@ -120,6 +120,10 @@ export function ProjectCard({ project }: { project: ProjectSummary }) {
               <p className="mt-0.5 text-sm text-gray-500 truncate">{project.description}</p>
             </div>
             <div className="flex flex-col items-end gap-1">
+              {/* ProjectSummary (the home-page card source) doesn't
+                  carry buildRunning; the scanner doesn't track PIDs.
+                  Badge falls back to non-paused styling. Paused
+                  detection lives on the detail page. */}
               <StateBadge state={project.state} size="lg" />
               {project.awaitingGate && (
                 <span

--- a/dashboard/src/components/project-header.tsx
+++ b/dashboard/src/components/project-header.tsx
@@ -79,7 +79,7 @@ export function ProjectHeader({
         <div className="flex flex-wrap items-center gap-4">
           <ProjectTitleEditable slug={project.slug} name={project.name} state={project.state} />
           <ProjectSettingsMenu slug={project.slug} state={project.state} />
-          <StateBadge state={project.state} size="lg" />
+          <StateBadge state={project.state} size="lg" buildRunning={project.buildRunning} />
         </div>
 
         {/* Real metrics only — Build Cost & Last Activity pulled from latest checkpoint */}

--- a/dashboard/src/components/state-badge.tsx
+++ b/dashboard/src/components/state-badge.tsx
@@ -27,16 +27,43 @@ const stateStyles: Record<string, string> = {
   ready: 'bg-slate-100 text-slate-600 border-slate-300',
 }
 
+// States where Rouge is actively running a phase (the loop should have
+// a live PID). Used to render a "Paused" overlay on the badge when
+// state claims building but no process is alive — previously the
+// badge said e.g. "Building this story" in blue while the action bar
+// said "Build stopped", which gave users contradictory signals.
+const MID_PHASE_STATES: ReadonlySet<ProjectState> = new Set([
+  'foundation',
+  'foundation-eval',
+  'story-building',
+  'milestone-check',
+  'milestone-fix',
+  'analyzing',
+  'generating-change-spec',
+  'vision-check',
+  'shipping',
+  'final-review',
+])
+
 export function StateBadge({
   state,
   className,
   size = 'default',
+  buildRunning,
 }: {
   state: ProjectState
   className?: string
   size?: 'default' | 'lg'
+  // When state is a mid-phase state but no loop is alive, the badge
+  // renders with a subtle "Paused" suffix + muted styling so the
+  // visual matches what the ActionBar is saying. Omit for surfaces
+  // (project cards on the dashboard home) that don't have PID info.
+  buildRunning?: boolean
 }) {
-  const style = stateStyles[state] ?? 'bg-slate-100 text-slate-600 border-slate-300'
+  const isPaused = buildRunning === false && MID_PHASE_STATES.has(state)
+  const style = isPaused
+    ? 'bg-slate-100 text-slate-600 border-slate-300'
+    : stateStyles[state] ?? 'bg-slate-100 text-slate-600 border-slate-300'
 
   return (
     <Badge
@@ -47,9 +74,15 @@ export function StateBadge({
         className,
       )}
       data-state={state}
+      data-paused={isPaused ? 'true' : undefined}
       title={phaseGloss(state)}
     >
       {phaseLabel(state)}
+      {isPaused && (
+        <span className="ml-1.5 text-[10px] uppercase tracking-wider opacity-70">
+          · paused
+        </span>
+      )}
     </Badge>
   )
 }

--- a/dashboard/src/data/projects.ts
+++ b/dashboard/src/data/projects.ts
@@ -150,6 +150,7 @@ const recipeOracleEscalations: Escalation[] = [
     tier: 1,
     reason: 'Staging deploy failed — Wrangler build timeout after 3 retries. Bundle size 1.4MB compressed, exceeds 1MB Workers limit. Likely caused by Supabase client bundling unused modules.',
     state: 'escalation',
+    status: 'pending',
     createdAt: '2026-03-30T16:20:00Z',
   },
 ]

--- a/dashboard/src/lib/__tests__/types.test.ts
+++ b/dashboard/src/lib/__tests__/types.test.ts
@@ -113,6 +113,7 @@ describe('Type contracts', () => {
       tier: 1,
       reason: 'Deploy failed',
       state: 'escalation',
+      status: 'pending',
       createdAt: '2026-04-01T00:00:00Z',
     }
     expect(escalation.tier).toBe(1)

--- a/dashboard/src/lib/types.ts
+++ b/dashboard/src/lib/types.ts
@@ -135,11 +135,12 @@ export interface Escalation {
   reason: string
   state: ProjectState
   // Pipeline status. Only 'pending' escalations block the loop / need
-  // user action; 'resolved' ones are history. Previously absent from
-  // the mapped shape, which made the page-level pending filter a no-op
-  // — three resolved escalations rendered as if they were all live
-  // until this field was carried through.
-  status?: 'pending' | 'resolved'
+  // user action; 'resolved' ones are history. Required — the mapper
+  // guarantees a value (defaults non-'resolved' raw input to
+  // 'pending'), so leaving this optional would let the page-level
+  // filter silently treat undefined as pending and show historical
+  // escalations as live.
+  status: 'pending' | 'resolved'
   createdAt: string
   resolvedAt?: string
   resolution?: string


### PR DESCRIPTION
## Summary

Consolidates the fixes from today's three-agent audit into one PR rather than iterating patch-by-patch. Each item below was flagged as P0 or high-impact P1 by at least one of the Explore passes (data-flow / reactivity / UX trust).

### Single source of truth for build status

- **`ActionBar` no longer polls build status itself.** The page already carries `buildRunning` on the project payload via PID liveness; ActionBar now reads it as a prop. The internal 5 s poll was drifting up to 5 s behind the rest of the UI — Stop button flicker, Start that looked like it hadn't registered. One clock, one source of truth.
- **`StateBadge` gets a `buildRunning` prop** and renders a subtle "· paused" suffix with muted styling when state is a mid-phase state but no loop is alive. Previously the badge said "Building this story" in blue while the ActionBar hint said "Build stopped at …" — users saw contradictory signals.

### No more lying casts

- **`Escalation.status` is required** on the mapped type. The mapper always writes it now; leaving the type optional let undefined values slip past the pending filter (the drift PR #186 patched at the mapper level but not the type).
- **Two unsafe `as { … }` casts in `page.tsx` are gone.** `esc.reason` is guaranteed by the mapper (summary / reason / classification / placeholder, in that order of preference), and `esc.id` is non-optional on the type. No need for runtime-lying annotations.

### UX continuity

- **`EscalationDrawer` accepts `onResolved`** and calls it after Resume / Skip. Previously the modal closed but the page waited on the SSE event (1–2 s) before the escalation card cleared.
- **`CurrentFocusCard` no longer returns null on escalation.** Renders a single-line "respond in the banner above ↑" nudge so the hero stays continuous without duplicating the drawer's content.
- **`BuildLogTail`** shows "Fetching raw log…" during the initial poll instead of rendering null; the diagnostics footer no longer flashes blank for a tick.
- **Build cost bar** renders whenever `budgetCap > 0`, even at $0 spent. New builds had no forward visibility into the available budget.

## Tests

- Dashboard: **409 / 409** · 0 TS errors
- Launcher: **459 / 459** (unchanged)
- Mock/test `Escalation` objects across data/projects.ts, escalation-drawer.test.tsx, types.test.ts updated to carry `status` explicitly.
- ActionBar tests now pass `buildRunning` as prop (previously relied on the internal 5 s poll).

## Deferred to follow-ups (P2 per audit)

- Distinct colors per mid-phase state (all currently blue)
- Optimistic UI for mutations (small perceived-latency cost but not a correctness bug)
- `cost.totalSpend = 0` ambiguity (no-spend vs failed-read)
- Mapper hard-codes `providers: []` and `confidence: 0.75` — real values aren't surfaced by the launcher yet; the placeholders are harmless but should be removed or populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)