### PR TITLE
followup(seed-loop): daemon-crash escalation + per-discipline stall threshold + per-discipline recovery prompts

### DIFF
--- a/dashboard/src/bridge/__tests__/recovery-prompts.test.ts
+++ b/dashboard/src/bridge/__tests__/recovery-prompts.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import { recoveryPromptFor } from '../recovery-prompts'
+
+describe('recoveryPromptFor', () => {
+  it('returns a discipline-specific prompt for each of the eight disciplines', () => {
+    const disciplines = [
+      'brainstorming',
+      'competition',
+      'taste',
+      'spec',
+      'infrastructure',
+      'design',
+      'legal-privacy',
+      'marketing',
+    ]
+    const texts = new Set<string>()
+    for (const d of disciplines) {
+      const p = recoveryPromptFor(d)
+      expect(p.text).toMatch(/^\[SYSTEM\]/)
+      expect(p.text.length).toBeGreaterThan(50)
+      texts.add(p.text)
+    }
+    // Each discipline gets a distinct prompt — if someone
+    // accidentally copies one over another, this test catches it.
+    expect(texts.size).toBe(disciplines.length)
+  })
+
+  it('returns a generic fallback for unknown discipline', () => {
+    const p = recoveryPromptFor('some-new-phase-we-dont-know-about')
+    expect(p.text).toMatch(/^\[SYSTEM\]/)
+    expect(p.text).toContain('Continue the current discipline')
+  })
+
+  it('returns a generic fallback for null discipline', () => {
+    expect(recoveryPromptFor(null).text).toMatch(/^\[SYSTEM\]/)
+    expect(recoveryPromptFor(undefined).text).toMatch(/^\[SYSTEM\]/)
+  })
+
+  it('spec recovery explicitly reminds about per-FA markers (the regression Phase 3 is meant to catch)', () => {
+    // Spec has the most explicit "please emit a marker" nudge
+    // because the colourcontrast stall happened inside spec.
+    const p = recoveryPromptFor('spec')
+    expect(p.text).toMatch(/WROTE:/)
+    expect(p.text.toLowerCase()).toContain('faN'.toLowerCase())
+  })
+})

--- a/dashboard/src/bridge/__tests__/state-repair.test.ts
+++ b/dashboard/src/bridge/__tests__/state-repair.test.ts
@@ -222,4 +222,93 @@ describe('repairProjectState', () => {
     expect(report.fixes.filter((f) => f.startsWith('orphan-daemon'))).toEqual([])
     expect(report.fixes.filter((f) => f.startsWith('stale-seed-pid'))).toEqual([])
   })
