### PR TITLE
chore(docs): regenerate cli.md (unblocks Docs check CI)

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -34,6 +34,9 @@ The Rouge CLI
     rouge secrets expiry set <s/K> <date>  Set expiry for a secret
     rouge feasibility <description> Assess feasibility of a proposed change
     rouge contribute <path>         Contribute a draft integration pattern via PR
+    rouge resume-escalation <slug>  Prime a direct Claude Code session for an
+                                    escalation hand-off. Parks the project,
+                                    prints the claude command + context.
     rouge improve                   Run one self-improvement iteration
     rouge improve --max-iterations 5  Run up to 5 iterations
     rouge improve --explore         Enable exploration when no issues remain


### PR DESCRIPTION
## Summary

The \"Docs check\" GitHub Action has been failing on every recent PR:

\`\`\`
FAIL: docs/reference/cli.md is out of date. Run: node scripts/generate-cli-reference.js
\`\`\`

The CLI gained a \`rouge resume-escalation\` command, but nobody re-ran the generator. This PR is the generator output — 3-line addition to \`docs/reference/cli.md\`, no functional changes.

After merge, the Docs check step turns green again on subsequent PRs.

## Test plan
- [x] \`node scripts/generate-cli-reference.js --check\` passes locally after the commit
- [ ] CI Docs check passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)