### PR TITLE
fix: testimonial stuck-at-escalation + schema noise + real providers

### DIFF
--- a/dashboard/src/app/api/projects/[name]/route.ts
+++ b/dashboard/src/app/api/projects/[name]/route.ts
@@ -14,7 +14,9 @@ import {
   mergeMilestonesFromLedger,
   readCheckpointSummary,
   readDeployUrls,
+  readProviders,
 } from "@/lib/project-details";
+import { repairProjectState } from "@/bridge/state-repair";
 
 export const dynamic = "force-dynamic";
 
@@ -36,6 +38,20 @@ export async function GET(
 
   if (!existsSync(stateFile)) {
     return NextResponse.json({ error: "Project not found" }, { status: 404 });
+  }
+
+  // Run state-repair before reading, same pattern the scanner uses on
+  // the home page. Without this, opening a project detail directly
+  // (bypassing the home page) could render against a zombie state —
+  // the user's "three boxes" / "stuck at escalation with no drawer"
+  // bug was a consequence of this path being unrepaired.
+  try {
+    const report = await repairProjectState(projectDir);
+    if (report.fixes.length > 0) {
+      console.log(`[state-repair] ${name} (detail): ${report.fixes.join('; ')}`);
+    }
+  } catch (err) {
+    console.warn(`[state-repair] ${name} (detail) threw:`, err instanceof Error ? err.message : err);
   }
 
   const raw = JSON.parse(readFileSync(stateFile, "utf-8"));
@@ -66,9 +82,17 @@ export async function GET(
     context: `detail:gated-autonomy:${name}`,
   });
 