+
+  // Daemon-crash → first-class escalation (follow-up to Phase 5). The
+  // chat system_note was already covered above; these tests lock in
+  // the additional state.json.escalations[] push so the crash
+  // surfaces on the project card and anywhere escalations render.
+  it('pushes a seed-daemon-crash escalation alongside the system note', async () => {
+    dir = mkdtempSync(join(tmpdir(), 'repair-'))
+    seedProject(
+      { current_state: 'seeding', name: 'crash-test', escalations: [] },
+      { session_id: null, status: 'active' },
+    )
+    writeFileSync(
+      join(dir, 'seed-queue.jsonl'),
+      JSON.stringify({ id: 'q1', text: 'stranded', enqueuedAt: '2026-04-21T00:00:00Z' }) + '\n',
+    )
+
+    const report = await repairProjectState(dir)
+    expect(report.fixes.some((f) => f.startsWith('seed-daemon-crash'))).toBe(true)
+
+    const state = JSON.parse(readFileSync(join(dir, '.rouge', 'state.json'), 'utf-8'))
+    const crashEsc = (state.escalations as Array<Record<string, unknown>>).find(
+      (e) => e.classification === 'seed-daemon-crash',
+    )
+    expect(crashEsc).toBeDefined()
+    expect(crashEsc!.status).toBe('pending')
+    expect(crashEsc!.tier).toBe(1)
+  })
+
+  it('does NOT add a second pending crash escalation on repeated repair passes', async () => {
+    // Repair runs on every scan + every detail fetch. Duplicating
+    // would spam the escalations array; we must dedupe.
+    dir = mkdtempSync(join(tmpdir(), 'repair-'))
+    seedProject(
+      { current_state: 'seeding', name: 'no-dup', escalations: [] },
+      { session_id: null, status: 'active' },
+    )
+    writeFileSync(
+      join(dir, 'seed-queue.jsonl'),
+      JSON.stringify({ id: 'q1', text: 'stranded', enqueuedAt: '2026-04-21T00:00:00Z' }) + '\n',
+    )
+
+    await repairProjectState(dir)
+    await repairProjectState(dir)
+    await repairProjectState(dir)
+
+    const state = JSON.parse(readFileSync(join(dir, '.rouge', 'state.json'), 'utf-8'))
+    const crashEscs = (state.escalations as Array<Record<string, unknown>>).filter(
+      (e) => e.classification === 'seed-daemon-crash' && e.status === 'pending',
+    )
+    expect(crashEscs).toHaveLength(1)
+  })
+
+  it('resolves stale crash escalations once the queue has drained', async () => {
+    // Flow: daemon crashes with queued work → escalation added.
+    // User sends a new message, daemon respawns, drains queue.
+    // State: queue empty, daemon alive → the escalation no longer
+    // applies, so the next repair pass resolves it.
+    dir = mkdtempSync(join(tmpdir(), 'repair-'))
+    seedProject(
+      {
+        current_state: 'seeding',
+        name: 'recovered',
+        escalations: [
+          {
+            id: 'esc-old-crash',
+            tier: 1,
+            classification: 'seed-daemon-crash',
+            summary: 'daemon crashed earlier',
+            status: 'pending',
+            created_at: '2026-04-21T00:00:00Z',
+          },
+        ],
+      },
+      { session_id: null, status: 'active' },
+    )
+    // No seed-queue.jsonl on disk → queue has drained. No .seed-pid
+    // → daemon idle-exited. The escalation should resolve because
+    // the queue is empty.
+
+    const report = await repairProjectState(dir)
+    expect(report.fixes.some((f) => f.startsWith('seed-daemon-crash-stale'))).toBe(true)
+
+    const state = JSON.parse(readFileSync(join(dir, '.rouge', 'state.json'), 'utf-8'))
+    const esc = (state.escalations as Array<Record<string, unknown>>).find(
+      (e) => e.id === 'esc-old-crash',
+    )
+    expect(esc!.status).toBe('resolved')
+    expect(esc!.resolved_at).toBeDefined()
+  })
 })

