### PR TITLE
plan(seed-loop phase 0): mark discipline in-progress when prompted

### DIFF
--- a/dashboard/src/bridge/__tests__/seeding-state.test.ts
+++ b/dashboard/src/bridge/__tests__/seeding-state.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, afterEach } from 'vitest'
-import { readSeedingState, writeSeedingState, updateSessionId, markDisciplineComplete, markSeedingComplete, appendPendingCorrection, peekPendingCorrection, clearPendingCorrection, setAwaitingGate, clearPendingGate, updateHeartbeat, isAwaitingGateFor, effectiveMode } from '../seeding-state'
-import { mkdirSync, readdirSync, rmSync } from 'fs'
+import { readSeedingState, writeSeedingState, updateSessionId, markDisciplineComplete, markDisciplinePrompted, markSeedingComplete, appendPendingCorrection, peekPendingCorrection, clearPendingCorrection, setAwaitingGate, clearPendingGate, updateHeartbeat, isAwaitingGateFor, effectiveMode } from '../seeding-state'
+import { writeStateJson, statePath } from '../state-path'
+import { mkdirSync, readdirSync, readFileSync, rmSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 
@@ -84,6 +85,105 @@ describe('seeding-state', () => {
     const state = readSeedingState(testDir)
     expect(state.seeding_complete).toBe(true)
     expect(state.status).toBe('complete')
+  })
+
+  // Phase 0 of the seed-loop architecture plan: when a discipline is
+  // prompted, its state.json entry flips to 'in-progress'. Previously
+  // nothing ever wrote in-progress — only 'complete' — so the stepper
+  // had to synthesise the active state from `currentDiscipline`. That
+  // synthesis broke in the stackrank case (competition was prompted but
+  // UI showed pending). These tests lock in the direct write path.
+  describe('markDisciplinePrompted — state.json flip to in-progress', () => {
+    function seedProjectWithDisciplines(): void {
+      mkdirSync(testDir, { recursive: true })
+      writeStateJson(testDir, {
+        current_state: 'seeding',
+        seedingProgress: {
+          disciplines: [
+            { discipline: 'brainstorming', status: 'pending' },
+            { discipline: 'competition', status: 'pending' },
+            { discipline: 'taste', status: 'pending' },
+            { discipline: 'spec', status: 'pending' },
+            { discipline: 'infrastructure', status: 'pending' },
+            { discipline: 'design', status: 'pending' },
+            { discipline: 'legal-privacy', status: 'pending' },
+            { discipline: 'marketing', status: 'pending' },
+          ],
+          completedCount: 0,
+          totalCount: 8,
+          currentDiscipline: 'brainstorming',
+        },
+      })
+      writeSeedingState(testDir, { session_id: null, status: 'active' })
+    }
+
+    function readDisciplineStatus(discipline: string): string | undefined {
+      const state = JSON.parse(readFileSync(statePath(testDir), 'utf-8'))
+      const entry = state.seedingProgress?.disciplines?.find(
+        (d: { discipline: string }) => d.discipline === discipline,
+      )
+      return entry?.status
+    }
+
+    it('flips discipline status from pending to in-progress', async () => {
+      seedProjectWithDisciplines()
+      await markDisciplinePrompted(testDir, 'competition')
+      expect(readDisciplineStatus('competition')).toBe('in-progress')
+    })
+
+    it('leaves other disciplines untouched', async () => {
+      seedProjectWithDisciplines()
+      await markDisciplinePrompted(testDir, 'competition')
+      expect(readDisciplineStatus('brainstorming')).toBe('pending')
+      expect(readDisciplineStatus('taste')).toBe('pending')
+    })
+
+    it('does not advance currentDiscipline when only going to in-progress', async () => {
+      seedProjectWithDisciplines()
+      await markDisciplinePrompted(testDir, 'competition')
+      // currentDiscipline is controlled by the seed-handler's prompt
+      // flow; markDisciplinePrompted must not clobber it when just
+      // promoting to in-progress. (It DOES advance on 'complete', which
+      // is the existing markDisciplineComplete behaviour.)
+      const state = JSON.parse(readFileSync(statePath(testDir), 'utf-8'))
+      expect(state.seedingProgress.currentDiscipline).toBe('brainstorming')
+    })
+
+    it('is idempotent — calling twice leaves status at in-progress', async () => {
+      seedProjectWithDisciplines()
+      await markDisciplinePrompted(testDir, 'competition')
+      await markDisciplinePrompted(testDir, 'competition')
+      expect(readDisciplineStatus('competition')).toBe('in-progress')
+    })
+
+    it('does not downgrade a complete discipline back to in-progress', async () => {
+      seedProjectWithDisciplines()
+      // First complete brainstorming.
+      await markDisciplineComplete(testDir, 'brainstorming')
+      expect(readDisciplineStatus('brainstorming')).toBe('complete')
+      // Now a stray markDisciplinePrompted — must NOT downgrade.
+      await markDisciplinePrompted(testDir, 'brainstorming')
+      expect(readDisciplineStatus('brainstorming')).toBe('complete')
+    })
+
+    it('still appends to disciplines_prompted in seeding-state.json', async () => {
+      seedProjectWithDisciplines()
+      await markDisciplinePrompted(testDir, 'competition')
+      const s = readSeedingState(testDir)
+      expect(s.disciplines_prompted).toContain('competition')
+    })
+
+    it('is a no-op on state.json when seedingProgress is missing', async () => {
+      // Old projects / malformed states must not throw — they just
+      // skip the state.json update and proceed with seeding-state
+      // mutation.
+      mkdirSync(testDir, { recursive: true })
+      writeStateJson(testDir, { current_state: 'seeding' })
+      writeSeedingState(testDir, { session_id: null, status: 'active' })
+      await expect(markDisciplinePrompted(testDir, 'competition')).resolves.toBeUndefined()
+      const s = readSeedingState(testDir)
+      expect(s.disciplines_prompted).toContain('competition')
+    })
   })
 
   it('writeSeedingState leaves no .tmp file behind on success', () => {

--- a/dashboard/src/bridge/seed-handler.ts
+++ b/dashboard/src/bridge/seed-handler.ts
@@ -405,8 +405,11 @@ async function runSeedingTurn(
 
   // We successfully handed the discipline's sub-prompt to Claude; record
   // it so we don't re-inject on every subsequent turn in the same phase.
+  // Also flips the discipline's status to 'in-progress' in state.json so
+  // the dashboard stepper reads it directly (Phase 0 of the seed-loop
+  // architecture plan — docs/plans/2026-04-19-seed-loop-architecture.md).
   if (needsDisciplinePrompt && activeDiscipline) {
-    markDisciplinePrompted(projectDir, activeDiscipline)
+    await markDisciplinePrompted(projectDir, activeDiscipline)
   }
 
   // Persist session_id if new

--- a/dashboard/src/bridge/seeding-state.ts
+++ b/dashboard/src/bridge/seeding-state.ts
@@ -64,7 +64,7 @@ export async function markDisciplineComplete(projectDir: string, discipline: str
   writeSeedingState(projectDir, state)
 
   // Also update state.json.seedingProgress so the dashboard sees progress
-  await updateStateJsonDiscipline(projectDir, discipline)
+  await updateDisciplineStatusInState(projectDir, discipline, 'complete')
 }
 
 function nextDiscipline(complete: string[]): string {
@@ -76,7 +76,25 @@ function nextDiscipline(complete: string[]): string {
   return DISCIPLINE_SEQUENCE[DISCIPLINE_SEQUENCE.length - 1]
 }
 
-async function updateStateJsonDiscipline(projectDir: string, discipline: string): Promise<void> {
+/**
+ * Update a discipline's status in state.json.seedingProgress.disciplines[].
+ *
+ * Only promotes forward: pending → in-progress → complete. Will not
+ * downgrade a complete entry back to in-progress, or an in-progress
+ * entry back to pending. This keeps the UI's sense of progress
+ * monotonic even if the seed-handler calls get interleaved (e.g. a
+ * discipline is both prompted and completed within the same turn).
+ *
+ * Advancing `currentDiscipline` to the next unfinished item happens
+ * ONLY when a discipline becomes complete — an in-progress transition
+ * leaves `currentDiscipline` pointing at this discipline (because it
+ * IS the one being worked on).
+ */
+async function updateDisciplineStatusInState(
+  projectDir: string,
+  discipline: string,
+  targetStatus: 'in-progress' | 'complete',
+): Promise<void> {
   const stateFile = statePath(projectDir)
   if (!existsSync(stateFile)) return
   await withStateLock(projectDir, () => {
@@ -86,15 +104,32 @@ async function updateStateJsonDiscipline(projectDir: string, discipline: string)
 
       const disciplines = rawState.seedingProgress.disciplines as Array<{ discipline: string; status: string }>
       const entry = disciplines.find(d => d.discipline === discipline)
-      if (entry && entry.status !== 'complete') {
-        entry.status = 'complete'
+      if (!entry) return
+
+      // Monotonic forward-only promotion. Rank: pending < in-progress < complete.
+      const rank = (s: string) => (s === 'complete' ? 2 : s === 'in-progress' ? 1 : 0)
+      if (rank(targetStatus) > rank(entry.status)) {
+        entry.status = targetStatus
+      } else {
+        // No-op — already at or past the target status. Skip the write
+        // to avoid thrashing the mtime (and the watcher) for idempotent
+        // calls.
+        return
       }
+
       rawState.seedingProgress.completedCount = disciplines.filter(d => d.status === 'complete').length
 
-      // Also update currentDiscipline to the next one in sequence
-      const complete = disciplines.filter(d => d.status === 'complete').map(d => d.discipline)
-      const current = DISCIPLINE_SEQUENCE.find(d => !complete.includes(d)) ?? DISCIPLINE_SEQUENCE[DISCIPLINE_SEQUENCE.length - 1]
-      rawState.seedingProgress.currentDiscipline = current
+      // Advance `currentDiscipline` only when something newly completed.
+      // Promoting pending → in-progress means THIS discipline is the
+      // current one, and any other disciplines' currentDiscipline
+      // pointer would be stale — but the handler's prompt logic sets
+      // currentDiscipline explicitly on handoff, so we leave it alone
+      // here for the in-progress case.
+      if (targetStatus === 'complete') {
+        const complete = disciplines.filter(d => d.status === 'complete').map(d => d.discipline)
+        const current = DISCIPLINE_SEQUENCE.find(d => !complete.includes(d)) ?? DISCIPLINE_SEQUENCE[DISCIPLINE_SEQUENCE.length - 1]
+        rawState.seedingProgress.currentDiscipline = current
+      }
 
       writeStateJson(projectDir, rawState)
     } catch {
@@ -122,8 +157,18 @@ export function setStatus(projectDir: string, status: SeedingSessionState['statu
  * Mark a discipline's detailed sub-prompt as having been injected into
  * the current session at least once. Used by the seed handler to decide
  * whether to re-inject on the next turn (#147).
+ *
+ * ALSO flips the matching `state.json.seedingProgress.disciplines[]`
+ * entry to `'in-progress'` (Phase 0 of the seed-loop architecture plan,
+ * see docs/plans/2026-04-19-seed-loop-architecture.md). Previously
+ * nothing ever wrote `in-progress` — the only status writer was
+ * `markDisciplineComplete`, so entries stayed `pending` the whole run
+ * and the dashboard stepper had to synthesise in-progress from
+ * `currentDiscipline`. That synthesis masked a real data gap and broke
+ * whenever the UI's copy of the project was stale (stackrank symptom:
+ * competition prompted, status still pending, UI shows nothing).
  */
-export function markDisciplinePrompted(projectDir: string, discipline: string): void {
+export async function markDisciplinePrompted(projectDir: string, discipline: string): Promise<void> {
   const state = readSeedingState(projectDir)
   const prompted = state.disciplines_prompted ?? []
   if (!prompted.includes(discipline)) {
@@ -132,6 +177,7 @@ export function markDisciplinePrompted(projectDir: string, discipline: string): 
     state.last_activity = new Date().toISOString()
     writeSeedingState(projectDir, state)
   }
+  await updateDisciplineStatusInState(projectDir, discipline, 'in-progress')
 }
 
 /**


### PR DESCRIPTION
## Phase 0 of the seed-loop architecture plan

Reference: [docs/plans/2026-04-19-seed-loop-architecture.md](../blob/main/docs/plans/2026-04-19-seed-loop-architecture.md) (merged in #194).

This is the first shippable piece. Zero architectural risk — just fills a writer gap. Nothing about the daemon extraction or HTTP handler is touched here; that's Phase 1.

## What was wrong

The only code that ever wrote to \`state.json.seedingProgress.disciplines[].status\` was \`markDisciplineComplete\`, which writes \`'complete'\`. Nothing ever wrote \`'in-progress'\`. Entries stayed \`'pending'\` the whole run.

The dashboard stepper compensated by synthesising in-progress from \`currentDiscipline\` (\`discipline-stepper.tsx:132-134\`), but that synthesis broke whenever the UI's cached project data was stale — producing the stackrank symptom where competition was prompted (autonomous seeding was running, producing chat output, building \`seed_spec\`) yet the stepper showed pending forever.

## Fix

When \`markDisciplinePrompted\` fires, also flip the matching \`state.json\` entry to \`'in-progress'\`. The stepper now reads truth directly from disk; synthesis remains as a fallback for projects that seeded before this patch.

Implementation detail: **monotonic forward-only**. A complete discipline cannot downgrade to in-progress; an in-progress cannot downgrade to pending. Prevents the UI's progress sense from going backwards if calls interleave.

Also intentionally does NOT advance \`currentDiscipline\` when promoting to in-progress (only when promoting to complete). The seed-handler's prompt flow owns \`currentDiscipline\` on handoff; this helper must not clobber it.

## Test plan

- [x] 7 new test cases covering the flip, idempotency, no-downgrade, currentDiscipline preservation, malformed-state.json no-op
- [x] Dashboard: 436/436 (+7)
- [x] 0 TS errors in \`src/\`
- [x] Stepper component tests unchanged (synthesis fallback still correct for legacy states)
- [ ] After merge: verify on stackrank that competition flips to in-progress in the UI without requiring a page refresh

## Rollback

Single revert. One-line function signature change plus the test block. No state migration needed (state.json entries at \`'in-progress'\` are still valid under the pre-patch code — they just never got written).

🤖 Generated with [Claude Code](https://claude.com/claude-code)