+  // Derive real providers from cycle_context.infrastructure so the
+  // header's stack area, the "Live on X" badge on complete projects,
+  // and the project-card icons all reflect reality. Previously the
+  // mapper hardcoded providers: [] which meant none of those ever
+  // rendered — dead UI on every project.
+  const providers = readProviders(projectDir);
+
   return NextResponse.json({
     slug: name,
     ...merged,
+    providers,
     costUsd: checkpoint.costUsd,
     lastCheckpointAt: checkpoint.lastCheckpointAt,
     lastPhase: checkpoint.lastPhase,

--- a/dashboard/src/lib/bridge-mapper.ts
+++ b/dashboard/src/lib/bridge-mapper.ts
@@ -86,6 +86,11 @@ interface RougeState {
   archived?: boolean
   archivedAt?: string
   budget_cap_usd?: number
+  // Providers derived from cycle_context.infrastructure by the detail
+  // API route. Used for "Live on Cloudflare" style badges and the
+  // project-card stack icons. Previously hardcoded to [] in the
+  // mapper, so none of those UI elements rendered.
+  providers?: string[]
   // Deploy URLs — populated by the project-detail API route from
   // infrastructure_manifest.json + cycle_context.json.deploy_history
   // before reaching this mapper.
@@ -294,7 +299,12 @@ export function mapRougeStateToProjectDetail(raw: unknown, slug: string): Projec
     // into the UI's state-badge switch and render as raw text. Now it
     // falls back to 'ready' and warns once.
     state: narrowEnum(state.current_state, PROJECT_STATES, 'project.current_state') ?? 'ready',
-    providers: [], // TODO: derive from infrastructure_manifest.json when available
+    // Narrow the raw string[] to Provider[]. Unknown values drop
+    // silently (they still render, via ProviderIcons' fallback, but
+    // in TS we only allow the recognised set).
+    providers: (state.providers ?? []).filter((p): p is 'vercel' | 'cloudflare' | 'supabase' | 'sentry' | 'posthog' =>
+      ['vercel', 'cloudflare', 'supabase', 'sentry', 'posthog'].includes(p),
+    ),
     progress: computeProgress(milestones),
     health: computeHealth(state, computeProgress(milestones)),
     cost: {

--- a/dashboard/src/lib/project-details.ts
+++ b/dashboard/src/lib/project-details.ts
@@ -141,6 +141,45 @@ export function readDeployUrls(projectDir: string): {
   return { stagingUrl, productionUrl }
 }
 
+/**
+ * Derive the list of providers this project actually uses from
+ * cycle_context.infrastructure. Mirrors the scanner's logic (same
+ * file at dashboard/src/bridge/scanner.ts) so the detail API and the
+ * home-page card agree on which badges to show. Previously the
+ * detail mapper hardcoded `providers: []` which meant the "Live on
+ * Cloudflare" badge and stack icons never appeared even for projects
+ * deployed to real infrastructure.
+ */
+export function readProviders(projectDir: string): string[] {
+  const providers: string[] = []
+  try {
+    const ctxPath = join(projectDir, 'cycle_context.json')
+    if (!existsSync(ctxPath)) return providers
+    const ctx = JSON.parse(readFileSync(ctxPath, 'utf-8')) as {
+      infrastructure?: {
+        staging_url?: string
+        production_url?: string
+        supabase_url?: string
+        supabase_ref?: string
+        sentry_dsn?: string
+        readiness?: { posthog?: boolean }
+      }
+    }
+    const infra = ctx.infrastructure ?? {}
+    const urls = [infra.staging_url, infra.production_url]
+      .filter(Boolean)
+      .join(' ')
+    if (urls.includes('.vercel.app')) providers.push('vercel')
+    if (urls.includes('.pages.dev') || urls.includes('.workers.dev')) providers.push('cloudflare')
+    if (infra.supabase_url && infra.supabase_ref) providers.push('supabase')
+    if (infra.sentry_dsn) providers.push('sentry')
+    if (infra.readiness?.posthog === true) providers.push('posthog')
+  } catch {
+    // malformed cycle_context — silent empty list
+  }
+  return providers
+}
+
 export interface CheckpointSummary {
   costUsd: number | null;
   lastCheckpointAt: string | null;

--- a/schemas/catalogue-entry.json
+++ b/schemas/catalogue-entry.json
@@ -17,9 +17,11 @@
       "description": "Human-readable display name (e.g. 'Stripe')."
     },
     "tier": {
-      "type": "integer",
-      "enum": [1, 2, 3],
-      "description": "1 = core platform primitive; 2 = integrated service (Stripe, Supabase); 3 = pattern within a service (Stripe webhook handler, Sentry React boundary)."
+      "oneOf": [
+        { "type": "integer", "enum": [1, 2, 3] },
+        { "type": "string", "const": "draft" }
+      ],
+      "description": "1 = core platform primitive; 2 = integrated service (Stripe, Supabase); 3 = pattern within a service (Stripe webhook handler, Sentry React boundary). 'draft' is valid for entries under library/integrations/drafts/ awaiting promotion to a numeric tier — see contribute-pattern.js."
     },
     "category": {
       "type": "string",

--- a/schemas/cycle-context-v3.json
+++ b/schemas/cycle-context-v3.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "V3 Cycle Context — Per-Phase Output Contract",
   "description": "Defines required and forbidden output keys per phase. Prompts write to cycle_context.json ONLY.",
   "phase_contracts": {

--- a/src/launcher/rouge-loop.js
+++ b/src/launcher/rouge-loop.js
@@ -711,6 +711,26 @@ async function advanceState(projectDir) {
 
       state.foundation.status = 'complete';
       state.foundation.completed_at = new Date().toISOString();
+      // Load task_ledger milestones into state.milestones if they're
+      // missing. V3 projects that complete seeding but don't go
+      // through the approval handshake end up with state.milestones=[]
+      // while task_ledger holds the real decomposition. Without this,
+      // findNextMilestone below returns undefined and the foundation-
+      // eval → escalation path fires for a purely synthetic reason.
+      if (!Array.isArray(state.milestones) || state.milestones.length === 0) {
+        try {
+          const ledgerPath = path.join(projectDir, 'task_ledger.json');
+          if (fs.existsSync(ledgerPath)) {
+            const ledger = JSON.parse(fs.readFileSync(ledgerPath, 'utf-8'));
+            if (Array.isArray(ledger.milestones) && ledger.milestones.length > 0) {
+              state.milestones = ledger.milestones;
+              log(`[${projectName}] Loaded ${ledger.milestones.length} milestones from task_ledger.json`);
+            }
+          }
+        } catch (err) {
+          log(`[${projectName}] Could not load milestones from task_ledger: ${(err.message || '').slice(0, 100)}`);
+        }
+      }
       // Also mark the foundation milestone as complete so findNextMilestone skips it
       const foundationMilestone = (state.milestones || []).find(m => m.name === 'foundation');
       if (foundationMilestone) foundationMilestone.status = 'complete';
@@ -817,12 +837,36 @@ async function advanceState(projectDir) {
         break;
       }
 
-      // Start first milestone
+      // Start first milestone. Informative escalations replace the
+      // old `next = 'escalation'` fallbacks so users see WHY the loop
+      // stopped, not a generic placeholder.
       const milestone = findNextMilestone(state);
-      if (!milestone) { next = 'escalation'; break; }
+      if (!milestone) {
+        next = escalate(state, {
+          id: `esc-no-next-milestone-${Date.now()}`,
+          tier: 1,
+          classification: 'no-milestones-defined',
+          summary:
+            'Foundation is complete but no milestones are in state.milestones or task_ledger.json. ' +
+            'The seeding step that decomposes the spec into milestones likely didn\'t finish. ' +
+            'Reset to Ready and re-run seeding, or populate task_ledger.json manually.',
+        });
+        break;
+      }
       milestone.status = 'in-progress';
       const story = findNextStory(milestone, flat);
-      if (!story) { next = 'escalation'; break; }
+      if (!story) {
+        next = escalate(state, {
+          id: `esc-no-next-story-${Date.now()}`,
+          tier: 1,
+          classification: 'empty-milestone',
+          summary:
+            `Foundation-eval passed but milestone "${milestone.name}" has no stories to build. ` +
+            'Check task_ledger.json — every milestone should have a non-empty stories array.',
+          story_id: null,
+        });
+        break;
+      }
       next = startStory(state, milestone, story);
       log(`[${projectName}] Starting milestone "${milestone.name}", story "${story.id}"`);
       break;


### PR DESCRIPTION
## Summary

Three real launcher bugs behind testimonial's "stuck at escalation" symptom, plus the providers wiring the user asked for.

**Testimonial spinning (root cause):** foundation-eval PASSed but `state.milestones` was empty (task_ledger had them). `findNextMilestone` returned undefined → `next='escalation'` without a pushed object → dispatcher synthesised a generic placeholder. Dismiss → same empty state → same placeholder. Cycle.

**Fixes:**
- `foundation-eval` now loads missing milestones from `task_ledger.json` before `findNextMilestone`, mirroring what `mergeMilestonesFromLedger` does at dashboard read time.
- Two raw `next='escalation'` sites in foundation-eval PASS block now call `escalate()` with specific summaries (`no-milestones-defined` / `empty-milestone`) so users see the failure class, not "unspecified".
- `/api/projects/[name]` GET now calls `repairProjectState` — scanner already did this, detail route didn't, so opening a project directly could render against a zombie state.

**Schema noise in raw log:**
- `catalogue-entry.json`: `tier` now accepts `integer 1..3` OR `'draft'` (launcher intentionally writes `'draft'` as a placeholder for drafts/*.yaml).
- `cycle-context-v3.json`: `$schema` switched from 2020-12 to draft-07 so ajv 8 compiles it (was failing silently).

**Providers wiring (explicit ask):**
- New `readProviders()` in `project-details.ts` mirrors scanner's derivation from `cycle_context.infrastructure` (vercel/cloudflare/supabase/sentry/posthog).
- Detail route returns `providers`; mapper narrows to the Provider union instead of hardcoded `[]`.
- "Live on Cloudflare" badge, header stack icons, and project-card providers column now render for projects with real infrastructure.

## Test plan
- [x] Launcher tests: 459/459
- [x] Dashboard tests: 415/415
- [x] TypeScript: 0 errors
- [ ] Verify testimonial unsticks: dismiss existing zombie escalation, loop advances into story-building instead of re-escalating
- [ ] Verify "Live on Cloudflare" badge renders on a deployed project
- [ ] Verify schema-validator no longer warns about `tier: draft` or cycle-context draft-2020-12

🤖 Generated with [Claude Code](https://claude.com/claude-code)