--- a/dashboard/src/bridge/recovery-prompts.ts
+++ b/dashboard/src/bridge/recovery-prompts.ts
@@ -1,0 +1,99 @@
+/**
+ * Per-discipline recovery prompts for the seed-daemon's self-heal
+ * path. When a turn returns bare prose (no gate, no decision, no
+ * completion marker), the daemon fires a recovery turn asking Rouge
+ * to continue. A discipline-specific prompt gives the recovery a
+ * better chance of producing markers than a generic "continue".
+ *
+ * The daemon calls `recoveryPromptFor(disciplineOrNull)`; if the
+ * discipline is unknown (or null), it returns a generic fallback.
+ *
+ * All prompts are wrapped in a `[SYSTEM]` bracket so the handler's
+ * normal marker parsing doesn't mistake them for chat content.
+ */
+
+export interface RecoveryPrompt {
+  /**
+   * The system text injected into the next turn. Keep these short —
+   * the handler concatenates them with the orchestrator prompt +
+   * sub-prompt on the first turn, so recovery turns already have
+   * context; the recovery text just narrows what we expect to see.
+   */
+  text: string
+}
+
+const GENERIC_RECOVERY: RecoveryPrompt = {
+  text:
+    '[SYSTEM] Recovery: the previous turn returned without markers. ' +
+    'Continue the current discipline — emit `[DECISION:]`, `[WROTE:]`, ' +
+    '`[HEARTBEAT:]`, `[GATE:]`, or `[DISCIPLINE_COMPLETE:]` as appropriate. ' +
+    'If you have a question for the human, emit `[GATE:]` and stop. ' +
+    'If you are mid-autonomous-work, emit a `[DECISION:]` or `[HEARTBEAT:]` and return.',
+}
+
+const RECOVERY_BY_DISCIPLINE: Record<string, RecoveryPrompt> = {
+  brainstorming: {
+    text:
+      '[SYSTEM] Recovery: brainstorming is in progress but the last turn produced no marker. ' +
+      'Check where you are in the four-beat flow (premise gate → shape → deep FA writes → sign-off). ' +
+      'If you still owe the human a gate answer, emit `[GATE:]` and stop. ' +
+      'If you are mid-FA-write, emit the next `[WROTE: faN-spec-written]` as soon as the FA hits disk. ' +
+      'If the skeleton + all FAs are on disk and the rollup is written, emit `[DISCIPLINE_COMPLETE: brainstorming]`.',
+  },
+  competition: {
+    text:
+      '[SYSTEM] Recovery: competition is active but the last turn produced no marker. ' +
+      'Continue the competitive scan. Emit a `[DECISION:]` for each real competitor you classify, ' +
+      'a `[WROTE: competition-analysis]` when the full comparison lands on disk, ' +
+      'and `[DISCIPLINE_COMPLETE: competition]` once the human has signed off on the competitive positioning.',
+  },
+  taste: {
+    text:
+      '[SYSTEM] Recovery: taste is active but the last turn produced no marker. ' +
+      'Continue the references + moodboard work. Emit `[DECISION:]` for each taste anchor you commit to, ' +
+      '`[WROTE: taste-brief]` when the taste brief is on disk, ' +
+      'and `[DISCIPLINE_COMPLETE: taste]` after the human signs off.',
+  },
+  spec: {
+    text:
+      '[SYSTEM] Recovery: spec is mid-decomposition. The three beats are (1) decomposition gate, ' +
+      '(2) complexity shape decision, (3) per-FA deep writes. If you are in Beat 3, emit the NEXT ' +
+      '`[WROTE: faN-spec-written]` as soon as its FA markdown is on disk — do NOT batch FAs into one message. ' +
+      'If you owe a gate answer, emit `[GATE:]` and stop. If all FAs are written and the scope summary ' +
+      'is on disk, emit `[DISCIPLINE_COMPLETE: spec]`.',
+  },
+  infrastructure: {
+    text:
+      '[SYSTEM] Recovery: infrastructure is deciding the deploy/DB/auth stack. ' +
+      'Emit `[DECISION:]` for each resolved choice, `[WROTE: infrastructure-manifest]` when ' +
+      '`infrastructure_manifest.json` is on disk, and `[DISCIPLINE_COMPLETE: infrastructure]` ' +
+      'once the manifest is complete and the human has signed off on the stack.',
+  },
+  design: {
+    text:
+      '[SYSTEM] Recovery: design is producing key screens. Emit `[DECISION:]` for each binding design choice, ' +
+      '`[WROTE: design-<screen>]` per screen artifact, and `[DISCIPLINE_COMPLETE: design]` when ' +
+      'the design brief and screen set are all on disk with human sign-off.',
+  },
+  'legal-privacy': {
+    text:
+      '[SYSTEM] Recovery: legal/privacy is producing the terms + privacy posture. ' +
+      'Emit `[DECISION:]` for each resolved legal choice, `[WROTE: legal-brief]` when the artifact ' +
+      'is on disk, and `[DISCIPLINE_COMPLETE: legal-privacy]` after human sign-off.',
+  },
+  marketing: {
+    text:
+      '[SYSTEM] Recovery: marketing is shaping voice + landing copy. ' +
+      'Emit `[DECISION:]` for each positioning choice, `[WROTE: marketing-brief]` when the artifact ' +
+      'lands, and `[DISCIPLINE_COMPLETE: marketing]` after human sign-off.',
+  },
+}
+
+/**
+ * Return the discipline-specific recovery prompt, or the generic
+ * fallback. Call site: seed-daemon's maybeFireRecovery.
+ */
+export function recoveryPromptFor(discipline: string | null | undefined): RecoveryPrompt {
+  if (!discipline) return GENERIC_RECOVERY
+  return RECOVERY_BY_DISCIPLINE[discipline] ?? GENERIC_RECOVERY
+}

