### PR TITLE
fix: wire docker-compose deployment target end-to-end

### DIFF
--- a/dashboard/src/bridge/__tests__/seeding-finalize.test.ts
+++ b/dashboard/src/bridge/__tests__/seeding-finalize.test.ts
@@ -116,4 +116,90 @@ describe('finalizeSeeding', () => {
     const second = readFileSync(join(testDir, '.rouge', 'state.json'), 'utf-8')
     expect(second).toBe(first)
   })
+
+  describe('infrastructure manifest propagation', () => {
+    function writeVision(extra: Record<string, unknown> = {}): void {
+      writeFileSync(
+        join(testDir, 'vision.json'),
+        JSON.stringify({
+          product_name: 'test',
+          one_liner: LONG, // keep byte size above the stub floor
+          infrastructure: {},
+          ...extra,
+        }),
+      )
+    }
+    function writeManifest(target: string, opts: { database?: boolean; auth?: boolean } = {}): void {
+      writeFileSync(
+        join(testDir, 'infrastructure_manifest.json'),
+        JSON.stringify({
+          deploy: { target },
+          database: opts.database ? { provider: 'self-hosted' } : null,
+          auth: opts.auth ? { strategy: 'home-grown' } : null,
+        }),
+      )
+    }
+
+    it('mirrors manifest.deploy.target into vision.json.infrastructure.deployment_target', async () => {
+      seedCompleteProject()
+      writeVision()
+      writeManifest('docker-compose', { database: true, auth: true })
+
+      const result = await finalizeSeeding(testDir)
+      expect(result.ok).toBe(true)
+
+      const vision = JSON.parse(readFileSync(join(testDir, 'vision.json'), 'utf-8'))
+      expect(vision.infrastructure.deployment_target).toBe('docker-compose')
+      expect(vision.infrastructure.needs_database).toBe(true)
+      expect(vision.infrastructure.needs_auth).toBe(true)
+    })
+
+    it('also writes into cycle_context.json.vision.infrastructure (where the provisioner reads)', async () => {
+      seedCompleteProject()
+      writeVision()
+      writeManifest('docker-compose')
+      writeFileSync(join(testDir, 'cycle_context.json'), JSON.stringify({ vision: { infrastructure: {} } }))
+
+      await finalizeSeeding(testDir)
+
+      const ctx = JSON.parse(readFileSync(join(testDir, 'cycle_context.json'), 'utf-8'))
+      expect(ctx.vision.infrastructure.deployment_target).toBe('docker-compose')
+    })
+
+    it('does not overwrite an explicit vision.infrastructure.deployment_target', async () => {
+      seedCompleteProject()
+      writeVision({ infrastructure: { deployment_target: 'vercel' } })
+      writeManifest('docker-compose')
+
+      await finalizeSeeding(testDir)
+
+      const vision = JSON.parse(readFileSync(join(testDir, 'vision.json'), 'utf-8'))
+      expect(vision.infrastructure.deployment_target).toBe('vercel')
+    })
+
+    it('is a no-op when manifest is missing', async () => {
+      seedCompleteProject()
+      writeVision()
+      // no infrastructure_manifest.json written
+
+      await finalizeSeeding(testDir)
+
+      const vision = JSON.parse(readFileSync(join(testDir, 'vision.json'), 'utf-8'))
+      expect(vision.infrastructure).toEqual({})
+    })
+
+    it('is a no-op when manifest has no deploy.target', async () => {
+      seedCompleteProject()
+      writeVision()
+      writeFileSync(
+        join(testDir, 'infrastructure_manifest.json'),
+        JSON.stringify({ deploy: {} }),
+      )
+
+      await finalizeSeeding(testDir)
+
+      const vision = JSON.parse(readFileSync(join(testDir, 'vision.json'), 'utf-8'))
+      expect(vision.infrastructure).toEqual({})
+    })
+  })
 })

--- a/dashboard/src/bridge/seeding-finalize.ts
+++ b/dashboard/src/bridge/seeding-finalize.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, readdirSync, statSync } from 'fs'
+import { existsSync, readFileSync, readdirSync, statSync, writeFileSync, renameSync } from 'fs'
 import { join } from 'path'
 import { statePath as resolveStatePath, writeStateJson } from './state-path'
 import { withStateLock } from './state-lock'
