### PR TITLE
Finish the build-view sweep: validators, dead fields, UX polish

### DIFF
--- a/dashboard/src/app/projects/[name]/page.tsx
+++ b/dashboard/src/app/projects/[name]/page.tsx
@@ -155,7 +155,11 @@ export default function ProjectPage({
     return () => { cancelled = true }
   }, [name, verboseActivity])
 
-  // Live updates — re-fetch this project on any matching bridge event
+  // Live updates — re-fetch on every matching bridge event.
+  // spec + infrastructure were mount-only previously, so if the loop
+  // edited the spec (generating-change-spec) or provisioned new infra
+  // mid-build, the dashboard ignored it until a manual refresh. Now
+  // in the refetch set.
   const refetch = useCallback(() => {
     if (!isBridgeEnabled()) return
     fetchBridgeProject(name)
@@ -169,6 +173,12 @@ export default function ProjectPage({
       .catch(() => {})
     fetchBridgeStoryEnrichment(name)
       .then((data) => setStoryEnrichment(data as StoryEnrichmentMap | null))
+      .catch(() => {})
+    fetchBridgeSpec(name)
+      .then((data) => setSpec(data as ProjectSpec))
+      .catch(() => {})
+    fetchBridgeInfrastructure(name)
+      .then((data) => setInfrastructure(data as InfrastructureManifest | null))
       .catch(() => {})
   }, [name, verboseActivity])
   useBridgeEvents(refetch, name)
@@ -365,13 +375,20 @@ export default function ProjectPage({
       {/* Build cost progress bar for BUILDING projects. Renders even
           at $0 spent so the user has forward visibility into available
           budget; previously hidden until the first token charge which
-          made new builds look unbudgeted. */}
+          made new builds look unbudgeted. When a build has run but
+          somehow totalSpend is still 0 (no checkpoints written yet)
+          we show "No spend recorded yet" instead of "$0.00" to
+          distinguish "hasn't started" from "couldn't read cost". */}
       {project.state !== 'complete' && project.cost.budgetCap > 0 && (
         <div className="mt-6 rounded-lg border border-gray-200 bg-gray-50 p-4">
           <div className="flex items-center justify-between mb-2">
             <span className="text-xs font-medium text-gray-500">Build Cost</span>
             <span className="text-sm font-medium tabular-nums text-gray-900">
-              ${project.cost.totalSpend.toFixed(2)} / ${project.cost.budgetCap.toFixed(0)} budget
+              {project.cost.totalSpend > 0
+                ? `$${project.cost.totalSpend.toFixed(2)} / $${project.cost.budgetCap.toFixed(0)} budget`
+                : project.state === 'ready' || project.state === 'seeding'
+                  ? `Budget: $${project.cost.budgetCap.toFixed(0)}`
+                  : `No spend recorded yet · cap $${project.cost.budgetCap.toFixed(0)}`}
             </span>
           </div>
           <div className="h-2 w-full overflow-hidden rounded-full bg-gray-200">

--- a/dashboard/src/components/milestone-timeline.tsx
+++ b/dashboard/src/components/milestone-timeline.tsx
@@ -118,15 +118,19 @@ export function MilestoneTimeline({ milestones, selectedId, onSelect }: Mileston
             className="flex items-start"
             data-testid="milestone-step"
           >
-            {/* Step */}
+            {/* Step — pending milestones can't be selected (nothing
+                to show yet), so render with a disabled cursor + muted
+                opacity so the user can see at a glance why clicking
+                doesn't respond. */}
             <button
               type="button"
               disabled={!isClickable}
               onClick={() => isClickable && onSelect?.(milestone.id)}
+              title={isClickable ? undefined : 'This milestone hasn\u2019t started yet'}
               className={cn(
                 'flex flex-col items-center gap-1.5 transition-transform',
                 isSelected ? 'min-w-[140px] scale-105' : 'min-w-[120px]',
-                isClickable ? 'cursor-pointer' : 'cursor-default',
+                isClickable ? 'cursor-pointer' : 'cursor-not-allowed opacity-70',
               )}
               data-testid="milestone-button"
             >

--- a/dashboard/src/components/phase-events-feed.tsx
+++ b/dashboard/src/components/phase-events-feed.tsx
@@ -168,29 +168,32 @@ export function PhaseEventsFeed({
   }
 
   if (!payload.exists || payload.events.length === 0) {
-    // Compact empty state — used inside story cards where the longer
-    // explanatory text would be noisy. Stories that haven't been
-    // actively built yet just get a short waiting line.
+    // Be specific about what we're waiting for. The generic "Waiting
+    // for the first event…" from earlier told users nothing about
+    // whether the subprocess was starting up, blocked, or had
+    // finished. The phrasing now differentiates the cases we know
+    // about.
+    const emptyMessage = live
+      ? payload.exists
+        ? 'Subprocess is running — waiting for its first tool call or message.'
+        : 'Starting the phase subprocess…'
+      : 'No phase events recorded for this project yet.'
     if (compact) {
       return (
         <p className="text-xs text-gray-500">
           {live
             ? storyId
-              ? 'Waiting for Rouge to act on this story…'
-              : 'Waiting for the first event…'
+              ? 'Waiting for Rouge to pick up this story. Activity will appear here as tool calls land.'
+              : emptyMessage
             : 'No activity recorded for this story yet.'}
         </p>
       )
     }
     return (
       <div className="rounded-lg border border-dashed border-gray-200 bg-gray-50/50 p-6 text-center">
-        <p className="text-sm text-gray-500">
-          {live
-            ? 'Waiting for the first event…'
-            : 'No phase events recorded for this project yet.'}
-        </p>
+        <p className="text-sm text-gray-500">{emptyMessage}</p>
         <p className="mt-1 text-xs text-gray-400">
-          Event capture requires stream-json output — available on rouge-loop runs started after this feature shipped.
+          Event capture runs through <code>claude -p --output-format stream-json</code>. If this stays empty during a build, check the Raw Log in diagnostics for subprocess errors.
         </p>
       </div>
     )

--- a/dashboard/src/components/project-header.tsx
+++ b/dashboard/src/components/project-header.tsx
@@ -132,17 +132,10 @@ export function ProjectHeader({
             Staging
           </a>
         )}
-        {project.repoUrl && (
-          <a
-            href={project.repoUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center gap-1.5 rounded-md border border-gray-200 bg-white px-3 py-1.5 text-xs text-gray-500 transition-colors hover:text-gray-900 hover:border-gray-300"
-          >
-            <ExternalLink className="size-3" />
-            Repository
-          </a>
-        )}
+        {/* Repository link removed — the mapper never populated
+            project.repoUrl so the button existed as dead UI for
+            months. If repo visibility is wanted, wire it through
+            from cycle_context.github_repo. */}
       </div>
 
       {/* Stack status card */}

--- a/dashboard/src/components/state-badge.tsx
+++ b/dashboard/src/components/state-badge.tsx
@@ -3,27 +3,40 @@ import { Badge } from '@/components/ui/badge'
 import { cn } from '@/lib/utils'
 import { phaseLabel, phaseGloss } from '@/lib/phase-labels'
 
+// Colour palette groups phases by what they're FOR, not when they
+// happen. Previously all "building" phases rendered as the same blue,
+// so the user couldn't tell at a glance whether Rouge was executing
+// (building), reviewing (milestone-check), or fixing (milestone-fix).
+// The three families:
+//   blue = actively producing code (foundation / story-building /
+//          generating-change-spec)
+//   amber = evaluating / reviewing (foundation-eval / milestone-check
+//           / vision-check / analyzing)
+//   orange = fixing something that failed review (milestone-fix)
+//   purple = forming / exploratory (seeding)
+//   green = success (complete)
+//   red = needs human (escalation / waiting-for-human)
+//   slate = parked / final gate (ready / final-review)
 const stateStyles: Record<string, string> = {
-  // Escalation / needs attention — warm, urgent
   escalation: 'bg-red-50 text-red-700 border-red-300',
   'waiting-for-human': 'bg-red-50 text-red-700 border-red-300',
-  // Building / active — productive, moving
-  'story-building': 'bg-blue-50 text-blue-700 border-blue-300',
+  // Producing
   foundation: 'bg-blue-50 text-blue-700 border-blue-300',
-  'foundation-eval': 'bg-blue-50 text-blue-700 border-blue-300',
-  'milestone-check': 'bg-blue-50 text-blue-700 border-blue-300',
-  'milestone-fix': 'bg-blue-50 text-blue-700 border-blue-300',
-  analyzing: 'bg-blue-50 text-blue-700 border-blue-300',
+  'story-building': 'bg-blue-50 text-blue-700 border-blue-300',
   'generating-change-spec': 'bg-blue-50 text-blue-700 border-blue-300',
-  'vision-check': 'bg-blue-50 text-blue-700 border-blue-300',
   shipping: 'bg-blue-50 text-blue-700 border-blue-300',
-  // Seeding / spec — creative, forming
+  // Reviewing
+  'foundation-eval': 'bg-amber-50 text-amber-700 border-amber-300',
+  'milestone-check': 'bg-amber-50 text-amber-700 border-amber-300',
+  'vision-check': 'bg-amber-50 text-amber-700 border-amber-300',
+  analyzing: 'bg-amber-50 text-amber-700 border-amber-300',
+  // Fixing
+  'milestone-fix': 'bg-orange-50 text-orange-700 border-orange-300',
+  // Forming
   seeding: 'bg-purple-50 text-purple-700 border-purple-300',
-  // Final review — attention, not alarm
-  'final-review': 'bg-amber-50 text-amber-700 border-amber-300',
-  // Complete / shipped — success
+  // Final gate / complete / ready
+  'final-review': 'bg-slate-100 text-slate-700 border-slate-400',
   complete: 'bg-green-50 text-green-700 border-green-300',
-  // Ready / parked — neutral
   ready: 'bg-slate-100 text-slate-600 border-slate-300',
 }
 

--- a/dashboard/src/components/story-list.tsx
+++ b/dashboard/src/components/story-list.tsx
@@ -389,6 +389,20 @@ export function StoryList({ milestones, selectedMilestoneId, enrichment, slug, b
 
                   {/* Enrichment details (files, tests, decisions, questions) */}
                   {storyEnrichment && <StoryDetails enrichment={storyEnrichment} />}
+
+                  {/* Pending-story placeholder — earlier, expanding a
+                      pending story showed a blank panel that felt
+                      broken. Now explains why there's nothing to
+                      read yet. Shown only when the user has nothing
+                      else to look at. */}
+                  {story.status === 'pending'
+                    && story.acceptanceCriteria.length === 0
+                    && !storyEnrichment
+                    && !story.failureReason && (
+                    <p className="py-1 text-xs italic text-muted-foreground">
+                      This story hasn&rsquo;t been picked up yet — acceptance criteria and implementation detail will appear here once Rouge starts it.
+                    </p>
+                  )}
                 </div>
               </AccordionContent>
             </AccordionItem>

--- a/dashboard/src/lib/__tests__/types.test.ts
+++ b/dashboard/src/lib/__tests__/types.test.ts
@@ -351,9 +351,10 @@ describe('Seed data integrity', () => {
     expect(disciplines.has('taste')).toBe(true)
   })
 
-  it('confidence histories are monotonically timestamped', () => {
+  it('confidence histories (when present on fixtures) are monotonically timestamped', () => {
     for (const slug of Object.keys(projectDetails)) {
       const history = projectDetails[slug].confidenceHistory
+      if (!history) continue
       for (let i = 1; i < history.length; i++) {
         expect(new Date(history[i].timestamp).getTime())
           .toBeGreaterThan(new Date(history[i - 1].timestamp).getTime())

--- a/dashboard/src/lib/__tests__/validate-enum.test.ts
+++ b/dashboard/src/lib/__tests__/validate-enum.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { narrowEnum, narrowEnumWithDefault } from '../validate-enum'
+
+type Color = 'red' | 'green' | 'blue'
+const COLORS: readonly Color[] = ['red', 'green', 'blue'] as const
+
+describe('narrowEnum', () => {
+  let warn: ReturnType<typeof vi.spyOn>
+  beforeEach(() => {
+    warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    warn.mockRestore()
+  })
+
+  it('returns the value when it matches', () => {
+    expect(narrowEnum('red', COLORS, 'color')).toBe('red')
+  })
+
+  it('returns undefined on unknown value', () => {
+    expect(narrowEnum('chartreuse', COLORS, 'color')).toBeUndefined()
+  })
+
+  it('warns once per unknown value per tag', () => {
+    narrowEnum('orange', COLORS, 'color')
+    narrowEnum('orange', COLORS, 'color')
+    expect(warn).toHaveBeenCalledTimes(1)
+    // Different unknown value warns again
+    narrowEnum('fuchsia', COLORS, 'color')
+    expect(warn).toHaveBeenCalledTimes(2)
+  })
+
+  it('treats null and undefined as missing, not as unknown', () => {
+    expect(narrowEnum(null, COLORS, 'color')).toBeUndefined()
+    expect(narrowEnum(undefined, COLORS, 'color')).toBeUndefined()
+    expect(warn).not.toHaveBeenCalled()
+  })
+})
+
+describe('narrowEnumWithDefault', () => {
+  let warn: ReturnType<typeof vi.spyOn>
+  beforeEach(() => {
+    warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    warn.mockRestore()
+  })
+
+  it('returns the value when valid', () => {
+    expect(narrowEnumWithDefault('blue', COLORS, 'red', 'color')).toBe('blue')
+  })
+
+  it('returns the fallback on unknown value and still warns', () => {
+    expect(narrowEnumWithDefault('purple', COLORS, 'red', 'color')).toBe('red')
+    expect(warn).toHaveBeenCalled()
+  })
+})

--- a/dashboard/src/lib/bridge-mapper.ts
+++ b/dashboard/src/lib/bridge-mapper.ts
@@ -16,6 +16,22 @@ import type {
   DisciplineStatus,
 } from '@/lib/types'
 import type { RougeEscalation } from '@/bridge/types'
+import { narrowEnum } from '@/lib/validate-enum'
+
+// Known-valid enum members — used by narrowEnum to reject launcher
+// typos ('brainstormng') instead of casting them through and causing
+// blank renders downstream.
+const SEEDING_DISCIPLINES: readonly SeedingDiscipline[] = [
+  'brainstorming', 'competition', 'taste', 'spec',
+  'infrastructure', 'design', 'legal-privacy', 'marketing',
+]
+const DISCIPLINE_STATUSES: readonly DisciplineStatus[] = ['pending', 'in-progress', 'complete']
+const PROJECT_STATES: readonly ProjectState[] = [
+  'seeding', 'ready', 'foundation', 'foundation-eval', 'story-building',
+  'milestone-check', 'milestone-fix', 'analyzing', 'generating-change-spec',
+  'vision-check', 'shipping', 'final-review', 'complete',
+  'escalation', 'waiting-for-human',
+]
 
 interface RougeStory {
   id: string
@@ -87,14 +103,24 @@ interface RougeState {
 
 function mapSeedingProgress(raw: RougeState['seedingProgress']): SeedingProgress | undefined {
   if (!raw || !raw.disciplines) return undefined
+  // Validate discipline and status rather than casting blind. A
+  // launcher-side typo used to propagate as a bogus enum value,
+  // breaking downstream components that expected to match it in a
+  // known set. Unknown values now drop with a one-time console
+  // warning; the UI renders without them rather than crashing.
+  const disciplines = raw.disciplines
+    .map((d) => {
+      const discipline = narrowEnum(d.discipline, SEEDING_DISCIPLINES, 'seedingProgress.discipline')
+      const status = narrowEnum(d.status, DISCIPLINE_STATUSES, 'seedingProgress.status')
+      if (!discipline || !status) return null
+      return { discipline, status }
+    })
+    .filter((x): x is { discipline: SeedingDiscipline; status: DisciplineStatus } => x !== null)
   return {
-    disciplines: raw.disciplines.map(d => ({
-      discipline: d.discipline as SeedingDiscipline,
-      status: d.status as DisciplineStatus,
-    })),
+    disciplines,
     completedCount: raw.completedCount ?? 0,
     totalCount: raw.totalCount ?? 8,
-    currentDiscipline: raw.currentDiscipline as SeedingDiscipline | undefined,
+    currentDiscipline: narrowEnum(raw.currentDiscipline, SEEDING_DISCIPLINES, 'seedingProgress.currentDiscipline'),
   }
 }
 
@@ -163,16 +189,15 @@ function mapMilestone(m: RougeMilestone, index: number): Milestone {
 function mapEscalation(e: RougeEscalation & { handoff_started_at?: string }): Escalation {
   const tier = (Math.max(0, Math.min(3, e.tier)) as EscalationTier)
   // Preserve 'status' — consumed by the page-level filter that decides
-  // which escalations render as active drawers. Before this field was
-  // carried through, every escalation in state.escalations (including
-  // historical resolved ones) rendered as pending, so testimonial's
-  // page showed three boxes for one real issue.
+  // which escalations render as active drawers.
   const status = e.status === 'resolved' ? 'resolved' : 'pending'
   return {
     id: e.id,
     tier,
     reason: e.summary ?? e.reason ?? e.classification ?? 'Escalation raised',
-    state: (e.state as ProjectState) ?? 'escalation',
+    // Validate the phase-of-origin field; bad values fall back to
+    // 'escalation' so the UI never renders an un-styleable state.
+    state: narrowEnum(e.state, PROJECT_STATES, 'escalation.state') ?? 'escalation',
     status,
     createdAt: e.created_at,
     resolvedAt: e.resolved_at,
@@ -265,12 +290,13 @@ export function mapRougeStateToProjectDetail(raw: unknown, slug: string): Projec
     name: state.project ?? state.name ?? slug,
     slug,
     description: '', // Rouge state.json doesn't have descriptions
-    state: (state.current_state as ProjectState) ?? 'ready',
+    // Validated: a typo in state.current_state used to leak straight
+    // into the UI's state-badge switch and render as raw text. Now it
+    // falls back to 'ready' and warns once.
+    state: narrowEnum(state.current_state, PROJECT_STATES, 'project.current_state') ?? 'ready',
     providers: [], // TODO: derive from infrastructure_manifest.json when available
     progress: computeProgress(milestones),
     health: computeHealth(state, computeProgress(milestones)),
-    confidence: 0.75, // Placeholder — Rouge doesn't surface this yet
-    confidenceHistory: [],
     cost: {
       // Real cumulative cost from latest checkpoint, or 0 if no checkpoints yet
       totalSpend: state.costUsd ?? 0,

--- a/dashboard/src/lib/types.ts
+++ b/dashboard/src/lib/types.ts
@@ -201,7 +201,11 @@ export interface ProjectSummary {
   }
   health: number        // 0-100
   progress: number      // 0-100 story completion %
-  confidence: number    // 0-1
+  // confidence — optional and currently unused. Kept on the mock
+  // shape so legacy fixtures don't need a sweep, but nothing in
+  // production renders it. Drop once we either surface real
+  // confidence or delete the mock fixtures.
+  confidence?: number   // 0-1
   cost: CostInfo
   lastCheckpointAt?: string
   milestonesTotal: number
@@ -247,8 +251,16 @@ export interface ProjectDetail {
   }
   health: number
   progress: number     // 0-100 story completion %
-  confidence: number
-  confidenceHistory: ConfidencePoint[]
+  // confidence / confidenceHistory / repoUrl are OPTIONAL and not set
+  // by the live mapper — the launcher doesn't surface confidence or
+  // a repo URL anywhere in state.json. The mapper used to fill them
+  // with hardcoded placeholders (0.75 / empty array / undefined);
+  // those placeholders rendered as if they were real data. The
+  // fields stay optional so legacy demo fixtures still type-check,
+  // but no production surface reads them. If a feature ever needs
+  // them, wire them from a real source before using in the UI.
+  confidence?: number
+  confidenceHistory?: ConfidencePoint[]
   cost: CostInfo
   milestones: Milestone[]
   escalations: Escalation[]

--- a/dashboard/src/lib/validate-enum.ts
+++ b/dashboard/src/lib/validate-enum.ts
@@ -1,0 +1,61 @@
+/**
+ * Bridge payloads arrive as `string` on the wire. The dashboard types
+ * narrow those strings to finite unions (ProjectState, SeedingDiscipline,
+ * StoryStatus, etc.), which is only safe if the value really is one
+ * of the permitted members. Previously the mapper used bare `as`
+ * casts that silently let a launcher typo leak through:
+ *
+ *   raw.currentDiscipline = 'brainstormng'   // typo on disk
+ *   mapped.currentDiscipline = 'brainstormng' as SeedingDiscipline
+ *   // DisciplineStepper can't find it → blank render, no warning
+ *
+ * These helpers validate the value against the known set, log a
+ * warning once per unknown value, and return either the narrowed
+ * value or `undefined` so callers can render a graceful empty state
+ * instead of crashing.
+ */
+
+const warnedValues = new Map<string, Set<string>>()
+
+function warnOnce(tag: string, value: string): void {
+  if (typeof console === 'undefined') return
+  let seen = warnedValues.get(tag)
+  if (!seen) {
+    seen = new Set()
+    warnedValues.set(tag, seen)
+  }
+  if (seen.has(value)) return
+  seen.add(value)
+  // eslint-disable-next-line no-console -- one-time dev surface for schema drift
+  console.warn(
+    `[validate-enum] ${tag}: unknown value "${value}" — launcher schema and dashboard type are out of sync`,
+  )
+}
+
+/**
+ * Returns `value` if it's a member of `allowed`, otherwise undefined
+ * plus a one-time console.warn tagged with `tag` for diagnosis.
+ */
+export function narrowEnum<T extends string>(
+  value: string | undefined | null,
+  allowed: readonly T[],
+  tag: string,
+): T | undefined {
+  if (value == null) return undefined
+  if ((allowed as readonly string[]).includes(value)) return value as T
+  warnOnce(tag, value)
+  return undefined
+}
+
+/**
+ * Like narrowEnum but returns a supplied fallback when the value is
+ * unknown, for fields where `undefined` would cascade into a crash.
+ */
+export function narrowEnumWithDefault<T extends string>(
+  value: string | undefined | null,
+  allowed: readonly T[],
+  fallback: T,
+  tag: string,
+): T {
+  return narrowEnum(value, allowed, tag) ?? fallback
+}


### PR DESCRIPTION
## Summary

Completes the audit list from PR #187, which shipped the P0 items and deferred the rest. This lands the remaining items.

### Type safety

- **`lib/validate-enum.ts`** — new `narrowEnum` / `narrowEnumWithDefault` helpers. Reject launcher typos with a one-time `console.warn` and fall back to `undefined` instead of casting garbage through to render paths.
- Mapper uses them for `SeedingDiscipline`, `DisciplineStatus`, `ProjectState` (top level + `escalation.state`). Previously a single `'brainstormng'` typo on disk would silently make the discipline stepper blank.

### Dead fields

- Mapper stops writing `confidence` (was hardcoded `0.75`) and `confidenceHistory` (was hardcoded `[]`). The launcher never surfaced real confidence data, so the UI was rendering a placeholder as if it were data. Fields stay optional on `ProjectDetail` so legacy demo fixtures compile; nothing in production reads them.
- `ProjectHeader` no longer renders the "Repository" link — `project.repoUrl` was never populated. Field stays optional on the type for the same reason.

### Reactivity

- `refetch()` now also fetches `spec` and `infrastructure`, not just on mount. If `generating-change-spec` adds stories mid-build or new infra gets provisioned, the page picks it up on the next SSE event instead of needing a manual refresh.

### UX trust

- **StateBadge colour palette** splits mid-phase states by purpose: blue = producing (foundation / story-building / generating-change-spec / shipping), amber = reviewing (foundation-eval / milestone-check / vision-check / analyzing), orange = fixing (milestone-fix). Previously every building phase was the same blue — you couldn't tell at a glance whether Rouge was writing code, reviewing it, or fixing it.
- **MilestoneTimeline** pending pills now use `cursor-not-allowed` + muted opacity + an explanatory tooltip so it's visually obvious they can't be selected yet.
- **StoryList** adds a pending-story placeholder ("This story hasn't been picked up yet…") so expanding a pending story doesn't show a blank panel.
- **PhaseEventsFeed** empty state differentiates "starting subprocess" / "running, awaiting first tool call" / "historical project" instead of one generic waiting message.
- **Build cost readout** distinguishes the $0-spent cases: `"Budget: \$X"` for ready/seeding, `"No spend recorded yet · cap \$X"` for mid-build, `"\$N.NN / \$X budget"` for real spend. Previously all three rendered as `"\$0.00 / \$X"` — a lie about mid-build projects where spend should exist.

## Tests

- Dashboard: **415 / 415** (+6 for validate-enum)
- Launcher: **459 / 459** (unchanged)
- TS: 0 errors

## Status of the full 40-item audit list

All shipped or explicitly deferred. The last remaining deferrals are honest scope calls:

- Optimistic UI on mutations — perceived-latency only; buttons already show a spinner
- `providers: []` hardcoded in the detail mapper — needs a real pipe from cycle_context.infrastructure; not a 10-line change
- Four concurrent fetches on every SSE event — works, just not cheap

🤖 Generated with [Claude Code](https://claude.com/claude-code)