--- a/dashboard/src/bridge/seed-daemon.ts
+++ b/dashboard/src/bridge/seed-daemon.ts
@@ -32,6 +32,7 @@ import { drainQueue, hasQueuedMessages, requeueFront, type QueueEntry } from './
 import { writeSeedPid, clearSeedPid, stillOwned, readSeedPid } from './seed-daemon-pid'
 import { readSeedingState, effectiveMode } from './seeding-state'
 import { readChatLog, appendChatMessage } from './chat-reader'
+import { recoveryPromptFor } from './recovery-prompts'
 
 const HEARTBEAT_FILENAME = 'seed-heartbeat.json'
 const POLL_INTERVAL_MS = 1000
@@ -379,12 +380,15 @@ async function maybeFireRecovery(projectDir: string, sessionId: string): Promise
     sessionId,
     pid: process.pid,
   })
+  // Pull a discipline-specific recovery prompt so the turn isn't
+  // just told "continue" — it's told what markers are expected at
+  // this point in the discipline's flow. Falls back to generic for
+  // unknown / null disciplines.
+  const recoveryPrompt = recoveryPromptFor(state.current_discipline)
   try {
-    await handleSeedMessage(
-      projectDir,
-      '[SYSTEM] Recovery: the previous turn returned without markers. Continue the current discipline — emit [DECISION:], [WROTE:], [HEARTBEAT:], [GATE:], or [DISCIPLINE_COMPLETE:] as appropriate.',
-      { humanMessageAlreadyPersisted: true },
-    )
+    await handleSeedMessage(projectDir, recoveryPrompt.text, {
+      humanMessageAlreadyPersisted: true,
+    })
   } catch (err) {
     console.error(`[seed-daemon] recovery turn failed:`, err)
     appendChatMessage(projectDir, {

--- a/dashboard/src/bridge/state-repair.ts
+++ b/dashboard/src/bridge/state-repair.ts
@@ -138,25 +138,101 @@ export async function repairProjectState(projectDir: string): Promise<RepairRepo
   // `readSeedPid` already cleans up the file and returns null in that
   // case, but we do the explicit call here for the report AND surface
   // stranded queue entries (messages enqueued but the daemon died
-  // before processing them). The user sees a system_note telling
-  // them exactly that happened — otherwise the stranded messages
-  // just sit there until the next user message respawns the daemon.
+  // before processing them). Plus we push a first-class Escalation
+  // so operators scanning the project list see the crash without
+  // needing to open the specific project's seeding chat.
   //
   // Phase 5 of the seed-loop architecture plan: make silent failures
   // visible. A crashed daemon with queued work is exactly the kind of
   // state the UI should surface rather than hide.
   const priorPid = readSeedPid(projectDir) // side-effect: cleans stale file
   const pidExistsOnDisk = existsSync(join(projectDir, '.seed-pid'))
-  // If readSeedPid returned null but the on-disk file existed before
-  // that call, it means readSeedPid evicted a stale entry.
-  // We can also detect stale indirectly: the file went from present
-  // to absent across the call. Simpler: inspect the queue and heartbeat.
   const queueHasWork = hasQueuedMessages(projectDir)
-  if (priorPid === null && !pidExistsOnDisk && queueHasWork) {
-    // Stranded entries with no daemon and no PID file. The user's
-    // next message will respawn a daemon that drains them, but they
-    // should know their prior messages are waiting — especially if
-    // it's been minutes since the crash.
+  const daemonDown = priorPid === null && !pidExistsOnDisk
+
+  // Sweep any `seed-daemon-crash` escalations that no longer apply
+  // (daemon is alive OR queue has drained). Lives OUTSIDE the
+  // "add escalation" path so it runs every repair pass — otherwise
+  // a crash-escalation persists forever after recovery.
+  const crashResolveFixed = await withStateLock(projectDir, () => {
+    try {
+      const current = JSON.parse(readFileSync(sp, 'utf-8')) as {
+        escalations?: Array<Record<string, unknown>>
+      } & Record<string, unknown>
+      const escalations = current.escalations ?? []
+      let mutated = false
+      for (const e of escalations) {
+        if (
+          e.classification === 'seed-daemon-crash' &&
+          e.status === 'pending' &&
+          // Resolve if daemon is back OR queue drained.
+          (!daemonDown || !queueHasWork)
+        ) {
+          e.status = 'resolved'
+          e.resolved_at = new Date().toISOString()
+          e.resolution = 'Daemon recovered or queue drained.'
+          mutated = true
+        }
+      }
+      if (mutated) {
+        writeStateJson(projectDir, current)
+        return true
+      }
+    } catch {
+      // swallow
+    }
+    return false
+  })
+  if (crashResolveFixed) {
+    fixes.push('seed-daemon-crash-stale: resolved prior crash escalation — daemon recovered')
+  }
+
+  if (daemonDown && queueHasWork) {
+    // Stranded entries with no daemon. Two visible surfaces:
+    //   1. A chat system_note in this project's seeding-chat.jsonl
+    //      (tells the user what happened inline with the conversation).
+    //   2. A first-class Escalation in state.json.escalations[]
+    //      (surfaces on the project card + anywhere escalations are
+    //      rendered, so the user sees it without opening the project).
+    //
+    // Only create a new escalation if one isn't already pending —
+    // the repair pass runs on every scan + every detail fetch, and
+    // re-creating would spam escalations.
+    const alreadyEscalated = await withStateLock(projectDir, () => {
+      try {
+        const current = JSON.parse(readFileSync(sp, 'utf-8')) as {
+          escalations?: Array<Record<string, unknown>>
+        } & Record<string, unknown>
+        const existingPendingCrash = (current.escalations ?? []).some(
+          (e) => e.classification === 'seed-daemon-crash' && e.status === 'pending',
+        )
+        if (existingPendingCrash) return true
+        if (!Array.isArray(current.escalations)) current.escalations = []
+        current.escalations.push({
+          id: `esc-seed-daemon-crash-${Date.now()}`,
+          tier: 1,
+          classification: 'seed-daemon-crash',
+          summary:
+            'The seeding daemon crashed with queued messages pending. ' +
+            'Send any message (or click Continue) to respawn — queued work drains first.',
+          story_id: null,
+          status: 'pending',
+          created_at: new Date().toISOString(),
+        })
+        writeStateJson(projectDir, current)
+        return false
+      } catch {
+        return false
+      }
+    })
+    if (!alreadyEscalated) {
+      fixes.push('seed-daemon-crash: added pending escalation for visibility')
+    }
+
+    // Inline chat system_note — written once per call. Dedupe on
+    // content is tolerable; consecutive repair passes might write
+    // duplicates, but the escalation itself is guarded against that
+    // above and is the authoritative signal.
     try {
       appendChatMessage(projectDir, {
         id: `repair-stranded-${Date.now()}`,

--- a/dashboard/src/components/chat-panel.tsx
+++ b/dashboard/src/components/chat-panel.tsx
@@ -11,21 +11,10 @@ import { cn } from '@/lib/utils'
 import { isBridgeEnabled } from '@/lib/bridge-client'
 import { useSeeding } from '@/lib/use-seeding'
 import { SeedingProgressIndicator } from '@/components/seeding-progress-indicator'
-
-// Rough per-discipline expected durations for an agent turn, derived
-// from observed runs. Used to give the elapsed-time display a baseline
-// so "2 minutes" means "on track for spec" rather than "alarming".
-// Tune as we collect more data.
-const TYPICAL_DURATION_SEC: Record<string, { low: number; high: number }> = {
-  brainstorming: { low: 60, high: 180 },
-  competition: { low: 90, high: 240 },
-  taste: { low: 60, high: 150 },
-  spec: { low: 180, high: 480 },
-  infrastructure: { low: 60, high: 180 },
-  design: { low: 240, high: 600 },
-  'legal-privacy': { low: 60, high: 180 },
-  marketing: { low: 120, high: 300 },
-}
+// Typical per-discipline durations + stall-threshold math live in a
+// shared module so use-seeding can derive per-discipline stall
+// windows without duplicating the table.
+import { TYPICAL_DURATION_SEC } from '@/lib/discipline-timing'
 
 interface ChatPanelProps {
   messages: ChatMessageType[]

--- a/dashboard/src/lib/discipline-timing.ts
+++ b/dashboard/src/lib/discipline-timing.ts
@@ -1,0 +1,49 @@
+/**
+ * Typical wall-clock durations per seeding discipline, in seconds.
+ *
+ * Used by two callers:
+ *   1. Chat panel's `ElapsedTimeIndicator` — renders "typical for
+ *      <discipline>: <low>–<high>" under the "Rouge is thinking" bar.
+ *   2. `use-seeding` — derives the stall-detection threshold, so long
+ *      disciplines (spec, design) don't false-alarm as stalled when
+ *      they legitimately take 5–10 minutes for one turn.
+ *
+ * The daemon's background heartbeat ticker writes the heartbeat file
+ * every 5s regardless of what the main loop is doing, so a genuine
+ * stall is detectable well inside the 30s default. This per-discipline
+ * table is the belt-and-braces: on the off chance the event loop is
+ * pinned (a very slow sync operation) or some pathological case, the
+ * UI won't yell about a stall while Rouge is genuinely inside a
+ * normal-length turn for its discipline.
+ */
+export const TYPICAL_DURATION_SEC: Record<string, { low: number; high: number }> = {
+  brainstorming: { low: 60, high: 180 },
+  competition: { low: 90, high: 240 },
+  taste: { low: 60, high: 150 },
+  spec: { low: 180, high: 480 },
+  infrastructure: { low: 60, high: 180 },
+  design: { low: 240, high: 600 },
+  'legal-privacy': { low: 60, high: 180 },
+  marketing: { low: 120, high: 300 },
+}
+
+/**
+ * Derive a stall threshold in milliseconds for a given discipline.
+ *
+ * Rule: max(defaultMs, typical.high * 1000 + 60000). So a discipline
+ * with typical.high of 600s gets a 660s stall threshold (11 min); a
+ * discipline with typical.high of 180s keeps the 30s default. The 60s
+ * buffer on top of typical.high catches the "daemon actually died"
+ * case without firing while Rouge is genuinely still within a
+ * reasonable turn window.
+ */
+export function stallThresholdMsForDiscipline(
+  discipline: string | null | undefined,
+  defaultMs: number,
+): number {
+  if (!discipline) return defaultMs
+  const typical = TYPICAL_DURATION_SEC[discipline]
+  if (!typical) return defaultMs
+  const derived = typical.high * 1000 + 60_000
+  return Math.max(defaultMs, derived)
+}

--- a/dashboard/src/lib/use-seeding.ts
+++ b/dashboard/src/lib/use-seeding.ts
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback, useMemo } from 'react'
 import { fetchSeedingMessages, fetchSeedingStatus, sendSeedMessage, type SeedingChatMessage, type SeedingLivenessStatus } from './bridge-client'
+import { stallThresholdMsForDiscipline } from './discipline-timing'
 
 // Phase 2 of the seed-loop architecture plan (see
 // docs/plans/2026-04-19-seed-loop-architecture.md). This hook polls
@@ -14,9 +15,14 @@ import { fetchSeedingMessages, fetchSeedingStatus, sendSeedMessage, type Seeding
 // turns it tracks.
 const POLL_INTERVAL_MS = 2000
 
-// How recently must a heartbeat have fired for the daemon to be
-// considered actively ticking? Above this, treat as stale.
-const HEARTBEAT_FRESHNESS_MS = 30_000
+// Default heartbeat freshness window — the daemon's background
+// ticker writes every 5s, so anything older than this means the
+// ticker isn't running (daemon dead or event loop pinned). The
+// per-discipline override below relaxes this on disciplines whose
+// typical turn duration is long enough that even a hiccup in the
+// ticker could look like staleness during normal work (spec,
+// design). See `stallThresholdMsForDiscipline` in discipline-timing.
+const DEFAULT_HEARTBEAT_FRESHNESS_MS = 30_000
 
 export type DaemonLiveness =
   /** Daemon not running, no session state on disk, or seeding complete. */
@@ -185,7 +191,17 @@ export function useSeeding(slug: string): UseSeedingResult {
     const d = status.daemon
     if (!d) return 'idle'
     if (!d.alive) return 'idle'
-    if (heartbeatAgeMs !== null && heartbeatAgeMs > HEARTBEAT_FRESHNESS_MS) {
+    // Per-discipline stall threshold: spec/design can legitimately
+    // take 8–10 min for a single turn, so a flat 30s window would
+    // false-alarm when the background ticker skips (which happens
+    // during large sync operations in the Node event loop). The
+    // lookup widens the window for long disciplines without
+    // weakening detection for short ones.
+    const threshold = stallThresholdMsForDiscipline(
+      status.current_discipline,
+      DEFAULT_HEARTBEAT_FRESHNESS_MS,
+    )
+    if (heartbeatAgeMs !== null && heartbeatAgeMs > threshold) {
       return 'stalled'
     }
     if (d.activity === 'processing') return 'processing'


### PR DESCRIPTION
## Summary

Three of the four deferred items from the seed-loop architecture plan. Follow-up to [PR #196](../pull/196).

- **#1 Daemon-crash escalation** — state-repair now pushes a first-class \`seed-daemon-crash\` Escalation alongside the chat system_note. Deduped across repair passes, auto-resolves once the daemon recovers or the queue drains.
- **#3 Per-discipline stall threshold** — stall window widens for spec/design (long legitimate turns) while staying tight for short disciplines. \`use-seeding\` reads it from shared \`dashboard/src/lib/discipline-timing.ts\`.
- **#4 Per-discipline recovery-turn copy** — new \`recovery-prompts.ts\` module. Daemon's \`maybeFireRecovery\` pulls a discipline-aware \`[SYSTEM]\` prompt that narrows what markers are expected at that stage, giving recovery better odds than generic "continue".

## Deferred

- **#2 Project-card daemon-status chip** — skipped per user "don't need".
- **#5 Retire \`rouge seed\` CLI** — separate follow-up PR. User wants the command kept (community surface) but rewritten to enqueue through the daemon so it benefits from observability + recovery.

## Tests

- Dashboard: 477/477 (was 470 on main, +7 new)
- 0 TS errors in src/
- New tests:
  - 3 in state-repair: add escalation, dedupe on repeated repair passes, auto-resolve once queue drains
  - 4 in recovery-prompts: all 8 disciplines distinct, generic fallback, spec-specific marker reminder

## Live smoke test ideas

- Kill a daemon mid-turn (`kill <pid>` while processing). Next scan → `seed-daemon-crash` escalation appears on the project card.
- Send another message. Escalation auto-resolves on the next repair pass.
- Run a spec cycle. No yellow "hasn't ticked" warning during 5–10 min autonomous chunks (previously would fire at 30s).
- Force a bare-prose return (edit Claude's response manually for testing, or hit a genuine stall). Recovery turn fires with a spec-specific prompt reminding about `[WROTE: faN-spec-written]` per FA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)