@@ -20,7 +20,103 @@ function fileLooksReal(path: string): boolean {
   }
 }
 
+function writeJsonAtomic(path: string, data: unknown): void {
+  const tmp = path + '.tmp'
+  writeFileSync(tmp, JSON.stringify(data, null, 2) + '\n')
+  renameSync(tmp, path)
+}
+
+/**
+ * Mirror infrastructure decisions from `infrastructure_manifest.json` into
+ * `vision.json.infrastructure` (and `cycle_context.json.vision.infrastructure`),
+ * where the launcher's provisioner actually looks them up.
+ *
+ * Background: the INFRASTRUCTURE discipline writes the chosen deploy target
+ * to `infrastructure_manifest.json.deploy.target`. The provisioner
+ * (src/launcher/provision-infrastructure.js:328) reads
+ * `cycle_context.vision.infrastructure.deployment_target`. Nothing was
+ * copying the value across, so a fresh project would always hit the
+ * "No deployment_target in vision.json.infrastructure" warning and stall.
+ * Testimonial reproduced this: manifest.deploy.target="docker-compose" but
+ * vision.json.infrastructure={}.
+ *
+ * This mirror is intentionally non-destructive: it only fills fields that
+ * are missing on the target, so explicit spec/vision overrides win.
+ */
+function propagateInfrastructureFromManifest(projectDir: string): void {
+  const manifestPath = join(projectDir, 'infrastructure_manifest.json')
+  if (!existsSync(manifestPath)) return
+  let manifest: {
+    deploy?: { target?: string; staging_env?: string; production_env?: string }
+    database?: { provider?: string | null } | null
+    auth?: { strategy?: string | null; provider?: string | null } | null
+  }
+  try {
+    manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'))
+  } catch {
+    return
+  }
+  const target = manifest.deploy?.target
+  if (!target || typeof target !== 'string') return
+
+  const needsDatabase = !!(manifest.database && manifest.database.provider)
+  const needsAuth = !!(manifest.auth && (manifest.auth.strategy || manifest.auth.provider))
+
+  const visionPath = join(projectDir, 'vision.json')
+  if (existsSync(visionPath)) {
+    try {
+      const vision = JSON.parse(readFileSync(visionPath, 'utf-8')) as {
+        infrastructure?: {
+          deployment_target?: string
+          needs_database?: boolean
+          needs_auth?: boolean
+        }
+      }
+      const infra = vision.infrastructure ?? {}
+      let changed = false
+      if (!infra.deployment_target) { infra.deployment_target = target; changed = true }
+      if (infra.needs_database === undefined) { infra.needs_database = needsDatabase; changed = true }
+      if (infra.needs_auth === undefined) { infra.needs_auth = needsAuth; changed = true }
+      if (changed) {
+        vision.infrastructure = infra
+        writeJsonAtomic(visionPath, vision)
+      }
+    } catch {
+      // malformed vision.json — leave alone; missing-artifacts check will
+      // flag it if it's below the byte floor.
+    }
+  }
+
+  const ctxPath = join(projectDir, 'cycle_context.json')
+  if (existsSync(ctxPath)) {
+    try {
+      const ctx = JSON.parse(readFileSync(ctxPath, 'utf-8')) as {
+        vision?: { infrastructure?: Record<string, unknown> }
+      }
+      ctx.vision = ctx.vision ?? {}
+      const infra = ctx.vision.infrastructure ?? {}
+      let changed = false
+      if (!infra.deployment_target) { infra.deployment_target = target; changed = true }
+      if (infra.needs_database === undefined) { infra.needs_database = needsDatabase; changed = true }
+      if (infra.needs_auth === undefined) { infra.needs_auth = needsAuth; changed = true }
+      if (changed) {
+        ctx.vision.infrastructure = infra
+        writeJsonAtomic(ctxPath, ctx)
+      }
+    } catch {
+      // malformed cycle_context.json — skip; rouge-loop has its own repair.
+    }
+  }
+}
+
 export async function finalizeSeeding(projectDir: string): Promise<FinalizeResult> {
+  // Propagate deployment_target and needs_* from the infrastructure
+  // manifest into vision.json + cycle_context.json before the artifact
+  // check runs — that way a project that had a valid manifest but an
+  // empty vision.infrastructure still passes the byte-floor check and
+  // the provisioner finds the target when the build loop boots.
+  propagateInfrastructureFromManifest(projectDir)
+
   const missing: string[] = []
 
   // Task ledger — V3 story/milestone tracking the launcher consumes.

--- a/schemas/vision.json
+++ b/schemas/vision.json
@@ -107,7 +107,11 @@
         "needs_database": { "type": "boolean" },
         "needs_auth": { "type": "boolean" },
         "needs_payments": { "type": "boolean" },
-        "deployment_target": { "type": "string", "default": "cloudflare-workers" },
+        "deployment_target": {
+          "type": "string",
+          "enum": ["cloudflare", "cloudflare-workers", "vercel", "docker-compose", "docker", "github-pages", "gh-pages", "none"],
+          "default": "cloudflare-workers"
+        },
         "services": {
           "type": "array",
           "items": { "type": "string" },

--- a/src/launcher/provision-infrastructure.js
+++ b/src/launcher/provision-infrastructure.js
@@ -335,7 +335,7 @@ function main() {
   // which meant a project declaring deployment_target: "vercel" would still get
   // wrangler.toml, @opennextjs/cloudflare, and a Workers staging deploy. See #96.
   if (!target) {
-    log('❌ No deployment_target in vision.json.infrastructure — cannot provision. Set it to one of: cloudflare, cloudflare-workers, vercel, docker-compose, none');
+    log('❌ No deployment_target in vision.json.infrastructure — cannot provision. Set it to one of: cloudflare, cloudflare-workers, vercel, docker-compose, docker, github-pages, gh-pages, none');
   } else if (target === 'cloudflare' || target === 'cloudflare-workers') {
     const stagingUrl = provisionCloudflare(projectDir, projectName);
     if (stagingUrl) {
@@ -348,8 +348,14 @@ function main() {
     log('Vercel: the deploy handler in deploy-to-staging.js handles `vercel deploy --yes --prod`.');
   } else if (target === 'docker-compose' || target === 'docker' || target === 'none') {
     log(`${target}: no cloud provisioning needed.`);
+  } else if (target === 'github-pages' || target === 'gh-pages') {
+    // Pages serves from the gh-pages branch; the staging deploy handler
+    // (deploy-to-staging.js:deployGithubPages) owns that push. No cloud
+    // provisioning step here — the project just needs a GitHub repo with
+    // Pages enabled, which is outside Rouge's provisioner scope.
+    log(`${target}: no cloud provisioning needed; deploy handler pushes to gh-pages branch.`);
   } else {
-    log(`❌ Unknown deployment_target "${target}" — no provisioner registered. Supported: cloudflare, cloudflare-workers, vercel, docker-compose, none`);
+    log(`❌ Unknown deployment_target "${target}" — no provisioner registered. Supported: cloudflare, cloudflare-workers, vercel, docker-compose, docker, github-pages, gh-pages, none`);
   }
 
   // Supabase (if needed).

--- a/src/prompts/loop/07-ship-promote.md
+++ b/src/prompts/loop/07-ship-promote.md
@@ -179,7 +179,15 @@ Execute the production deployment. Read `infrastructure_manifest.json` (or `visi
 
 - **Cloudflare Workers** (`deployment_target: "cloudflare"` or `"cloudflare-workers"`): Run `npx wrangler deploy` to promote to production. Verify with `curl -s -o /dev/null -w "%{http_code}" <production-url>`.
 - **Vercel** (`deployment_target: "vercel"`): Run `npx vercel deploy --yes --prod`. Verify the stable project URL responds with 200.
+- **Docker Compose** (`deployment_target: "docker-compose"` or `"docker"`): Rouge does not own the production host — self-hosted products are deployed to **the user's** infrastructure. Production promote here means publishing the artifact, not running a server. Steps:
+  1. Confirm `.github/workflows/publish-image.yml` (or equivalent) builds and pushes a multi-arch image to the project's registry (GHCR by default). If missing, ESCALATE rather than improvising a registry target.
+  2. Tag the release: `git tag v<version> && git push origin v<version>`. The workflow publishes `ghcr.io/<org>/<repo>:v<version>` on tag push.
+  3. Verify the image is pullable: `docker manifest inspect ghcr.io/<org>/<repo>:v<version>` (or `docker buildx imagetools inspect`). Record the digest as the production artifact reference.
+  4. Update `infrastructure_manifest.json.deploy.production_artifact` with the digest + tag so downstream users can pin.
+  5. Record `production_url: null` in `ship_result` — there is no Rouge-managed production URL for self-hosted products; the user runs the image on their own box.
+- **GitHub Pages** (`deployment_target: "github-pages"` or `"gh-pages"`): Production IS the gh-pages branch; the staging deploy already serves the live site. Verify the Pages URL (`https://<owner>.github.io/<repo>/`) responds with 200 and record it as `production_url`. No separate promote step.
 - **npm publish**: Run `npm publish` (only if the project is a published package — check `package.json.private`).
+- **None** (`deployment_target: "none"`): Non-web deliverable (CLI tool, MCP server, library). Skip deploy; the ship step is whatever makes the artifact consumable (npm publish, binary release, etc.). If no distribution path is configured, ESCALATE.
 - **Other platforms**: Read the deployment pattern from the integration catalogue (`library/integrations/`) and execute accordingly. If no pattern exists for the target, ESCALATE — do not improvise a deploy command.
 
 **CRITICAL: If promotion fails, do NOT retry automatically.** Production deployments that fail may leave the system in an inconsistent state. On failure:

--- a/src/prompts/seeding/04-spec.md
+++ b/src/prompts/seeding/04-spec.md
@@ -580,7 +580,9 @@ Write the required services list to `vision.json.infrastructure.services`:
   "needs_database": true,
   "needs_auth": true,
   "needs_payments": true,
-  "deployment_target": "cloudflare",
+  "deployment_target": "<one of: cloudflare | cloudflare-workers | vercel | docker-compose | github-pages | none>",
   "services": ["supabase", "stripe", "mapbox"]
 }
 ```
+
+Pick `deployment_target` based on what the product needs, not on a house default. Leave it unset only if you genuinely cannot decide yet — the INFRASTRUCTURE discipline will confirm or override it, and `seeding-finalize` will mirror the final choice from `infrastructure_manifest.json.deploy.target`. Docker Compose (`docker-compose`) is the right pick for self-hosted open-source products and complex multi-service stacks; GitHub Pages (`github-pages`) for static-only single-page builds; `none` for CLIs, MCP servers, and other non-web deliverables.


### PR DESCRIPTION
## Summary

The INFRASTRUCTURE seeding discipline writes the chosen deploy target to \`infrastructure_manifest.json.deploy.target\`, but the provisioner reads it from \`cycle_context.vision.infrastructure.deployment_target\`. Nothing was copying between them — every non-Cloudflare target silently failed at provision time. Testimonial reproduced this: \`manifest.deploy.target="docker-compose"\`, \`vision.json.infrastructure={}\`.

## Fixes

- **seeding-finalize propagates manifest → vision + cycle_context** (\`dashboard/src/bridge/seeding-finalize.ts\`). Non-destructive: explicit SPEC/human values win.
- **vision.json schema enum** for \`deployment_target\` — \`cloudflare | cloudflare-workers | vercel | docker-compose | docker | github-pages | gh-pages | none\`. Typos now caught at the schema layer, not deep in provisioning.
- **04-spec.md** no longer implies Cloudflare is the default; the example shows the full enum + notes the INFRASTRUCTURE handoff.
- **07-ship-promote.md** gains Docker Compose, GitHub Pages, and \`none\` production-promote paths. Docker "promote" = publish multi-arch image to GHCR + tag release; no Rouge-managed production URL.
- **Provisioner** recognises \`github-pages\` / \`gh-pages\` (deployer already supported them, provisioner didn't), and the unknown-target warning enumerates the full supported set.

## Note on testimonial

This PR does **not** self-heal testimonial — its vision.json was written before the mirror existed. Re-running \`finalizeSeeding\` (or a one-shot manual merge) is needed to unstick it. New projects seeded after this picks up the wiring automatically.

## Test plan

- [x] Launcher: 459/459
- [x] Dashboard: 420/420 (added 5 mirror tests)
- [x] 0 TS errors in \`src/\` (pre-existing stale-\`dist/\` errors are gitignored local build artifacts)
- [ ] Seed a fresh project that picks \`docker-compose\`, verify \`vision.json.infrastructure.deployment_target\` ends up populated without manual intervention
- [ ] Verify the provisioner logs "docker-compose: no cloud provisioning needed" instead of the "No deployment_target" warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)