### PR TITLE
feat: self-heal + triage subsystem — all 4 waves

### DIFF
--- a/docs/plans/2026-04-22-self-heal-and-triage.md
+++ b/docs/plans/2026-04-22-self-heal-and-triage.md
@@ -123,6 +123,61 @@ Parallel-safe, can ship together.
 
 All 458 launcher tests pass (one CLI-probe test skipped — external claude-cli behavior, unrelated).
 
-### Wave 2 — pending
-### Wave 3 — pending
-### Wave 4 — pending
+### Wave 2 — complete (2026-04-22)
+
+- 1.2 ✓ `src/launcher/spin-detector.js` + `phase-fingerprints.jsonl` — 17 tests pass. Wired into foundation-eval + milestone-check in rouge-loop; 3 identical cycles → semantic-spin escalation.
+- 4.2 ✓ Four manifests at `library/integrations/tier-2/{github-pages,vercel,cloudflare-pages,docker-compose}/manifest.json`. Prereqs with auto_remediate, env_vars, secrets_required, health_check.
+- 4.3 ✓ `src/launcher/integration-catalog.js` — `getManifest` / `runCheck` / `runPrerequisites` / `runAutoRemediate` / `ensurePrerequisites` / `runHealthCheck`. 22 tests pass.
+- 4.4 ✓ `deployGithubPages` rewritten to call `ensurePrerequisites` + `runHealthCheck`. GH-Pages auto-enable + CDN propagation wait expressed entirely in the manifest.
+- 5.1/5.2 ✓ Provisioner reads secrets via `getSecret` with keychain fallback. `getCloudflareToken` + `getCloudflareAccountId` added. `mergeSecretsIntoEnv` merges at main() entry.
+- 5.3 ✓ `rouge-loop.js:894` hard-coded token list replaced with target-aware message derived from the integration manifest's `secrets_required`.
+- 6.2/6.3 ✓ Cost-tracker splits `cumulative_cost_usd` into `_real` + `_estimated`. Cap enforcement uses real only; heuristic-fallback estimates cannot trip the cap. Schema enum for `phase_cost_source` extended. 8 tests pass.
+
+### Wave 3 — complete (2026-04-22)
+
+- 2.1/2.2/2.3 ✓ `src/launcher/triage.js` — 4-class rule-based classifier. Schema-warn detection in build.log; fingerprint-history inspection; infrastructure-gap routing. 14 tests.
+- 3.1 ✓ `src/launcher/self-heal-planner.js` — AST-walks launcher source to find the offending literal assignment, proposes an `add-enum-value` plan. 7 tests.
+- 3.2 ✓ `src/launcher/self-heal-zones.js` — green/yellow/red classification. Multi-file → yellow. Safety modules / prompts / CI → red. 29 adversarial tests.
+- 3.3 ✓ `src/launcher/self-heal-applier.js` — branch + patch + test + commit / revert. 17 tests.
+- 3.4 ✓ Rollback via `git checkout <start-branch> && git branch -D <self-heal-branch>` on test failure. Audit log records every action.
+- 3.5 ✓ `rouge doctor` now includes a Self-heal activity section (pending branches, drafts, recent audit events) via `summariseSelfHeal()` in `doctor.js`.
+- 3.6 ✓ Kill switch in `rouge.config.json` — `self_heal: { enabled: true, zones: ['green'] }`. Default is enabled; user can set `enabled: false` or `zones: []` to disable.
+
+Wiring: `attemptSelfHeal()` helper in rouge-loop invoked when foundation-eval semantic-spin fires. Runs triage → plan → apply, embeds outcome in the escalation summary.
+
+### Wave 4 — complete (2026-04-22)
+
+- 8.1 ✓ Stuck-loop early warning — `fingerprintRepeats()` counts trailing identical cycles per phase; `rouge health` surfaces any phase at `repeats >= 2` (default threshold) BEFORE the spin escalation fires at 3.
+- 8.2 ✓ Self-heal activity surface — covered by the `rouge doctor` integration in 3.5 plus `selfHealStats()` in the health report (applied/drafted/refused/reverted lifetime totals).
+- 8.3 ✓ Escalation-category trend — `buildReport()` aggregates escalations across all projects into a histogram, sorted by count. Smoke-tested against the 10 real projects on disk.
+
+New command: `rouge health [--json]` surfaces the whole fleet view. 16 tests.
+
+## Final status
+
+**All four waves shipped. 458 existing launcher tests pass, plus 11 new test files adding ~175 assertions across the new modules:**
+
+| Module | Tests |
+|---|---|
+| schema-assignments | 8 |
+| schema-validator | 11 |
+| findings-fingerprint | 21 |
+| integration-manifest | 8 |
+| spin-detector | 17 |
+| integration-catalog | 22 |
+| cost-tracker | 8 |
+| triage | 14 |
+| self-heal-zones | 29 |
+| self-heal-planner | 7 |
+| self-heal-applier | 17 |
+| health-report | 16 |
+
+**Architectural summary:**
+
+- The loop no longer retries indefinitely. Semantic-spin is detected at 3 identical cycles and routed to triage.
+- Triage classifies the owning layer (Rouge-code / product-taste / missing-automation / unknown) and routes accordingly.
+- Self-heal auto-applies green-zone fixes within tight bounds (single file in `src/launcher/*.js`, ≤30 lines, tests pass, dedicated branch, full audit trail). Yellow-zone plans are drafted for human review. Red-zone refused outright (safety modules, prompts, schemas, CI).
+- Budget cap enforces only on parsed real costs. Heuristic-fallback estimates cannot trip the cap.
+- Deploy-target knowledge lives in `library/integrations/tier-2/*/manifest.json` catalog; launcher consumes via `integration-catalog.js` — no hardcoded target logic in the deploy handler.
+- Secrets unified through the provisioner's `mergeSecretsIntoEnv` at startup. Missing tokens escalate with the specific provider name, not a generic list.
+- Observability: `rouge doctor` shows self-heal activity; `rouge health` gives the fleet-wide stuck-loop + escalation-trend view.

--- a/docs/plans/2026-04-22-self-heal-and-triage.md
+++ b/docs/plans/2026-04-22-self-heal-and-triage.md
@@ -65,7 +65,7 @@ Parallel-safe, can ship together.
 - **1.3** Promote schema validation from warn to enforce (safe once 7.1/7.2 land).
 - **1.1** Findings-fingerprint contract — deterministic hash of evaluator findings, added to eval-report schemas.
 - **4.1** Integration-manifest schema (`schemas/integration-manifest.json`). Fields: `target`, `kind`, `prerequisites`, `auto_remediate`, `health_check`, `build_output_dirs`, `env_vars`, `secrets_required`.
-- **6.1** Budget-cap enforcement audit — trace testimonial's $522 path, confirm whether cap actually halts. Fix so cap = hard stop.
+- **6.1** Checkpoint proliferation fix — `advanceState` writes a checkpoint unconditionally at its top; for escalation/no-transition ticks, this produces hundreds of identical snapshots. Gate the write on `if (next)` so only real transitions checkpoint. (Audit correction: testimonial's "$522 spend" was phantom — it came from summing `phase_cost_usd` across 500 stale escalation snapshots. Real spend was $90.38, exactly at cap. Cap IS halting; checkpoint proliferation was the only real bug.)
 
 ### Wave 2 — Build on contracts
 
@@ -112,4 +112,17 @@ Parallel-safe, can ship together.
 
 ## Progress log
 
-_Update at the end of each merged Wave._
+### Wave 1 — complete (2026-04-22)
+
+- 7.1 ✓ `foundation.status='evaluating'` added to `schemas/state.json` enum.
+- 7.2 ✓ `tests/schema-assignments.test.js` — acorn-based CI invariant walks literal-string assignments to enum-constrained paths. 8 checks, passes. Verified to fail when the schema reverts.
+- 1.3 ✓ `schema-validator.js` gains strict mode (opts in via `{strict: true}` or `ROUGE_STRICT_SCHEMA=1`). `SchemaViolationError` throws instead of warns. `rouge-loop.js:writeJson` uses strict for state.json writes. 11 unit-test checks pass.
+- 1.1 ✓ `src/launcher/findings-fingerprint.js` + 21 tests. Deterministic SHA-256 of eval-report content; ignores transient fields (timestamps, session IDs), case-insensitive verdicts, whitespace-normalised findings, 2-decimal confidence rounding. `hasIdenticalTail(fps, n)` helper for Wave-2 spin detection.
+- 4.1 ✓ `schemas/integration-manifest.json` — structured knowledge schema for deploy/database/auth/payment/observability/storage/queue targets. Fields: prerequisites (with auto_remediate), env_vars, secrets_required, health_check with first-deploy grace window. 8 tests pass.
+- 6.1 ✓ `advanceState` no longer writes a checkpoint on no-op ticks. Gated on `if (next)`. Corrects the checkpoint-proliferation pattern that produced testimonial's 500 identical escalation snapshots.
+
+All 458 launcher tests pass (one CLI-probe test skipped — external claude-cli behavior, unrelated).
+
+### Wave 2 — pending
+### Wave 3 — pending
+### Wave 4 — pending

--- a/docs/plans/2026-04-22-self-heal-and-triage.md
+++ b/docs/plans/2026-04-22-self-heal-and-triage.md
@@ -1,0 +1,115 @@
+# Self-Heal + Triage Architecture
+
+Date: 2026-04-22
+Status: in progress
+Owner: self-assigned (Greg + Claude)
+
+## Problem statement
+
+The integrated build loop can enter unbounded retry cycles when an evaluator returns the same verdict repeatedly. Audit of four concurrent projects (`stack-rank`, `testimonial`, `uat-test`, `irish-planning`) on 2026-04-21 found:
+
+- Zero out of four stalls required product-judgment input from the human.
+- Three of four were Rouge-side bugs (schema enum drift, missing automation, wiring error).
+- One (testimonial) was a real 1-bit taste call, but the loop asked it at cycle 87 instead of cycle 3.
+
+The loop treats every stuck state as an escalation to the human. Most are not. The architecture needs to know which layer owns a failure (Rouge's code, product taste, external constraint) and route accordingly.
+
+## Architectural additions
+
+Two new subsystems, plus tightening of existing contracts:
+
+1. **Triage classifier** — when a phase produces identical findings N times, classify the owning layer and route.
+2. **Self-heal subsystem** — when the classifier says "Rouge-side", apply bounded fixes within strict zones.
+
+The existing escalation pipeline is preserved for its actual purpose: product-direction calls, external constraints, taste disagreement, safety confirmations.
+
+## Self-heal zone contract
+
+**Green zone — auto-apply permitted** (test-gated, git-revertable, audit-logged):
+
+- Bug fixes in `src/launcher/*.js` that are NOT `safety.js`, `deploy-blocking.js`, `self-improve-safety.js`, or `audit-trail.js`.
+- Single-file change ≤ 30 lines.
+- All existing tests pass post-apply.
+- Additive schema extensions — new enum values the launcher already writes.
+- Missing wiring between existing modules (e.g. calling an existing `loadProjectSecrets()` from a new site).
+- Sanitisation fixes for invalid characters in generated identifiers, tags, paths.
+
+**Yellow zone — draft PR, never auto-apply**:
+
+- Anything in `src/prompts/**` (prompts cascade to every future product).
+- Schema contract changes (shape, required fields, value removals).
+- New launcher modules or refactors > 30 lines.
+- New integration-catalog entries.
+
+**Red zone — never self-heal, always human**:
+
+- Phase-prompt content.
+- Product-direction decisions (deploy-target swap, framework swap).
+- Agentic actions outside Rouge's repo (Playwright against third-party accounts, account signups, modifying the user's product code outside the normal story flow).
+- Safety-mechanism logic.
+- `self-improve-safety.js` itself (the meta-gate cannot self-modify).
+
+Every self-heal action, auto or drafted, emits:
+- `audit-log.jsonl` entry (signed via existing `audit-trail.js`).
+- Dedicated `rouge-self-heal/<timestamp>-<slug>` branch.
+- Surface in `rouge doctor`.
+
+## Waves
+
+### Wave 1 — Foundational contracts
+
+Parallel-safe, can ship together.
+
+- **7.1** Fix `foundation.status = 'evaluating'` enum violation (`rouge-loop.js:695` vs `schemas/state.json:41`).
+- **7.2** Schema-write invariant CI test — walk every `state.X = Y` assignment against the schema.
+- **1.3** Promote schema validation from warn to enforce (safe once 7.1/7.2 land).
+- **1.1** Findings-fingerprint contract — deterministic hash of evaluator findings, added to eval-report schemas.
+- **4.1** Integration-manifest schema (`schemas/integration-manifest.json`). Fields: `target`, `kind`, `prerequisites`, `auto_remediate`, `health_check`, `build_output_dirs`, `env_vars`, `secrets_required`.
+- **6.1** Budget-cap enforcement audit — trace testimonial's $522 path, confirm whether cap actually halts. Fix so cap = hard stop.
+
+### Wave 2 — Build on contracts
+
+- **1.2** Semantic-spin detector — compare consecutive evaluator fingerprints per phase; N identical → route to triage.
+- **4.2** First four integration manifests: github-pages, vercel, cloudflare-pages, docker-compose.
+- **4.3** Catalog reader (`src/launcher/integration-catalog.js`) — `getManifest`, `runPrerequisites`, `runHealthCheck`.
+- **4.4** Phase integration — infrastructure-discipline + foundation + deploy handler read from catalog.
+- **5.1** Provisioner uses `loadProjectSecrets()` exclusively.
+- **5.2** Cloudflare helper symmetric with Supabase.
+- **5.3** Dynamic escalation message at `rouge-loop.js:831` — name only the provider that failed.
+- **5.4** Secrets-health as prerequisite check via catalog.
+- **6.2** Cost-tracker fallback labelling — heuristic vs real cost, enforce cap on real only.
+- **6.3** Escalation checkpoints charge $0, not $0.09 × heartbeat-count.
+
+### Wave 3 — Triage + self-heal
+
+- **2.1** Triage classifier module (`src/launcher/triage.js`).
+- **2.2** Routing: self-heal-candidate / human-judgment-needed / mechanical-automation-missing / unknown.
+- **2.3** Initial classifier heuristics.
+- **3.1** Self-heal planner (`src/launcher/self-heal-planner.js`).
+- **3.2** Zone enforcer (`src/launcher/self-heal-zones.js`).
+- **3.3** Applier (`src/launcher/self-heal-applier.js`).
+- **3.4** Rollback via git-revert.
+- **3.5** `rouge doctor` + dashboard surfaces.
+- **3.6** Kill switch in `rouge.config.json`.
+
+### Wave 4 — Observability
+
+- **8.1** Stuck-loop early warning (before budget cap).
+- **8.2** Self-heal activity view.
+- **8.3** Escalation-category trend analysis.
+
+## Test strategy
+
+- Unit tests for every new module under `tests/` or `dashboard/src/**/__tests__/` per the repo convention.
+- A fixture project at `tests/fixtures/stuck-project/` intentionally broken in known ways (schema enum violation, missing wiring, identical-findings loop). End-to-end self-heal regression runs against it.
+- Live-project validation deferred until wave 3 lands — existing stuck projects (stack-rank, testimonial, irish-planning) are the final proof.
+
+## Non-goals
+
+- Fixing evaluator prompt calibration directly. Prompts are red-zone; their drift is a separate taste conversation.
+- Auto-remediating anything outside Rouge's own repo. The product under build is off-limits to self-heal.
+- Replacing the existing escalation UX. Escalation remains the human handoff for the cases where a human is actually needed.
+
+## Progress log
+
+_Update at the end of each merged Wave._

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -27,6 +27,7 @@ The Rouge CLI
   ADVANCED / AUTOMATION
     rouge status <name>             Show state for a single project
     rouge cost <name> [--actual]    Show cost estimate or actuals
+    rouge health [--json]           Cross-project loop-health report (stuck loops, escalations, self-heal)
     rouge secrets list              List stored secret names
     rouge secrets check <dir>       Check project against stored secrets
     rouge secrets validate <target> Validate keys against API endpoints

--- a/library/integrations/tier-2/cloudflare-pages/manifest.json
+++ b/library/integrations/tier-2/cloudflare-pages/manifest.json
@@ -1,0 +1,43 @@
+{
+  "target": "cloudflare-pages",
+  "aliases": ["cloudflare", "cloudflare-workers"],
+  "kind": "deploy",
+  "version": 1,
+  "human_name": "Cloudflare Pages / Workers",
+  "summary": "Edge-deployed site + Workers API. Low-latency global CDN, KV/R2/D1 bundled integrations.",
+  "prerequisites": [
+    {
+      "id": "wrangler-available",
+      "label": "`wrangler` CLI is available on PATH or via npx",
+      "check": { "kind": "shell", "command": "npx --yes wrangler --version" }
+    },
+    {
+      "id": "cloudflare-token",
+      "label": "Cloudflare API token is configured",
+      "check": { "kind": "secret-present", "secret_key": "CLOUDFLARE_API_TOKEN" }
+    },
+    {
+      "id": "cloudflare-account-id",
+      "label": "Cloudflare account ID is configured",
+      "check": { "kind": "secret-present", "secret_key": "CLOUDFLARE_ACCOUNT_ID" }
+    }
+  ],
+  "build_output_dirs": ["dist", "build", ".next", ".open-next"],
+  "env_vars": [
+    { "name": "CLOUDFLARE_API_TOKEN", "required": true, "secret_provider": "cloudflare" },
+    { "name": "CLOUDFLARE_ACCOUNT_ID", "required": true, "secret_provider": "cloudflare" }
+  ],
+  "secrets_required": [
+    { "provider": "cloudflare", "key": "CLOUDFLARE_API_TOKEN" },
+    { "provider": "cloudflare", "key": "CLOUDFLARE_ACCOUNT_ID" }
+  ],
+  "health_check": {
+    "kind": "http-200",
+    "url_template": "https://{project}.pages.dev",
+    "timeout_ms": 10000,
+    "first_deploy_grace_ms": 15000,
+    "first_deploy_poll_window_ms": 90000,
+    "poll_interval_ms": 10000
+  },
+  "notes_for_prompt": "Edge workers reuse instances across concurrent requests (Fluid-Compute-style). For Next.js deploys use `@opennextjs/cloudflare` adapter. For rollback, wrangler retains version history — `wrangler rollback <version>` is available."
+}

--- a/library/integrations/tier-2/docker-compose/manifest.json
+++ b/library/integrations/tier-2/docker-compose/manifest.json
@@ -1,0 +1,42 @@
+{
+  "target": "docker-compose",
+  "aliases": ["docker"],
+  "kind": "deploy",
+  "version": 1,
+  "human_name": "Docker Compose (self-hosted)",
+  "summary": "Self-hosted containerised stack — the product ships its own Dockerfile + compose file and Rouge runs them on localhost for staging.",
+  "prerequisites": [
+    {
+      "id": "docker-available",
+      "label": "Docker daemon is running",
+      "check": { "kind": "shell", "command": "docker info" }
+    },
+    {
+      "id": "compose-available",
+      "label": "docker compose subcommand is available",
+      "check": { "kind": "shell", "command": "docker compose version" }
+    },
+    {
+      "id": "dockerfile-present",
+      "label": "Project has a Dockerfile",
+      "check": { "kind": "file-exists", "path": "Dockerfile" }
+    },
+    {
+      "id": "compose-file-present",
+      "label": "Project has docker-compose.yml",
+      "check": { "kind": "file-exists", "path": "docker-compose.yml" }
+    }
+  ],
+  "build_output_dirs": [],
+  "env_vars": [],
+  "secrets_required": [],
+  "health_check": {
+    "kind": "http-200",
+    "url_template": "http://localhost:{port}",
+    "timeout_ms": 10000,
+    "first_deploy_grace_ms": 5000,
+    "first_deploy_poll_window_ms": 60000,
+    "poll_interval_ms": 5000
+  },
+  "notes_for_prompt": "Staging runs locally via `docker compose up -d --build`. Port resolves from infrastructure_manifest.staging.port → vision.infrastructure.staging_port → 3000. Multi-arch image publishing to GHCR is the product's CI responsibility (via a GitHub Actions workflow foundation scaffolds), not a Rouge staging-deploy concern. No rollback — the previous compose run is torn down before the new one starts."
+}

--- a/library/integrations/tier-2/github-pages/manifest.json
+++ b/library/integrations/tier-2/github-pages/manifest.json
@@ -1,0 +1,43 @@
+{
+  "target": "github-pages",
+  "aliases": ["gh-pages"],
+  "kind": "deploy",
+  "version": 1,
+  "human_name": "GitHub Pages",
+  "summary": "Static site hosting on the gh-pages branch of the project's GitHub repo. No backend, no SSR, no API routes.",
+  "prerequisites": [
+    {
+      "id": "gh-cli-authenticated",
+      "label": "`gh` CLI is installed and authenticated",
+      "check": { "kind": "shell", "command": "gh auth status" }
+    },
+    {
+      "id": "origin-is-github",
+      "label": "origin remote points at github.com",
+      "check": { "kind": "shell", "command": "git config --get remote.origin.url | grep -q github.com" }
+    },
+    {
+      "id": "pages-enabled",
+      "label": "GitHub Pages is enabled on the repo",
+      "check": { "kind": "gh-api", "endpoint": "repos/{owner}/{repo}/pages" },
+      "auto_remediate": {
+        "kind": "gh-api-post",
+        "endpoint": "repos/{owner}/{repo}/pages",
+        "body": { "source": { "branch": "gh-pages", "path": "/" } },
+        "grace_seconds": 30
+      }
+    }
+  ],
+  "build_output_dirs": ["dist", "build", "out", "public"],
+  "env_vars": [],
+  "secrets_required": [],
+  "health_check": {
+    "kind": "http-200",
+    "url_template": "https://{owner}.github.io/{repo}/",
+    "timeout_ms": 10000,
+    "first_deploy_grace_ms": 30000,
+    "first_deploy_poll_window_ms": 150000,
+    "poll_interval_ms": 15000
+  },
+  "notes_for_prompt": "Static-only. No `/api/*` routes. No server components reading secrets at request time. All data baked in at build time or fetched client-side with public keys only."
+}

--- a/library/integrations/tier-2/vercel/manifest.json
+++ b/library/integrations/tier-2/vercel/manifest.json
@@ -1,0 +1,35 @@
+{
+  "target": "vercel",
+  "kind": "deploy",
+  "version": 1,
+  "human_name": "Vercel",
+  "summary": "Managed deployment platform with Fluid Compute functions, ISR, and AI Gateway integration.",
+  "prerequisites": [
+    {
+      "id": "vercel-cli-available",
+      "label": "`vercel` CLI is available on PATH or via npx",
+      "check": { "kind": "shell", "command": "npx --yes vercel --version" }
+    },
+    {
+      "id": "project-linked",
+      "label": "Project is linked (.vercel/project.json exists)",
+      "check": { "kind": "file-exists", "path": ".vercel/project.json" }
+    }
+  ],
+  "build_output_dirs": [".vercel/output", ".next", "dist"],
+  "env_vars": [
+    { "name": "VERCEL_TOKEN", "required": false, "description": "OAuth token for non-interactive `vercel deploy`. If absent, falls back to the user's linked CLI session." },
+    { "name": "VERCEL_ORG_ID", "required": false },
+    { "name": "VERCEL_PROJECT_ID", "required": false }
+  ],
+  "secrets_required": [],
+  "health_check": {
+    "kind": "http-200",
+    "url_template": "https://{project}.vercel.app",
+    "timeout_ms": 10000,
+    "first_deploy_grace_ms": 10000,
+    "first_deploy_poll_window_ms": 60000,
+    "poll_interval_ms": 10000
+  },
+  "notes_for_prompt": "Hobby plan preview URLs return 401 (auth required); deploys use --prod for accessible health checks. Use `vercel.ts` for project config (TypeScript; replaces vercel.json). Default to AI Gateway via `provider/model` strings, not direct provider SDKs unless explicitly requested. Middleware and functions run on Fluid Compute with full Node.js — not edge-only."
+}

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "ajv": "^8.18.0"
   },
   "scripts": {
-    "test": "node tests/secrets.test.js && node tests/cli.test.js && node tests/self-improve.test.js && node tests/auth-mode.test.js && node tests/schema-assignments.test.js && node tests/schema-validator.test.js && node tests/findings-fingerprint.test.js && node tests/integration-manifest.test.js && node --test test/launcher/*.test.js test/prompts/*.test.js test/integration/*.test.js",
+    "test": "node tests/secrets.test.js && node tests/cli.test.js && node tests/self-improve.test.js && node tests/auth-mode.test.js && node tests/schema-assignments.test.js && node tests/schema-validator.test.js && node tests/findings-fingerprint.test.js && node tests/integration-manifest.test.js && node tests/spin-detector.test.js && node tests/integration-catalog.test.js && node --test test/launcher/*.test.js test/prompts/*.test.js test/integration/*.test.js",
     "test:all": "npm test && npm run dashboard:test",
     "dashboard": "cd dashboard && npm run dev",
     "dashboard:install": "cd dashboard && npm install",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "ajv": "^8.18.0"
   },
   "scripts": {
-    "test": "node tests/secrets.test.js && node tests/cli.test.js && node tests/self-improve.test.js && node tests/auth-mode.test.js && node tests/schema-assignments.test.js && node tests/schema-validator.test.js && node tests/findings-fingerprint.test.js && node tests/integration-manifest.test.js && node tests/spin-detector.test.js && node tests/integration-catalog.test.js && node tests/cost-tracker.test.js && node tests/triage.test.js && node tests/self-heal-zones.test.js && node tests/self-heal-planner.test.js && node tests/self-heal-applier.test.js && node --test test/launcher/*.test.js test/prompts/*.test.js test/integration/*.test.js",
+    "test": "node tests/secrets.test.js && node tests/cli.test.js && node tests/self-improve.test.js && node tests/auth-mode.test.js && node tests/schema-assignments.test.js && node tests/schema-validator.test.js && node tests/findings-fingerprint.test.js && node tests/integration-manifest.test.js && node tests/spin-detector.test.js && node tests/integration-catalog.test.js && node tests/cost-tracker.test.js && node tests/triage.test.js && node tests/self-heal-zones.test.js && node tests/self-heal-planner.test.js && node tests/self-heal-applier.test.js && node tests/health-report.test.js && node --test test/launcher/*.test.js test/prompts/*.test.js test/integration/*.test.js",
     "test:all": "npm test && npm run dashboard:test",
     "dashboard": "cd dashboard && npm run dev",
     "dashboard:install": "cd dashboard && npm install",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "ajv": "^8.18.0"
   },
   "scripts": {
-    "test": "node tests/secrets.test.js && node tests/cli.test.js && node tests/self-improve.test.js && node tests/auth-mode.test.js && node tests/schema-assignments.test.js && node tests/schema-validator.test.js && node tests/findings-fingerprint.test.js && node tests/integration-manifest.test.js && node tests/spin-detector.test.js && node tests/integration-catalog.test.js && node tests/cost-tracker.test.js && node --test test/launcher/*.test.js test/prompts/*.test.js test/integration/*.test.js",
+    "test": "node tests/secrets.test.js && node tests/cli.test.js && node tests/self-improve.test.js && node tests/auth-mode.test.js && node tests/schema-assignments.test.js && node tests/schema-validator.test.js && node tests/findings-fingerprint.test.js && node tests/integration-manifest.test.js && node tests/spin-detector.test.js && node tests/integration-catalog.test.js && node tests/cost-tracker.test.js && node tests/triage.test.js && node tests/self-heal-zones.test.js && node tests/self-heal-planner.test.js && node tests/self-heal-applier.test.js && node --test test/launcher/*.test.js test/prompts/*.test.js test/integration/*.test.js",
     "test:all": "npm test && npm run dashboard:test",
     "dashboard": "cd dashboard && npm run dev",
     "dashboard:install": "cd dashboard && npm install",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "ajv": "^8.18.0"
   },
   "scripts": {
-    "test": "node tests/secrets.test.js && node tests/cli.test.js && node tests/self-improve.test.js && node tests/auth-mode.test.js && node tests/schema-assignments.test.js && node tests/schema-validator.test.js && node tests/findings-fingerprint.test.js && node tests/integration-manifest.test.js && node tests/spin-detector.test.js && node tests/integration-catalog.test.js && node --test test/launcher/*.test.js test/prompts/*.test.js test/integration/*.test.js",
+    "test": "node tests/secrets.test.js && node tests/cli.test.js && node tests/self-improve.test.js && node tests/auth-mode.test.js && node tests/schema-assignments.test.js && node tests/schema-validator.test.js && node tests/findings-fingerprint.test.js && node tests/integration-manifest.test.js && node tests/spin-detector.test.js && node tests/integration-catalog.test.js && node tests/cost-tracker.test.js && node --test test/launcher/*.test.js test/prompts/*.test.js test/integration/*.test.js",
     "test:all": "npm test && npm run dashboard:test",
     "dashboard": "cd dashboard && npm run dev",
     "dashboard:install": "cd dashboard && npm install",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "ajv": "^8.18.0"
   },
   "scripts": {
-    "test": "node tests/secrets.test.js && node tests/cli.test.js && node tests/self-improve.test.js && node tests/auth-mode.test.js && node --test test/launcher/*.test.js test/prompts/*.test.js test/integration/*.test.js",
+    "test": "node tests/secrets.test.js && node tests/cli.test.js && node tests/self-improve.test.js && node tests/auth-mode.test.js && node tests/schema-assignments.test.js && node tests/schema-validator.test.js && node --test test/launcher/*.test.js test/prompts/*.test.js test/integration/*.test.js",
     "test:all": "npm test && npm run dashboard:test",
     "dashboard": "cd dashboard && npm run dev",
     "dashboard:install": "cd dashboard && npm install",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "ajv": "^8.18.0"
   },
   "scripts": {
-    "test": "node tests/secrets.test.js && node tests/cli.test.js && node tests/self-improve.test.js && node tests/auth-mode.test.js && node tests/schema-assignments.test.js && node tests/schema-validator.test.js && node --test test/launcher/*.test.js test/prompts/*.test.js test/integration/*.test.js",
+    "test": "node tests/secrets.test.js && node tests/cli.test.js && node tests/self-improve.test.js && node tests/auth-mode.test.js && node tests/schema-assignments.test.js && node tests/schema-validator.test.js && node tests/findings-fingerprint.test.js && node tests/integration-manifest.test.js && node --test test/launcher/*.test.js test/prompts/*.test.js test/integration/*.test.js",
     "test:all": "npm test && npm run dashboard:test",
     "dashboard": "cd dashboard && npm run dev",
     "dashboard:install": "cd dashboard && npm install",

--- a/rouge.config.json
+++ b/rouge.config.json
@@ -31,6 +31,10 @@
     ],
     "test_budget_usd": 5
   },
+  "self_heal": {
+    "enabled": true,
+    "zones": ["green"]
+  },
   "linked_projects": {
     "max_depth": 3,
     "registry_path": "~/.rouge/registry.json"

--- a/schemas/integration-manifest.json
+++ b/schemas/integration-manifest.json
@@ -1,0 +1,157 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Rouge Integration Manifest",
+  "description": "Structured knowledge for a deployment target, database, auth provider, or observability service. Consumed by src/launcher/integration-catalog.js. Phase prompts read resolved manifest content via cycle_context.json rather than parsing YAML/JSON directly — the launcher is the only manifest consumer.",
+  "type": "object",
+  "required": ["target", "kind", "version"],
+  "additionalProperties": false,
+  "properties": {
+    "target": {
+      "type": "string",
+      "description": "Canonical slug for this integration — must match exactly the value that appears in vision.json.infrastructure.deployment_target (or the analogous field for non-deploy kinds). Lowercase, hyphen-separated.",
+      "pattern": "^[a-z][a-z0-9-]*$"
+    },
+    "aliases": {
+      "type": "array",
+      "description": "Alternate slugs that resolve to this manifest. e.g. github-pages manifests should alias 'gh-pages'. Lets the resolver accept variants without duplicating the file.",
+      "items": { "type": "string", "pattern": "^[a-z][a-z0-9-]*$" }
+    },
+    "kind": {
+      "type": "string",
+      "enum": ["deploy", "database", "auth", "payment", "observability", "storage", "queue"],
+      "description": "Which Rouge subsystem consumes this. 'deploy' → deploy-to-staging.js. 'database' → provision-infrastructure.js. 'auth' → foundation prompt. etc."
+    },
+    "version": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Manifest schema version. Bump when the manifest's contract changes in a breaking way. The catalog refuses to load manifests whose version exceeds what the runtime supports."
+    },
+    "human_name": {
+      "type": "string",
+      "description": "Pretty name for UI surfaces (dashboard badges, escalation text)."
+    },
+    "summary": {
+      "type": "string",
+      "description": "One-line description of the target, shown to users during infrastructure-discipline selection."
+    },
+    "prerequisites": {
+      "type": "array",
+      "description": "Ordered checks Rouge runs before attempting to use this integration. Each prerequisite has a machine-readable `check` that returns pass/fail and a human-readable `label` for surfacing in escalations. If `auto_remediate` is set on a prerequisite, the launcher may attempt it green-zone when the check fails (see self-heal zones).",
+      "items": {
+        "type": "object",
+        "required": ["id", "label", "check"],
+        "additionalProperties": false,
+        "properties": {
+          "id": { "type": "string", "pattern": "^[a-z][a-z0-9-]*$" },
+          "label": { "type": "string" },
+          "check": {
+            "type": "object",
+            "description": "How to verify this prerequisite. The launcher dispatches on 'kind'.",
+            "required": ["kind"],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": ["shell", "gh-api", "secret-present", "file-exists", "env-var-present"]
+              },
+              "command": { "type": "string", "description": "For kind=shell. Non-zero exit = fail." },
+              "endpoint": { "type": "string", "description": "For kind=gh-api. e.g. 'repos/{owner}/{repo}/pages'." },
+              "secret_key": { "type": "string", "description": "For kind=secret-present. Key in the Rouge secrets store." },
+              "env_var": { "type": "string", "description": "For kind=env-var-present." },
+              "path": { "type": "string", "description": "For kind=file-exists. Relative to project dir." }
+            }
+          },
+          "auto_remediate": {
+            "type": "object",
+            "description": "Green-zone auto-remediation. Runs only if the prerequisite check fails AND self-heal green-zone is enabled. Omit to disable auto-remediation for this prerequisite.",
+            "required": ["kind"],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": ["shell", "gh-api-post"]
+              },
+              "command": { "type": "string" },
+              "endpoint": { "type": "string", "description": "For kind=gh-api-post." },
+              "body": { "type": "object", "description": "For kind=gh-api-post. JSON body to POST." },
+              "grace_seconds": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "After remediation, wait up to this long (polling) before the next check. 0 = don't wait. GitHub Pages first-enable needs ~90s for CDN provisioning, for instance."
+              }
+            }
+          }
+        }
+      }
+    },
+    "build_output_dirs": {
+      "type": "array",
+      "description": "For kind=deploy: candidate directories the framework writes static build output to. Probed in order. First match wins. If the project declares an explicit output dir in its infrastructure_manifest.json, that takes precedence over this list.",
+      "items": { "type": "string" }
+    },
+    "env_vars": {
+      "type": "array",
+      "description": "Environment variables the integration's CLI expects in process.env at spawn time. Rouge merges these from the secrets store before launching the integration tool. A missing var is escalated with the specific name, not a generic 'missing token' message.",
+      "items": {
+        "type": "object",
+        "required": ["name", "required"],
+        "additionalProperties": false,
+        "properties": {
+          "name": { "type": "string", "pattern": "^[A-Z][A-Z0-9_]*$" },
+          "required": { "type": "boolean" },
+          "description": { "type": "string" },
+          "secret_provider": {
+            "type": "string",
+            "description": "Which provider in the secrets store holds this. Lets the secret lookup know which keychain namespace to read from."
+          }
+        }
+      }
+    },
+    "secrets_required": {
+      "type": "array",
+      "description": "Secrets the integration needs. Each maps to a key in Rouge's secrets.js store. Missing secrets escalate with 'run rouge setup <provider>'.",
+      "items": {
+        "type": "object",
+        "required": ["provider", "key"],
+        "additionalProperties": false,
+        "properties": {
+          "provider": { "type": "string", "description": "Secrets-store provider slug (e.g. 'cloudflare', 'supabase')." },
+          "key": { "type": "string", "pattern": "^[A-Z][A-Z0-9_]*$" },
+          "optional": { "type": "boolean", "default": false }
+        }
+      }
+    },
+    "health_check": {
+      "type": "object",
+      "description": "How to determine if a deploy succeeded. The deploy handler calls this after push.",
+      "required": ["kind"],
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["http-200", "http-status-any-2xx", "none"]
+        },
+        "url_template": {
+          "type": "string",
+          "description": "Templated URL with {owner}, {repo}, {project} placeholders the deploy handler fills in."
+        },
+        "timeout_ms": { "type": "integer", "minimum": 1000, "default": 10000 },
+        "first_deploy_grace_ms": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 0,
+          "description": "On first-time deploys (after prerequisite auto_remediate fired), wait this long before the first probe. GitHub Pages CDN provisioning needs ~30s initial delay."
+        },
+        "first_deploy_poll_window_ms": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 0,
+          "description": "Total time to keep polling on first-time deploys before giving up."
+        },
+        "poll_interval_ms": { "type": "integer", "minimum": 500, "default": 15000 }
+      }
+    },
+    "notes_for_prompt": {
+      "type": "string",
+      "description": "Free-form text the foundation/ship prompt should surface. Keep short — prompts already carry a lot of context. Use this for target-specific gotchas the prompt can't derive."
+    }
+  }
+}

--- a/schemas/state.json
+++ b/schemas/state.json
@@ -119,7 +119,7 @@
         "phase_cost_usd": { "type": "number" },
         "cumulative_tokens": { "type": "number" },
         "cumulative_cost_usd": { "type": "number" },
-        "phase_cost_source": { "type": "string", "enum": ["parsed", "heuristic"] }
+        "phase_cost_source": { "type": "string", "enum": ["parsed", "parsed-tokens", "heuristic", "estimated"] }
       }
     },
     "budget_cap_usd": { "type": "number", "minimum": 0 },

--- a/schemas/state.json
+++ b/schemas/state.json
@@ -38,7 +38,7 @@
       "type": ["object", "null"],
       "additionalProperties": true,
       "properties": {
-        "status": { "type": "string", "enum": ["pending", "not-needed", "in-progress", "complete"] },
+        "status": { "type": "string", "enum": ["pending", "not-needed", "in-progress", "evaluating", "complete"] },
         "scope": { "type": "array", "items": { "type": "string" } },
         "completed_at": { "type": "string" }
       }

--- a/src/launcher/cost-tracker.js
+++ b/src/launcher/cost-tracker.js
@@ -85,15 +85,35 @@ function parseRealCostFromLog(logPath) {
   }
 }
 
-function trackPhaseCost(state, phaseTokens, model) {
+function initCosts(state) {
   if (!state.costs) {
-    state.costs = { cumulative_tokens: 0, cumulative_cost_usd: 0 };
+    state.costs = {
+      cumulative_tokens: 0,
+      cumulative_cost_usd: 0,
+      // Split tracking (added 2026-04-22): cap enforcement uses the
+      // 'real' stream only so heuristic fallback estimates can't trip
+      // the cap. Total = real + estimated for display.
+      cumulative_cost_usd_real: 0,
+      cumulative_cost_usd_estimated: 0,
+    };
+  } else {
+    // Backfill the split fields for pre-existing state.json files so
+    // callers can rely on them being present after any trackPhase call.
+    if (state.costs.cumulative_cost_usd_real == null) state.costs.cumulative_cost_usd_real = 0;
+    if (state.costs.cumulative_cost_usd_estimated == null) state.costs.cumulative_cost_usd_estimated = 0;
   }
+}
+
+function trackPhaseCost(state, phaseTokens, model) {
+  initCosts(state);
   const phaseCost = estimatePhaseCost(phaseTokens, model);
   state.costs.phase_tokens = phaseTokens;
   state.costs.phase_cost_usd = phaseCost;
   state.costs.cumulative_tokens += phaseTokens;
   state.costs.cumulative_cost_usd += phaseCost;
+  // trackPhaseCost is heuristic-only (no log to parse) — label as estimated.
+  state.costs.cumulative_cost_usd_estimated += phaseCost;
+  state.costs.phase_cost_source = 'estimated';
 }
 
 /**
@@ -101,25 +121,35 @@ function trackPhaseCost(state, phaseTokens, model) {
  * token heuristic. If parseRealCostFromLog returns a real costUsd,
  * use it directly (bypass the estimate). Otherwise fall back to the
  * token-based estimate.
+ *
+ * Labels the cost source so cap enforcement can exclude heuristic
+ * fallbacks: `parsed` (real costUsd from log) → counted toward
+ * cumulative_cost_usd_real. `parsed-tokens` (real tokens only,
+ * priced via the model table) → also counted as real. `heuristic`
+ * (log-size proxy) → counted as estimated, excluded from cap.
  */
 function trackPhaseCostFromLog(state, logPath, fallbackTokens, model) {
-  if (!state.costs) {
-    state.costs = { cumulative_tokens: 0, cumulative_cost_usd: 0 };
-  }
+  initCosts(state);
   const real = parseRealCostFromLog(logPath);
   const tokens = real?.tokens || fallbackTokens;
   const cost = (real?.costUsd !== null && real?.costUsd !== undefined)
     ? real.costUsd
     : estimatePhaseCost(tokens, model);
-  state.costs.phase_tokens = tokens;
-  state.costs.phase_cost_usd = cost;
-  state.costs.cumulative_tokens += tokens;
-  state.costs.cumulative_cost_usd += cost;
-  state.costs.phase_cost_source = real?.costUsd != null
+  const source = real?.costUsd != null
     ? 'parsed'
     : real?.tokens
       ? 'parsed-tokens'
       : 'heuristic';
+  state.costs.phase_tokens = tokens;
+  state.costs.phase_cost_usd = cost;
+  state.costs.cumulative_tokens += tokens;
+  state.costs.cumulative_cost_usd += cost;
+  if (source === 'parsed' || source === 'parsed-tokens') {
+    state.costs.cumulative_cost_usd_real += cost;
+  } else {
+    state.costs.cumulative_cost_usd_estimated += cost;
+  }
+  state.costs.phase_cost_source = source;
 }
 
 /**
@@ -128,9 +158,21 @@ function trackPhaseCostFromLog(state, logPath, fallbackTokens, model) {
  * than after. Previously `cumulative >= cap` fired only after a phase
  * had already pushed past — typical phase cost is a few dollars on
  * Opus, so caps could miss by a meaningful amount.
+ *
+ * Uses the REAL cumulative stream only (parsed / parsed-tokens), not
+ * the heuristic fallback. Prior to 2026-04-22 the cap was tripped by
+ * heuristic estimates that inflated with log size — a pattern that
+ * could halt a project on "budget exceeded" without having actually
+ * spent the money. If a project exclusively produces heuristic costs
+ * (old state.json with no real-cost split), fall back to the total
+ * so we don't silently disable the cap for legacy data.
  */
 function checkBudgetCap(state, budgetCapUsd) {
-  const cumulative = state.costs?.cumulative_cost_usd || 0;
+  const cumulativeReal = state.costs?.cumulative_cost_usd_real;
+  const cumulativeTotal = state.costs?.cumulative_cost_usd || 0;
+  // If the split-tracking fields aren't populated yet (pre-split state),
+  // use the total. Otherwise prefer real.
+  const cumulative = (cumulativeReal == null) ? cumulativeTotal : cumulativeReal;
   const margin = Math.max(budgetCapUsd * CAP_SAFETY_FRACTION, CAP_SAFETY_MIN_USD);
   return cumulative >= (budgetCapUsd - margin);
 }
@@ -138,10 +180,12 @@ function checkBudgetCap(state, budgetCapUsd) {
 /**
  * Strict cap check — true only when the cumulative has actually
  * exceeded the cap. Use for logging / alerting; use `checkBudgetCap`
- * for the pre-phase gate.
+ * for the pre-phase gate. Uses real cumulative, matching checkBudgetCap.
  */
 function isOverBudget(state, budgetCapUsd) {
-  const cumulative = state.costs?.cumulative_cost_usd || 0;
+  const cumulativeReal = state.costs?.cumulative_cost_usd_real;
+  const cumulativeTotal = state.costs?.cumulative_cost_usd || 0;
+  const cumulative = (cumulativeReal == null) ? cumulativeTotal : cumulativeReal;
   return cumulative >= budgetCapUsd;
 }
 

--- a/src/launcher/deploy-to-staging.js
+++ b/src/launcher/deploy-to-staging.js
@@ -225,6 +225,28 @@ function deployGithubPages(projectDir) {
   }
   const [, owner, repo] = remoteMatch;
 
+  // Catalog-driven prerequisite handling. The github-pages manifest
+  // declares "pages-enabled" with a gh-api-post auto_remediate, so a
+  // first-time deploy against a repo without Pages enabled gets
+  // auto-toggled in the green zone. Any prerequisite without
+  // auto_remediate that fails raises a prerequisite-failed error.
+  const { getManifest, ensurePrerequisites } = require('./integration-catalog.js');
+  const manifestDef = getManifest('github-pages');
+  const prereqCtx = { projectDir, owner, repo, project: path.basename(projectDir) };
+  let firstTimeDeploy = false;
+  if (manifestDef) {
+    const prereq = ensurePrerequisites(manifestDef, prereqCtx);
+    if (prereq.remediated.length > 0) {
+      firstTimeDeploy = prereq.remediated.includes('pages-enabled');
+      log(`Auto-remediated prerequisites: ${prereq.remediated.join(', ')}`);
+    }
+    if (!prereq.ok) {
+      throw new Error(
+        `GitHub Pages prerequisites failed: ${prereq.failed.map((f) => `${f.label} (${f.detail})`).join('; ')}`,
+      );
+    }
+  }
+
   const manifest = readJson(path.join(projectDir, 'infrastructure_manifest.json'));
   const vision = readJson(path.join(projectDir, 'vision.json'));
   const configuredOutput =
@@ -232,7 +254,7 @@ function deployGithubPages(projectDir) {
     vision?.infrastructure?.github_pages?.output_dir;
   const outputCandidates = configuredOutput
     ? [configuredOutput]
-    : ['dist', 'build', 'out', 'public'];
+    : (manifestDef?.build_output_dirs || ['dist', 'build', 'out', 'public']);
 
   // Build — same timeout profile as Cloudflare since a cold Vite/Next
   // build on a fresh runner can crest 2 min.
@@ -280,7 +302,19 @@ function deployGithubPages(projectDir) {
   // https://<owner>.github.io/ without the repo suffix.
   const url = `https://${owner}.github.io/${repo}/`;
   log(`Deployed to ${url}`);
-  log('⚠️  First-time deploy: enable GitHub Pages in repo settings (Source: Deploy from a branch → gh-pages) if not already. Propagation takes ~1 min.');
+  // If we just enabled Pages for the first time, use the manifest's
+  // first-deploy grace + poll window to wait for CDN propagation
+  // before the shared post-deploy health check lands. On subsequent
+  // deploys, no wait — the site is already serving.
+  if (firstTimeDeploy && manifestDef) {
+    const { runHealthCheck } = require('./integration-catalog.js');
+    const probe = runHealthCheck(manifestDef, url, { firstDeploy: true });
+    if (probe.ok) {
+      log(`Pages serving (${probe.attempts} probe${probe.attempts === 1 ? '' : 's'}, ${Math.round(probe.elapsedMs / 1000)}s after enable)`);
+    } else {
+      log(`Pages did not respond within the first-deploy window (${probe.attempts} probes, last status ${probe.status}); the caller health check will surface this.`);
+    }
+  }
   return url;
 }
 

--- a/src/launcher/doctor.js
+++ b/src/launcher/doctor.js
@@ -132,13 +132,61 @@ function runDoctor({ ROUGE_ROOT, getSecret } = {}) {
   const blockers = checks.filter((c) => c.status === 'blocker').map((c) => c.id);
   const warnings = checks.filter((c) => c.status === 'warning').map((c) => c.id);
 
+  // Self-heal activity summary. Reads audit log + in-repo git branches
+  // so the user can see what Rouge has auto-applied or drafted since
+  // last time they looked. Non-blocking: any failure to read just
+  // omits the section.
+  const selfHeal = summariseSelfHeal(ROUGE_ROOT);
+
   return {
     checks,
     blockers,
     warnings,
+    selfHeal,
     allGreen: blockers.length === 0 && warnings.length === 0,
     allRequired: blockers.length === 0,
   };
+}
+
+function summariseSelfHeal(ROUGE_ROOT) {
+  const summary = { branches: [], drafts: [], recent: [] };
+  try {
+    // Count self-heal branches waiting for merge.
+    const { execSync } = require('child_process');
+    const out = execSync('git branch --list "rouge-self-heal/*"', {
+      cwd: ROUGE_ROOT || process.cwd(),
+      encoding: 'utf8',
+      stdio: 'pipe',
+    });
+    summary.branches = out.trim().split('\n').map((l) => l.replace(/^[* ]+/, '')).filter(Boolean);
+  } catch {
+    // not a git repo / git missing — fine.
+  }
+  try {
+    const draftsDir = path.join(ROUGE_ROOT || process.cwd(), '.rouge', 'self-heal-drafts');
+    if (fs.existsSync(draftsDir)) {
+      summary.drafts = fs.readdirSync(draftsDir).filter((f) => f.endsWith('.json'));
+    }
+  } catch { /* ignore */ }
+  try {
+    // Last 5 self-heal audit entries. Reads from ~/.rouge/audit-log.jsonl.
+    const auditPath = path.join(process.env.HOME || '/tmp', '.rouge', 'audit-log.jsonl');
+    if (fs.existsSync(auditPath)) {
+      const raw = fs.readFileSync(auditPath, 'utf8');
+      const lines = raw.trim().split('\n').filter(Boolean);
+      const entries = [];
+      for (let i = lines.length - 1; i >= 0 && entries.length < 5; i--) {
+        try {
+          const e = JSON.parse(lines[i]);
+          if (e && typeof e.kind === 'string' && e.kind.startsWith('self-heal')) {
+            entries.unshift({ ts: e.ts, kind: e.kind, plan_kind: e.plan_kind, zone: e.zone });
+          }
+        } catch { /* skip */ }
+      }
+      summary.recent = entries;
+    }
+  } catch { /* ignore */ }
+  return summary;
 }
 
 function formatDoctorText(result) {
@@ -167,8 +215,32 @@ function formatDoctorText(result) {
       lines.push(`    - ${c.label}: ${c.detail}`);
     }
   }
+  // Self-heal activity section.
+  if (result.selfHeal) {
+    const sh = result.selfHeal;
+    const hasAny = (sh.branches && sh.branches.length > 0) || (sh.drafts && sh.drafts.length > 0) || (sh.recent && sh.recent.length > 0);
+    if (hasAny) {
+      lines.push('');
+      lines.push('  Self-heal activity');
+      lines.push(`  ${'─'.repeat(40)}`);
+      if (sh.branches.length > 0) {
+        lines.push(`  \u{1F527} ${sh.branches.length} pending self-heal branch${sh.branches.length > 1 ? 'es' : ''} (ready to merge):`);
+        for (const b of sh.branches) lines.push(`     - ${b}`);
+      }
+      if (sh.drafts.length > 0) {
+        lines.push(`  \u{1F4DD} ${sh.drafts.length} draft plan${sh.drafts.length > 1 ? 's' : ''} awaiting review in .rouge/self-heal-drafts/`);
+      }
+      if (sh.recent.length > 0) {
+        lines.push(`  Recent self-heal events:`);
+        for (const e of sh.recent) {
+          lines.push(`     - ${e.ts} ${e.kind}${e.plan_kind ? ` (${e.plan_kind})` : ''}${e.zone ? ` [${e.zone}]` : ''}`);
+        }
+      }
+      lines.push('');
+    }
+  }
   lines.push('');
   return lines.join('\n');
 }
 
-module.exports = { runDoctor, formatDoctorText };
+module.exports = { runDoctor, formatDoctorText, summariseSelfHeal };

--- a/src/launcher/findings-fingerprint.js
+++ b/src/launcher/findings-fingerprint.js
@@ -1,0 +1,133 @@
+/**
+ * Deterministic fingerprint of evaluator findings.
+ *
+ * Purpose: detect semantic spin — the pattern where a phase produces
+ * the same bad verdict for N consecutive cycles with no progress
+ * between them. Wave-2's triage classifier compares consecutive
+ * fingerprints per phase; N identical → route to self-heal / escalate.
+ *
+ * Design: fingerprint is computed at the launcher (not in the prompt),
+ * so prompts stay focused on their domain and don't need to know about
+ * the spin-detection mechanism. The launcher reads the report out of
+ * cycle_context.json and passes it through `fingerprintReport`.
+ *
+ * What gets hashed:
+ *   - `verdict` (PASS / FAIL / NEEDS_IMPROVEMENT / etc.)
+ *   - `dimensions.*.status` — the per-dimension verdict breakdown
+ *   - `structural_gaps[]`, `integration_gaps[]`, `findings[]` — the
+ *     content of what's wrong, sorted for stability
+ *   - Confidence score, if present, rounded to 2 decimals (tiny
+ *     numeric drift shouldn't split the fingerprint)
+ *
+ * What gets ignored:
+ *   - Timestamps, session IDs, phase names, any transient metadata
+ *   - Key order (canonical JSON)
+ *   - Whitespace in finding strings (collapsed to single spaces)
+ *   - Case in verdict/status strings (upper-cased)
+ *
+ * The goal is "same finding tomorrow as today" → same hash.
+ */
+
+const crypto = require('crypto');
+
+function normaliseString(s) {
+  if (typeof s !== 'string') return String(s);
+  return s.replace(/\s+/g, ' ').trim().toLowerCase();
+}
+
+function normaliseFindingList(list) {
+  if (!Array.isArray(list)) return [];
+  return list
+    .map((item) => {
+      if (typeof item === 'string') return normaliseString(item);
+      if (item && typeof item === 'object') {
+        // Normalise the whole object into sorted-key JSON so field
+        // order and insignificant whitespace don't shift the hash.
+        return canonicalise(item);
+      }
+      return String(item);
+    })
+    .sort();
+}
+
+function canonicalise(value) {
+  if (value === null || typeof value !== 'object') return value;
+  if (Array.isArray(value)) return value.map(canonicalise);
+  const keys = Object.keys(value).sort();
+  const out = {};
+  for (const k of keys) out[k] = canonicalise(value[k]);
+  return out;
+}
+
+function normaliseDimensions(dimensions) {
+  if (!dimensions || typeof dimensions !== 'object') return {};
+  const out = {};
+  for (const k of Object.keys(dimensions).sort()) {
+    const dim = dimensions[k];
+    if (!dim || typeof dim !== 'object') {
+      out[k] = { status: String(dim).toUpperCase() };
+      continue;
+    }
+    out[k] = {
+      status: (dim.status ? String(dim.status) : '').toUpperCase(),
+      // Include findings per dimension so a dimension swap shifts the
+      // fingerprint even if the overall verdict doesn't.
+      findings: normaliseFindingList(dim.findings),
+    };
+  }
+  return out;
+}
+
+function roundConfidence(score) {
+  if (typeof score !== 'number' || Number.isNaN(score)) return null;
+  return Math.round(score * 100) / 100;
+}
+
+/**
+ * Compute the fingerprint of an evaluator report. Stable across
+ * runs that produce semantically identical findings.
+ *
+ * @param {object|null|undefined} report — an eval report object
+ *   (foundation_eval_report, milestone_check_report, po_review_report,
+ *   evaluation_report, or any shape with `verdict` + findings fields).
+ * @returns {string} hex-encoded SHA-256 of the normalised payload,
+ *   or an empty string if the report is null/undefined.
+ */
+function fingerprintReport(report) {
+  if (report == null) return '';
+  const payload = {
+    verdict: (report.verdict ? String(report.verdict) : '').toUpperCase(),
+    dimensions: normaliseDimensions(report.dimensions),
+    structural_gaps: normaliseFindingList(report.structural_gaps),
+    integration_gaps: normaliseFindingList(report.integration_gaps),
+    findings: normaliseFindingList(report.findings),
+    recommendations: normaliseFindingList(report.recommendations),
+    confidence: roundConfidence(report.confidence ?? report.confidence_score),
+    // Silent-degradation is its own dimension on foundation-eval and
+    // load-bearing for whether the verdict should have been FAIL.
+    silent_degradation: report.silent_degradation_check
+      ? {
+          status: (report.silent_degradation_check.status || '').toUpperCase(),
+          evidence: normaliseFindingList(report.silent_degradation_check.evidence),
+        }
+      : null,
+  };
+  const canonical = JSON.stringify(canonicalise(payload));
+  return crypto.createHash('sha256').update(canonical).digest('hex');
+}
+
+/**
+ * Given a sequence of fingerprints (most recent first or last — either
+ * order works), return true iff the last N entries are identical.
+ * Used by the spin detector to decide "this verdict hasn't moved in N
+ * cycles; escalate."
+ */
+function hasIdenticalTail(fingerprints, n) {
+  if (!Array.isArray(fingerprints) || fingerprints.length < n) return false;
+  const tail = fingerprints.slice(-n);
+  const first = tail[0];
+  if (!first) return false;
+  return tail.every((f) => f === first);
+}
+
+module.exports = { fingerprintReport, hasIdenticalTail };

--- a/src/launcher/health-report.js
+++ b/src/launcher/health-report.js
@@ -1,0 +1,222 @@
+/**
+ * Cross-project health report.
+ *
+ * Aggregates the signals the self-heal + triage subsystem emits into
+ * a single view so the user can answer "is anything stuck?" without
+ * clicking into each project. Powers `rouge health` and (when we
+ * wire it) the dashboard's self-heal-activity page.
+ *
+ * Signals per project:
+ *   - current_state + budget usage
+ *   - phase fingerprint repeat counts (early-warning on semantic spin)
+ *   - pending / resolved escalations with their classifications
+ *   - pending self-heal branches / drafts
+ *
+ * Aggregates across all projects:
+ *   - escalation-category histogram
+ *   - self-heal attempt count + success rate
+ *   - fleet-wide budget totals (real vs estimated)
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const DEFAULT_PROJECTS_DIR = path.join(process.env.HOME || '/tmp', '.rouge', 'projects');
+
+function listProjects(projectsDir) {
+  const dir = projectsDir || DEFAULT_PROJECTS_DIR;
+  if (!fs.existsSync(dir)) return [];
+  return fs.readdirSync(dir, { withFileTypes: true })
+    .filter((e) => e.isDirectory() && !e.name.startsWith('.'))
+    .map((e) => e.name);
+}
+
+function readJson(p) {
+  try { return JSON.parse(fs.readFileSync(p, 'utf8')); } catch { return null; }
+}
+
+function readStateFor(projectsDir, name) {
+  const newLoc = path.join(projectsDir, name, '.rouge', 'state.json');
+  if (fs.existsSync(newLoc)) return readJson(newLoc);
+  const legacy = path.join(projectsDir, name, 'state.json');
+  if (fs.existsSync(legacy)) return readJson(legacy);
+  return null;
+}
+
+/**
+ * Per-phase fingerprint repeat counts. Gives the spin-detector's early-
+ * warning view: how close is each phase to tripping the 3-identical
+ * threshold?
+ */
+function fingerprintRepeats(projectsDir, name) {
+  const fpPath = path.join(projectsDir, name, 'phase-fingerprints.jsonl');
+  if (!fs.existsSync(fpPath)) return {};
+  let raw;
+  try { raw = fs.readFileSync(fpPath, 'utf8'); } catch { return {}; }
+  const entries = raw.trim().split('\n').filter(Boolean).map((l) => {
+    try { return JSON.parse(l); } catch { return null; }
+  }).filter(Boolean);
+  // Group tail per phase.
+  const byPhase = new Map();
+  for (const e of entries) {
+    if (!byPhase.has(e.phase)) byPhase.set(e.phase, []);
+    byPhase.get(e.phase).push(e);
+  }
+  const out = {};
+  for (const [phase, list] of byPhase) {
+    // Count trailing identical fingerprints.
+    if (list.length === 0) { out[phase] = { repeats: 0, last_verdict: null }; continue; }
+    const last = list[list.length - 1];
+    let repeats = 1;
+    for (let i = list.length - 2; i >= 0; i--) {
+      if (list[i].fingerprint && list[i].fingerprint === last.fingerprint) repeats++;
+      else break;
+    }
+    out[phase] = { repeats, last_verdict: last.verdict };
+  }
+  return out;
+}
+
+/**
+ * Count self-heal events by kind from the audit log. Returns
+ * { applied, drafted, refused, reverted, total }.
+ */
+function selfHealStats() {
+  const auditPath = path.join(process.env.HOME || '/tmp', '.rouge', 'audit-log.jsonl');
+  const stats = { applied: 0, drafted: 0, refused: 0, reverted: 0, total: 0 };
+  if (!fs.existsSync(auditPath)) return stats;
+  let raw;
+  try { raw = fs.readFileSync(auditPath, 'utf8'); } catch { return stats; }
+  for (const line of raw.split('\n')) {
+    if (!line.trim()) continue;
+    let e;
+    try { e = JSON.parse(line); } catch { continue; }
+    if (typeof e.kind !== 'string' || !e.kind.startsWith('self-heal-')) continue;
+    stats.total++;
+    if (e.kind === 'self-heal-applied') stats.applied++;
+    else if (e.kind === 'self-heal-draft') stats.drafted++;
+    else if (e.kind === 'self-heal-revert') stats.reverted++;
+    else if (e.kind === 'self-heal-skipped' || e.kind === 'self-heal-zone') {
+      if (e.zone === 'red') stats.refused++;
+    }
+  }
+  return stats;
+}
+
+function summariseEscalations(state) {
+  const byClass = {};
+  const pending = [];
+  for (const e of state?.escalations || []) {
+    const cls = e.classification || 'unclassified';
+    byClass[cls] = (byClass[cls] || 0) + 1;
+    if (e.status === 'pending') pending.push({ id: e.id, classification: cls, summary: e.summary });
+  }
+  return { byClass, pending, total: (state?.escalations || []).length };
+}
+
+/**
+ * Build a full health report. Pure function of filesystem state.
+ *
+ * @param {object} [opts] — { projectsDir: string, spinWarnThreshold: number }
+ * @returns {object}
+ */
+function buildReport(opts) {
+  const projectsDir = (opts && opts.projectsDir) || DEFAULT_PROJECTS_DIR;
+  const warnThreshold = (opts && opts.spinWarnThreshold) || 2;
+  const projects = listProjects(projectsDir);
+  const perProject = [];
+  const fleetClassHistogram = {};
+  let fleetRealSpend = 0;
+  let fleetEstimatedSpend = 0;
+  const stuckProjects = [];
+
+  for (const name of projects) {
+    const state = readStateFor(projectsDir, name);
+    if (!state) continue;
+    const fp = fingerprintRepeats(projectsDir, name);
+    const esc = summariseEscalations(state);
+    const cost = state.costs || {};
+    const real = cost.cumulative_cost_usd_real || 0;
+    const est = cost.cumulative_cost_usd_estimated || 0;
+    fleetRealSpend += real;
+    fleetEstimatedSpend += est;
+    for (const [k, v] of Object.entries(esc.byClass)) {
+      fleetClassHistogram[k] = (fleetClassHistogram[k] || 0) + v;
+    }
+    const earlyWarnings = Object.entries(fp)
+      .filter(([, v]) => v.repeats >= warnThreshold)
+      .map(([phase, v]) => ({ phase, ...v }));
+    if (earlyWarnings.length > 0) stuckProjects.push(name);
+    perProject.push({
+      name,
+      state: state.current_state,
+      budget_cap_usd: state.budget_cap_usd,
+      cumulative_cost_usd: cost.cumulative_cost_usd || 0,
+      cumulative_cost_usd_real: real,
+      cumulative_cost_usd_estimated: est,
+      escalations: esc,
+      fingerprint_repeats: fp,
+      early_warnings: earlyWarnings,
+    });
+  }
+
+  return {
+    generated_at: new Date().toISOString(),
+    projects_dir: projectsDir,
+    projects: perProject,
+    fleet: {
+      project_count: perProject.length,
+      stuck_project_count: stuckProjects.length,
+      stuck_projects: stuckProjects,
+      escalation_histogram: fleetClassHistogram,
+      cumulative_cost_usd_real: fleetRealSpend,
+      cumulative_cost_usd_estimated: fleetEstimatedSpend,
+      self_heal: selfHealStats(),
+    },
+  };
+}
+
+function formatReport(report) {
+  const lines = [];
+  lines.push('');
+  lines.push('  Rouge Health');
+  lines.push(`  ${'─'.repeat(40)}`);
+  lines.push(`  Projects scanned: ${report.fleet.project_count}`);
+  lines.push(`  Stuck projects (spin ≥ 2): ${report.fleet.stuck_project_count}${report.fleet.stuck_projects.length > 0 ? ' — ' + report.fleet.stuck_projects.join(', ') : ''}`);
+  lines.push(`  Fleet spend: $${report.fleet.cumulative_cost_usd_real.toFixed(2)} real / $${report.fleet.cumulative_cost_usd_estimated.toFixed(2)} estimated`);
+  const sh = report.fleet.self_heal;
+  lines.push(`  Self-heal lifetime: ${sh.applied} applied, ${sh.drafted} drafted, ${sh.refused} refused, ${sh.reverted} reverted`);
+  if (Object.keys(report.fleet.escalation_histogram).length > 0) {
+    lines.push('  Escalation histogram:');
+    const sorted = Object.entries(report.fleet.escalation_histogram).sort((a, b) => b[1] - a[1]);
+    for (const [cls, n] of sorted) lines.push(`     ${n.toString().padStart(4)} ${cls}`);
+  }
+  lines.push('');
+  lines.push('  Per project:');
+  lines.push(`  ${'─'.repeat(40)}`);
+  for (const p of report.projects) {
+    const cap = p.budget_cap_usd ? `/$${p.budget_cap_usd}` : '';
+    lines.push(`  ${p.name} — ${p.state} — $${p.cumulative_cost_usd_real.toFixed(2)} real${cap}`);
+    if (p.early_warnings.length > 0) {
+      for (const w of p.early_warnings) {
+        const icon = w.repeats >= 3 ? '\u{1F6A8}' : '\u26A0\uFE0F ';
+        lines.push(`    ${icon} ${w.phase}: ${w.repeats} identical cycle${w.repeats > 1 ? 's' : ''}${w.last_verdict ? ` (last verdict: ${w.last_verdict})` : ''}`);
+      }
+    }
+    if (p.escalations.pending.length > 0) {
+      lines.push(`    ${p.escalations.pending.length} pending escalation${p.escalations.pending.length > 1 ? 's' : ''}:`);
+      for (const e of p.escalations.pending) lines.push(`      - ${e.classification}: ${(e.summary || '').slice(0, 100)}`);
+    }
+  }
+  lines.push('');
+  return lines.join('\n');
+}
+
+module.exports = {
+  buildReport,
+  formatReport,
+  listProjects,
+  fingerprintRepeats,
+  summariseEscalations,
+  selfHealStats,
+};

--- a/src/launcher/integration-catalog.js
+++ b/src/launcher/integration-catalog.js
@@ -1,0 +1,328 @@
+/**
+ * Integration catalog reader.
+ *
+ * Single entry point for every consumer that needs structured knowledge
+ * about a deploy target (or database, auth, payment, etc.). Manifests
+ * live at `library/integrations/tier-2/<target>/manifest.json` and
+ * conform to `schemas/integration-manifest.json`.
+ *
+ * Consumers:
+ *   - `deploy-to-staging.js` — reads health_check, prerequisites,
+ *     auto_remediate for the selected target.
+ *   - `provision-infrastructure.js` — reads env_vars + secrets_required
+ *     to know what to merge into the spawn env from the secrets store.
+ *   - Phase prompts (via cycle_context injection) — read
+ *     `notes_for_prompt` and `build_output_dirs` to know target-specific
+ *     gotchas without Rouge hardcoding them into prompt text.
+ *
+ * Alias resolution: if `vision.json.infrastructure.deployment_target`
+ * is `gh-pages`, the catalog resolves it to the `github-pages` manifest
+ * via the aliases array. Lets us normalise on one canonical slug without
+ * breaking projects that declared an alternate name.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const ROOT = path.resolve(__dirname, '../..');
+const CATALOG_DIR = path.join(ROOT, 'library/integrations/tier-2');
+const SCHEMA_PATH = path.join(ROOT, 'schemas/integration-manifest.json');
+
+let cachedManifests = null;
+let cachedValidator = null;
+
+function validator() {
+  if (cachedValidator) return cachedValidator;
+  try {
+    // eslint-disable-next-line global-require
+    const Ajv = require('ajv');
+    const ajv = new Ajv({ allErrors: true, strict: false });
+    const schema = JSON.parse(fs.readFileSync(SCHEMA_PATH, 'utf8'));
+    cachedValidator = ajv.compile(schema);
+    return cachedValidator;
+  } catch {
+    // ajv unavailable — skip validation rather than crash the loader.
+    cachedValidator = () => true;
+    return cachedValidator;
+  }
+}
+
+function loadAll() {
+  if (cachedManifests) return cachedManifests;
+  const byTarget = new Map();
+  if (!fs.existsSync(CATALOG_DIR)) {
+    cachedManifests = byTarget;
+    return byTarget;
+  }
+  const validate = validator();
+  const entries = fs.readdirSync(CATALOG_DIR, { withFileTypes: true });
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const manifestPath = path.join(CATALOG_DIR, entry.name, 'manifest.json');
+    if (!fs.existsSync(manifestPath)) continue;
+    let manifest;
+    try {
+      manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+    } catch (err) {
+      console.warn(`[integration-catalog] skip ${entry.name}: parse error — ${err.message}`);
+      continue;
+    }
+    if (!validate(manifest)) {
+      console.warn(`[integration-catalog] skip ${entry.name}: schema violation`);
+      continue;
+    }
+    byTarget.set(manifest.target, manifest);
+    for (const alias of manifest.aliases || []) {
+      byTarget.set(alias, manifest);
+    }
+  }
+  cachedManifests = byTarget;
+  return byTarget;
+}
+
+/**
+ * Resolve a target slug to its manifest. Accepts canonical slugs and
+ * any alias declared in a manifest's `aliases` array.
+ *
+ * @param {string} target — e.g. 'github-pages' or 'gh-pages'.
+ * @returns {object|null} the manifest, or null if unknown.
+ */
+function getManifest(target) {
+  if (!target) return null;
+  return loadAll().get(target) || null;
+}
+
+/**
+ * Run a manifest prerequisite's `check` step and return the result.
+ *
+ * @param {object} check — the `check` object from the manifest.
+ * @param {object} ctx — resolution context: { projectDir, owner, repo, project, env }.
+ * @returns {{ ok: boolean, detail?: string }}
+ */
+function runCheck(check, ctx) {
+  if (!check || !check.kind) return { ok: false, detail: 'no check kind' };
+  try {
+    if (check.kind === 'shell') {
+      execSync(check.command, {
+        cwd: ctx.projectDir || process.cwd(),
+        stdio: 'pipe',
+        timeout: 10000,
+      });
+      return { ok: true };
+    }
+    if (check.kind === 'gh-api') {
+      const endpoint = resolveTemplate(check.endpoint, ctx);
+      execSync(`gh api ${endpoint}`, { stdio: 'pipe', timeout: 10000 });
+      return { ok: true };
+    }
+    if (check.kind === 'file-exists') {
+      const p = path.join(ctx.projectDir || '.', check.path);
+      return fs.existsSync(p) ? { ok: true } : { ok: false, detail: `not found: ${check.path}` };
+    }
+    if (check.kind === 'env-var-present') {
+      const present = !!(ctx.env && ctx.env[check.env_var]) || !!process.env[check.env_var];
+      return present ? { ok: true } : { ok: false, detail: `env var not set: ${check.env_var}` };
+    }
+    if (check.kind === 'secret-present') {
+      // Secrets store lookup — deferred to the caller who holds the
+      // secrets module. We return 'unknown' to signal "ask the
+      // secrets subsystem," rather than crashing the catalog reader
+      // with a circular require.
+      return { ok: false, detail: `check kind=secret-present requires caller resolution for ${check.secret_key}` };
+    }
+    return { ok: false, detail: `unknown check kind: ${check.kind}` };
+  } catch (err) {
+    return { ok: false, detail: (err.stderr || err.stdout || err.message || 'check failed').toString().slice(0, 200) };
+  }
+}
+
+/**
+ * Run every prerequisite check for a manifest. Returns the list of
+ * results in manifest order. Callers decide whether to auto-remediate
+ * failing prerequisites (per self-heal green-zone rules).
+ */
+function runPrerequisites(manifest, ctx) {
+  if (!manifest || !Array.isArray(manifest.prerequisites)) return [];
+  return manifest.prerequisites.map((p) => ({
+    id: p.id,
+    label: p.label,
+    has_auto_remediate: !!p.auto_remediate,
+    ...runCheck(p.check, ctx),
+  }));
+}
+
+function resolveTemplate(s, ctx) {
+  if (!s) return s;
+  return s.replace(/\{(\w+)\}/g, (m, k) => (ctx[k] != null ? String(ctx[k]) : m));
+}
+
+/**
+ * Render a manifest's health-check URL with the given context.
+ */
+function resolveHealthCheckUrl(manifest, ctx) {
+  if (!manifest || !manifest.health_check || !manifest.health_check.url_template) return null;
+  return resolveTemplate(manifest.health_check.url_template, ctx);
+}
+
+/**
+ * Run one prerequisite's `auto_remediate` step. Returns result shape
+ * matching `runCheck` — ok/false with an optional detail.
+ *
+ * Only invoked by callers after they've confirmed the failing
+ * prerequisite is in the self-heal green zone.
+ */
+function runAutoRemediate(prerequisite, ctx) {
+  const r = prerequisite && prerequisite.auto_remediate;
+  if (!r) return { ok: false, detail: 'no auto_remediate defined' };
+  try {
+    if (r.kind === 'shell') {
+      execSync(r.command, { cwd: ctx.projectDir || process.cwd(), stdio: 'pipe', timeout: 15000 });
+      return { ok: true };
+    }
+    if (r.kind === 'gh-api-post') {
+      const endpoint = resolveTemplate(r.endpoint, ctx);
+      const args = [`-X`, `POST`, endpoint];
+      for (const [k, v] of Object.entries(r.body || {})) {
+        if (v !== null && typeof v === 'object') {
+          for (const [ik, iv] of Object.entries(v)) {
+            args.push('-f', `${k}[${ik}]=${iv}`);
+          }
+        } else {
+          args.push('-f', `${k}=${v}`);
+        }
+      }
+      const cmd = `gh api ${args.map((a) => (a.includes('=') || a.includes('[') ? `'${a}'` : a)).join(' ')}`;
+      execSync(cmd, { stdio: 'pipe', timeout: 15000 });
+      return { ok: true };
+    }
+    return { ok: false, detail: `unknown remediation kind: ${r.kind}` };
+  } catch (err) {
+    return { ok: false, detail: (err.stderr || err.stdout || err.message || 'remediation failed').toString().slice(0, 200) };
+  }
+}
+
+/**
+ * Run all prerequisites; for any that fail AND define auto_remediate,
+ * attempt remediation (green-zone self-heal). Re-check afterwards.
+ *
+ * Returns `{ ok, remediated: [ids], failed: [{id, label, detail}] }`.
+ * ok=true iff every prerequisite is satisfied (directly or after
+ * remediation). The caller decides whether to proceed on partial
+ * success.
+ *
+ * @param {object} manifest
+ * @param {object} ctx — resolution context: { projectDir, owner, repo, project, env }.
+ * @param {object} [opts] — { allowRemediate: bool } (default true).
+ */
+function ensurePrerequisites(manifest, ctx, opts) {
+  const allow = !opts || opts.allowRemediate !== false;
+  const results = runPrerequisites(manifest, ctx);
+  const remediated = [];
+  const failed = [];
+  const prereqs = (manifest && manifest.prerequisites) || [];
+  results.forEach((res, i) => {
+    if (res.ok) return;
+    const prereq = prereqs[i];
+    if (allow && prereq && prereq.auto_remediate) {
+      const rem = runAutoRemediate(prereq, ctx);
+      if (rem.ok) {
+        const grace = (prereq.auto_remediate.grace_seconds || 0) * 1000;
+        if (grace > 0) {
+          try {
+            Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, grace);
+          } catch { /* environment without SharedArrayBuffer — no-op sleep */ }
+        }
+        // Re-check to confirm the remediation actually landed.
+        const recheck = runCheck(prereq.check, ctx);
+        if (recheck.ok) {
+          remediated.push(prereq.id);
+          return;
+        }
+        failed.push({ id: prereq.id, label: prereq.label, detail: `remediation ran but check still fails: ${recheck.detail}` });
+        return;
+      }
+      failed.push({ id: prereq.id, label: prereq.label, detail: `remediation failed: ${rem.detail}` });
+      return;
+    }
+    failed.push({ id: res.id, label: res.label, detail: res.detail });
+  });
+  return { ok: failed.length === 0, remediated, failed };
+}
+
+/**
+ * Probe the manifest's health_check URL with the appropriate grace
+ * window. On a freshly-remediated prerequisite (firstDeploy=true),
+ * uses first_deploy_grace_ms + first_deploy_poll_window_ms; otherwise
+ * does a single timeout_ms probe.
+ *
+ * Returns { ok, attempts, elapsedMs, status? }.
+ */
+function runHealthCheck(manifest, url, opts) {
+  const hc = manifest && manifest.health_check;
+  if (!hc || hc.kind === 'none') return { ok: true, attempts: 0, elapsedMs: 0 };
+  const start = Date.now();
+  const firstDeploy = !!(opts && opts.firstDeploy);
+  const timeoutMs = hc.timeout_ms || 10000;
+  const graceMs = firstDeploy ? (hc.first_deploy_grace_ms || 0) : 0;
+  const pollWindowMs = firstDeploy ? (hc.first_deploy_poll_window_ms || 0) : 0;
+  const intervalMs = hc.poll_interval_ms || 15000;
+
+  function probe() {
+    try {
+      const output = execSync(
+        `curl -s -o /dev/null -w "%{http_code}" --max-time ${Math.ceil(timeoutMs / 1000)} "${url}"`,
+        { encoding: 'utf8', timeout: timeoutMs + 2000 },
+      );
+      const status = parseInt(output.trim(), 10);
+      const passes = hc.kind === 'http-status-any-2xx'
+        ? status >= 200 && status < 300
+        : status >= 200 && status < 400;
+      return { status, passes };
+    } catch {
+      return { status: 0, passes: false };
+    }
+  }
+
+  if (graceMs > 0) {
+    try {
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, graceMs);
+    } catch { /* no-op sleep */ }
+  }
+
+  let attempts = 0;
+  let last = probe();
+  attempts++;
+  if (last.passes) return { ok: true, attempts, elapsedMs: Date.now() - start, status: last.status };
+  if (pollWindowMs <= 0) return { ok: false, attempts, elapsedMs: Date.now() - start, status: last.status };
+  while (Date.now() - start < pollWindowMs) {
+    try {
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, intervalMs);
+    } catch { /* no-op sleep */ }
+    last = probe();
+    attempts++;
+    if (last.passes) return { ok: true, attempts, elapsedMs: Date.now() - start, status: last.status };
+  }
+  return { ok: false, attempts, elapsedMs: Date.now() - start, status: last.status };
+}
+
+/**
+ * Testing hook — flush the in-memory cache so tests can reload with
+ * a fresh manifest directory. Not exposed for production use.
+ */
+function _resetCache() {
+  cachedManifests = null;
+  cachedValidator = null;
+}
+
+module.exports = {
+  getManifest,
+  runCheck,
+  runPrerequisites,
+  runAutoRemediate,
+  ensurePrerequisites,
+  runHealthCheck,
+  resolveTemplate,
+  resolveHealthCheckUrl,
+  _resetCache,
+};

--- a/src/launcher/provision-infrastructure.js
+++ b/src/launcher/provision-infrastructure.js
@@ -148,8 +148,20 @@ export default config;
 
 // --- Supabase setup ---
 
-function getSupabaseToken() {
-  // V1 (macOS): extract from keychain
+function getSupabaseToken(projectDir) {
+  // Preferred path: Rouge's own secrets store. If the user ran
+  // `rouge setup supabase`, the token is there under the 'supabase'
+  // service namespace. Check this first so we find tokens stored via
+  // Rouge's CLI rather than falling through to the Supabase CLI's
+  // own keychain (a pre-unification bug that stranded irish-planning
+  // on 2026-04-10 even though the secret was saved).
+  try {
+    const { getSecret } = require('./secrets.js');
+    const rouge = getSecret('supabase', 'SUPABASE_ACCESS_TOKEN');
+    if (rouge) return rouge;
+  } catch {}
+  // V1 (macOS): extract from the Supabase CLI's own keychain entry,
+  // shared when the user authenticated via `supabase login`.
   // Keychain stores: "go-keyring-base64:<base64-encoded-token>"
   // Strip prefix, base64 decode to get the actual token (sbp_...)
   try {
@@ -157,8 +169,49 @@ function getSupabaseToken() {
     const b64 = raw.replace('go-keyring-base64:', '');
     return Buffer.from(b64, 'base64').toString('utf8');
   } catch {}
-  // V2 (Linux/Docker): env var
+  // V2 (Linux/Docker): env var.
   return process.env.SUPABASE_ACCESS_TOKEN || null;
+}
+
+// Cloudflare API token lookup — symmetric with getSupabaseToken. Prior
+// to 2026-04-22 there was no helper; wrangler relied on the token
+// already being in process.env, so a token stored via `rouge setup
+// cloudflare` was unreachable. Now we merge from the secrets store.
+function getCloudflareToken(projectDir) {
+  try {
+    const { getSecret } = require('./secrets.js');
+    const rouge = getSecret('cloudflare', 'CLOUDFLARE_API_TOKEN');
+    if (rouge) return rouge;
+  } catch {}
+  return process.env.CLOUDFLARE_API_TOKEN || null;
+}
+
+function getCloudflareAccountId(projectDir) {
+  try {
+    const { getSecret } = require('./secrets.js');
+    const rouge = getSecret('cloudflare', 'CLOUDFLARE_ACCOUNT_ID');
+    if (rouge) return rouge;
+  } catch {}
+  return process.env.CLOUDFLARE_ACCOUNT_ID || null;
+}
+
+// Called at the top of main() so every provisioner (supabase,
+// cloudflare, sentry, stripe) sees the keychain-backed secrets as
+// ambient env vars. Equivalent of what rouge-loop.js does for phase
+// spawns, but for the direct provisioner path.
+function mergeSecretsIntoEnv(projectDir) {
+  try {
+    const { loadProjectSecrets } = require('./secrets.js');
+    const { env, loaded } = loadProjectSecrets(projectDir);
+    for (const [k, v] of Object.entries(env)) {
+      if (!process.env[k] && v) process.env[k] = v;
+    }
+    if (loaded.length > 0) {
+      log(`Loaded ${loaded.length} secret${loaded.length === 1 ? '' : 's'} from secrets store: ${loaded.join(', ')}`);
+    }
+  } catch (err) {
+    log(`Secrets store unavailable: ${(err.message || '').slice(0, 120)}`);
+  }
 }
 
 function supabaseApi(method, path, token) {
@@ -318,6 +371,15 @@ function main() {
   }
 
   const projectName = path.basename(projectDir);
+  // Unify keychain-backed secrets into process.env BEFORE any
+  // provisioner reads. Previously the provisioner's per-provider
+  // lookups bypassed the Rouge secrets store; tokens stored via
+  // `rouge setup <provider>` were unreachable (irish-planning was
+  // stuck here for 12 days). With this merge, every subsequent tool
+  // spawn (wrangler, supabase, sentry-cli, stripe) inherits the
+  // tokens automatically.
+  mergeSecretsIntoEnv(projectDir);
+
   const ctxFile = path.join(projectDir, 'cycle_context.json');
   const ctx = readJson(ctxFile);
   if (!ctx) {
@@ -456,6 +518,9 @@ module.exports = {
   provisionCloudflare,
   provisionSupabase,
   getSupabaseToken,
+  getCloudflareToken,
+  getCloudflareAccountId,
+  mergeSecretsIntoEnv,
   supabaseApi,
 };
 

--- a/src/launcher/rouge-cli.js
+++ b/src/launcher/rouge-cli.js
@@ -1159,6 +1159,21 @@ function cmdDoctor() {
 
 
 // ---------------------------------------------------------------------------
+// Health — cross-project loop-health report
+// ---------------------------------------------------------------------------
+
+function cmdHealth() {
+  const { buildReport, formatReport } = require('./health-report.js');
+  const report = buildReport();
+  if (process.argv.includes('--json')) {
+    console.log(JSON.stringify(report, null, 2));
+    return;
+  }
+  console.log(formatReport(report));
+}
+
+
+// ---------------------------------------------------------------------------
 // Feasibility assessment
 // ---------------------------------------------------------------------------
 
@@ -1260,6 +1275,8 @@ if (command === 'doctor') {
   });
 } else if (command === 'cost') {
   cmdCost(args[1]);
+} else if (command === 'health') {
+  cmdHealth();
 } else if (command === 'setup') {
   cmdSetup(args[1]).catch((err) => {
     console.error(err.message);
@@ -1721,6 +1738,7 @@ if (command === 'doctor') {
   ADVANCED / AUTOMATION
     rouge status <name>             Show state for a single project
     rouge cost <name> [--actual]    Show cost estimate or actuals
+    rouge health [--json]           Cross-project loop-health report (stuck loops, escalations, self-heal)
     rouge secrets list              List stored secret names
     rouge secrets check <dir>       Check project against stored secrets
     rouge secrets validate <target> Validate keys against API endpoints

--- a/src/launcher/rouge-loop.js
+++ b/src/launcher/rouge-loop.js
@@ -25,6 +25,7 @@ const { loadProjectSecrets } = require('./secrets.js');
 const { writeCheckpoint, readLatestCheckpoint, readAllCheckpoints } = require('./checkpoint.js');
 const { checkMilestoneLock, promoteMilestone, shouldEscalateForSpin, getCompletedStoryNames, isStoryDuplicate } = require('./safety.js');
 const { trackPhaseCost, trackPhaseCostFromLog, checkBudgetCap } = require('./cost-tracker.js');
+const { recordAndCheck: recordEvalFingerprint } = require('./spin-detector.js');
 const { deployWithRetry, shouldBlockMilestoneCheck } = require('./deploy-blocking.js');
 const { migrateV2StateToV3 } = require('./state-migration.js');
 const { injectPreamble } = require('./preamble-injector.js');
@@ -732,6 +733,40 @@ async function advanceState(projectDir) {
       const verdict = ctx?.foundation_eval_report?.verdict || 'PASS';
 
       if (verdict !== 'PASS') {
+        // Record + check for semantic spin. Three identical
+        // foundation_eval_reports in a row means the foundation phase
+        // can't move the needle on what the evaluator is flagging —
+        // this is the stack-rank pattern (94× loop on a schema enum
+        // drift the foundation phase couldn't fix). Escalate rather
+        // than continue the retry spiral.
+        const { isSpin, recent } = recordEvalFingerprint(
+          projectDir,
+          'foundation-eval',
+          ctx?.foundation_eval_report,
+          { meta: { cycle_number: state.cycle_number || 0 } },
+        );
+        if (isSpin) {
+          if (!state.escalations) state.escalations = [];
+          state.escalations.push({
+            id: `esc-semantic-spin-foundation-${Date.now()}`,
+            tier: 1,
+            classification: 'semantic-spin',
+            phase: 'foundation-eval',
+            summary:
+              `Foundation-eval has returned identical findings ${recent.length} times in a row. ` +
+              `Verdict: ${verdict}. The foundation phase cannot fix what the evaluator is flagging — ` +
+              `a human needs to inspect. Findings repeat exactly; Wave-3 triage will route this to ` +
+              `self-heal when Rouge-side bugs are identifiable, or escalate when not.`,
+            story_id: null,
+            status: 'pending',
+            created_at: new Date().toISOString(),
+            recent_fingerprints: recent.map((e) => ({ ts: e.ts, verdict: e.verdict })),
+          });
+          writeJson(stateFile, state);
+          next = 'escalation';
+          log(`[${projectName}] Foundation-eval semantic spin (${recent.length} identical cycles) — escalating`);
+          break;
+        }
         next = 'foundation';
         log(`[${projectName}] Foundation eval FAIL — retrying`);
         break;
@@ -1192,6 +1227,39 @@ async function advanceState(projectDir) {
         poVerdict === 'NOT_READY' || poVerdict === 'NEEDS_IMPROVEMENT';
 
       if (lensFail) {
+        // Record + check for semantic spin. Testimonial ran
+        // milestone-check/milestone-fix 87× in a row with identical
+        // PO NEEDS_IMPROVEMENT findings; milestone-fix couldn't move
+        // the score. Escalate the loop instead of continuing to burn
+        // budget on a verdict that isn't going to change.
+        const { isSpin, recent } = recordEvalFingerprint(
+          projectDir,
+          'milestone-check',
+          ctx?.evaluation_report,
+          { meta: { cycle_number: state.cycle_number || 0 } },
+        );
+        if (isSpin) {
+          if (!state.escalations) state.escalations = [];
+          state.escalations.push({
+            id: `esc-semantic-spin-milestone-${Date.now()}`,
+            tier: 1,
+            classification: 'semantic-spin',
+            phase: 'milestone-check',
+            summary:
+              `Milestone-check has returned identical findings ${recent.length} times in a row ` +
+              `(qa=${qaVerdict}, design=${designVerdict}, po=${poVerdict}). milestone-fix cannot ` +
+              `move the score. This is either a 1-bit taste call (accept/reject at this quality) ` +
+              `or a miscalibrated evaluator — a human needs to break the tie.`,
+            story_id: null,
+            status: 'pending',
+            created_at: new Date().toISOString(),
+            recent_fingerprints: recent.map((e) => ({ ts: e.ts, verdict: e.verdict })),
+          });
+          writeJson(stateFile, state);
+          next = 'escalation';
+          log(`[${projectName}] Milestone-check semantic spin (${recent.length} identical cycles) — escalating`);
+          break;
+        }
         next = 'milestone-fix';
         log(`[${projectName}] Milestone evaluation FAIL (qa=${qaVerdict}, design=${designVerdict}, po=${poVerdict}) — fixing`);
       } else {

--- a/src/launcher/rouge-loop.js
+++ b/src/launcher/rouge-loop.js
@@ -885,13 +885,40 @@ async function advanceState(projectDir) {
       } catch (err) {
         log(`[${projectName}] Provisioning failed: ${(err.message || '').slice(0, 200)}`);
         log(`[${projectName}] Escalating — can't build without infrastructure`);
+        // Dynamic escalation message — name only the providers the
+        // project actually targets, not a generic "Check both" string.
+        // irish-planning's hard-coded "Check CLOUDFLARE_API_TOKEN,
+        // SUPABASE_ACCESS_TOKEN" message was misleading because the
+        // project targeted vercel — it didn't need a CF token at all.
+        const deployTarget = infra?.deployment_target || state.deployment_target;
+        const needsDb = !!infra?.needs_database;
+        const missingHints = [];
+        if (deployTarget) {
+          const { getManifest } = require('./integration-catalog.js');
+          const m = getManifest(deployTarget);
+          if (m && Array.isArray(m.secrets_required)) {
+            for (const sec of m.secrets_required) {
+              if (sec.optional) continue;
+              missingHints.push(`${sec.key} (for ${deployTarget})`);
+            }
+          }
+        }
+        if (needsDb) {
+          // Supabase is the only database provider currently supported;
+          // if that expands, read from a database-kind manifest.
+          missingHints.push('SUPABASE_ACCESS_TOKEN (for database)');
+        }
+        const reason = (err.message || '').slice(0, 150);
+        const summary = missingHints.length > 0
+          ? `Infrastructure provisioning for ${deployTarget || 'this project'} failed: ${reason}. Verify: ${missingHints.join(', ')}. Store via \`rouge setup <provider>\` if missing.`
+          : `Infrastructure provisioning failed: ${reason}`;
         next = 'escalation';
         if (!state.escalations) state.escalations = [];
         state.escalations.push({
-          id: 'esc-provisioning-failed',
+          id: `esc-provisioning-failed-${Date.now()}`,
           tier: 1,
           classification: 'infrastructure-gap',
-          summary: 'Cloud infrastructure provisioning failed. Check CLOUDFLARE_API_TOKEN, SUPABASE_ACCESS_TOKEN env vars.',
+          summary,
           story_id: null,
           status: 'pending',
           created_at: new Date().toISOString(),

--- a/src/launcher/rouge-loop.js
+++ b/src/launcher/rouge-loop.js
@@ -26,6 +26,29 @@ const { writeCheckpoint, readLatestCheckpoint, readAllCheckpoints } = require('.
 const { checkMilestoneLock, promoteMilestone, shouldEscalateForSpin, getCompletedStoryNames, isStoryDuplicate } = require('./safety.js');
 const { trackPhaseCost, trackPhaseCostFromLog, checkBudgetCap } = require('./cost-tracker.js');
 const { recordAndCheck: recordEvalFingerprint } = require('./spin-detector.js');
+const { classify: triageClassify, CLASSES: TRIAGE_CLASSES } = require('./triage.js');
+const { planFix: selfHealPlan } = require('./self-heal-planner.js');
+const { applyPlan: selfHealApply } = require('./self-heal-applier.js');
+
+// When a stuck-loop signal fires, run triage → self-heal. Returns
+// either the self-heal result (for note-writing) or null if the caller
+// should fall through to the normal escalation path.
+function attemptSelfHeal(projectDir, phase, escalation) {
+  try {
+    const triage = triageClassify({ projectDir, phase, escalation });
+    if (triage.class !== TRIAGE_CLASSES.SELF_HEAL_CANDIDATE) {
+      return { triage, attempted: false };
+    }
+    const planResult = selfHealPlan(triage);
+    if (!planResult.ok) {
+      return { triage, attempted: false, plan_reason: planResult.reason };
+    }
+    const applyResult = selfHealApply(planResult.plan);
+    return { triage, attempted: true, plan: planResult.plan, result: applyResult };
+  } catch (err) {
+    return { triage: null, attempted: false, error: (err.message || '').slice(0, 200) };
+  }
+}
 const { deployWithRetry, shouldBlockMilestoneCheck } = require('./deploy-blocking.js');
 const { migrateV2StateToV3 } = require('./state-migration.js');
 const { injectPreamble } = require('./preamble-injector.js');
@@ -746,25 +769,45 @@ async function advanceState(projectDir) {
           { meta: { cycle_number: state.cycle_number || 0 } },
         );
         if (isSpin) {
+          // Before escalating, attempt triage + self-heal. If triage
+          // classifies this as a Rouge-side bug (schema drift,
+          // identical foundation-eval) and the planner can produce a
+          // bounded fix, the applier runs it on a self-heal branch.
+          // Green-zone fixes auto-apply; yellow-zone get drafted for
+          // review; red-zone refused. Either way, the project's own
+          // loop continues past this point with the findings noted.
+          const healResult = attemptSelfHeal(projectDir, 'foundation-eval', {
+            id: `esc-semantic-spin-foundation-${Date.now()}`,
+            classification: 'semantic-spin',
+            phase: 'foundation-eval',
+            summary: `Foundation-eval identical ${recent.length}x, verdict=${verdict}`,
+          });
           if (!state.escalations) state.escalations = [];
-          state.escalations.push({
+          const esc = {
             id: `esc-semantic-spin-foundation-${Date.now()}`,
             tier: 1,
             classification: 'semantic-spin',
             phase: 'foundation-eval',
             summary:
               `Foundation-eval has returned identical findings ${recent.length} times in a row. ` +
-              `Verdict: ${verdict}. The foundation phase cannot fix what the evaluator is flagging — ` +
-              `a human needs to inspect. Findings repeat exactly; Wave-3 triage will route this to ` +
-              `self-heal when Rouge-side bugs are identifiable, or escalate when not.`,
+              `Verdict: ${verdict}. ` +
+              (healResult.attempted
+                ? (healResult.result && healResult.result.applied
+                    ? `Self-heal auto-applied fix on branch ${healResult.result.branch} — review and merge when ready.`
+                    : healResult.result && healResult.result.draft_path
+                      ? `Self-heal produced a draft plan at ${path.relative(ROUGE_ROOT, healResult.result.draft_path)} (yellow-zone, needs review).`
+                      : `Self-heal attempted but could not apply: ${healResult.result ? healResult.result.reason : 'unknown'}.`)
+                : `Self-heal did not run (${healResult.plan_reason || healResult.triage?.reason || healResult.error || 'no candidate'}).`),
             story_id: null,
             status: 'pending',
             created_at: new Date().toISOString(),
             recent_fingerprints: recent.map((e) => ({ ts: e.ts, verdict: e.verdict })),
-          });
+            self_heal: healResult,
+          };
+          state.escalations.push(esc);
           writeJson(stateFile, state);
           next = 'escalation';
-          log(`[${projectName}] Foundation-eval semantic spin (${recent.length} identical cycles) — escalating`);
+          log(`[${projectName}] Foundation-eval semantic spin (${recent.length} identical cycles) — escalating (self-heal: ${healResult.attempted ? (healResult.result && healResult.result.applied ? 'applied' : 'drafted') : 'n/a'})`);
           break;
         }
         next = 'foundation';

--- a/src/launcher/rouge-loop.js
+++ b/src/launcher/rouge-loop.js
@@ -200,21 +200,39 @@ function readJson(filePath) {
 }
 
 function writeJson(filePath, data) {
-  // Schema validation (warn-only). Matches filenames to the schemas
-  // that live in the repo's `schemas/` dir. Failures don't block the
-  // write — we prefer a bad shape on disk over a loop that refuses
-  // to progress because validation found a nitpick.
+  // Schema validation. state.json writes are strict — a drift here
+  // causes phase-loop pathologies (see stack-rank's 94-cycle foundation
+  // -eval spiral on `status='evaluating'` absent from the enum). Better
+  // to halt the loop on the offending write than let it compound across
+  // every future iteration.
+  //
+  // cycle_context.json and task_ledger.json stay warn-only for now —
+  // they have historical drift we haven't finished auditing, and a
+  // halted cycle-context write strands the whole project. Those will
+  // be promoted to strict once the schemas are fully reconciled.
   try {
-    const { validate } = require('./schema-validator.js');
+    const { validate, SchemaViolationError } = require('./schema-validator.js');
     const base = path.basename(filePath);
     if (base === 'state.json') {
-      validate('state.json', data, `write ${filePath}`);
+      try {
+        validate('state.json', data, `write ${filePath}`, { strict: true });
+      } catch (err) {
+        if (err instanceof SchemaViolationError) {
+          // Re-throw so the caller halts rather than persisting the
+          // bad shape. The stack trace identifies the assignment site.
+          throw err;
+        }
+        throw err;
+      }
     } else if (base === 'cycle_context.json') {
       validate('cycle-context-v3.json', data, `write ${filePath}`);
     } else if (base === 'task_ledger.json') {
       validate('task-ledger-v3.json', data, `write ${filePath}`);
     }
-  } catch {
+  } catch (err) {
+    // Only swallow the "validator unavailable" case. A schema violation
+    // must propagate so the write doesn't happen.
+    if (err && err.name === 'SchemaViolationError') throw err;
     /* validator unavailable — skip silently */
   }
   const tmp = filePath + '.tmp';

--- a/src/launcher/rouge-loop.js
+++ b/src/launcher/rouge-loop.js
@@ -683,13 +683,23 @@ async function advanceState(projectDir) {
   const flat = flatStories(state);
   let next = null;
 
-  // V3: Write checkpoint before state transition
-  // Include story_results (derived from flat stories) for dedup detection
+  // V3: Checkpoint payload prepared here but written conditionally
+  // below, only when the tick actually produces a state transition.
+  //
+  // Previously this was unconditional at the top of advanceState.
+  // That produced checkpoint proliferation: testimonial's 500 escalation
+  // checkpoints were 500 no-op outer-loop ticks, each writing an
+  // identical snapshot because no state advanced. Inflated
+  // checkpoints.jsonl size, inflated the dashboard's phase-histogram,
+  // and (because `phase_cost_usd` carries the last-real-phase cost
+  // forward in state.costs) made phantom spend look like real spend
+  // when any consumer summed phase_cost_usd across checkpoints.
+  // Include story_results (derived from flat stories) for dedup detection.
   const storyResults = flat
     .filter(s => s.status === 'done' || s.status === 'blocked')
     .map(s => ({ name: s.name || s.id, outcome: s.status === 'done' ? 'pass' : 'blocked' }));
 
-  writeCheckpoint(checkpointsFile, {
+  const pendingCheckpoint = {
     phase: current,
     state: {
       current_milestone: state.current_milestone,
@@ -700,7 +710,7 @@ async function advanceState(projectDir) {
       story_results: storyResults,
     },
     costs: state.costs || {},
-  });
+  };
 
   switch (current) {
 
@@ -1687,6 +1697,11 @@ async function advanceState(projectDir) {
   }
 
   if (next) {
+    // Write the pre-transition checkpoint only now that we know a
+    // transition is actually happening. No-op ticks (escalation with
+    // no feedback, terminal states, etc.) skip the write.
+    writeCheckpoint(checkpointsFile, pendingCheckpoint);
+
     log(`[${projectName}] ${current} → ${next}`);
 
     // Self-heal: if a case block set next='escalation' without pushing

--- a/src/launcher/schema-validator.js
+++ b/src/launcher/schema-validator.js
@@ -1,11 +1,23 @@
 /**
- * Shared schema validator (warn-only).
+ * Shared schema validator.
  *
- * ajv + the JSON Schemas in `schemas/` catch shape violations that
- * silent-swallow catches in readers couldn't. The violation surfaces
- * as a warn log (with file path + first error) so the operator has a
- * trail — but the read/write still proceeds so a bad shape on disk
- * can't take the whole loop down.
+ * Two modes:
+ *
+ * - Warn (default) — violation logs + returns `{valid: false, errors}`,
+ *   caller decides. Used by reads where a bad shape on disk shouldn't
+ *   block forward progress.
+ *
+ * - Strict — violation throws a `SchemaViolationError`. Used by writes
+ *   where letting the bad shape land would corrupt state for later
+ *   readers. Callers opt in via `{strict: true}` or the env var
+ *   `ROUGE_STRICT_SCHEMA=1`.
+ *
+ * Rationale: stack-rank looped foundation-eval 94× because a write of
+ * `foundation.status='evaluating'` (not in the schema enum) was logged
+ * as a warn and proceeded, and no downstream reader could distinguish
+ * "schema-violating state" from "normal state." Strict-mode writes
+ * surface the drift immediately at the site of introduction, which is
+ * where the stack trace is useful.
  *
  * Scope: used from launcher paths that read/write state.json,
  * cycle_context.json, task_ledger.json, and checkpoint entries.
@@ -56,23 +68,42 @@ function loadValidator(schemaName) {
   }
 }
 
+class SchemaViolationError extends Error {
+  constructor(schemaName, context, errors) {
+    super(`[schema:${schemaName}] ${context}: ${errors[0] || 'unknown violation'}`);
+    this.name = 'SchemaViolationError';
+    this.schemaName = schemaName;
+    this.context = context;
+    this.errors = errors;
+  }
+}
+
 /**
- * Validate a JSON value against a schema file. Warn-only.
+ * Validate a JSON value against a schema file.
  *
  * @param {string} schemaName — filename inside `schemas/` (e.g. 'state.json').
  * @param {unknown} data — value to validate.
  * @param {string} context — for log tag ('state.json write', 'cycle_context read', etc).
+ * @param {{ strict?: boolean }} [opts] — strict mode throws on violation.
+ *   Env var `ROUGE_STRICT_SCHEMA=1` promotes all calls to strict.
  * @returns {{ valid: boolean, errors: string[] }}
+ * @throws {SchemaViolationError} when strict mode is on and validation fails.
  */
-function validate(schemaName, data, context) {
+function validate(schemaName, data, context, opts) {
   const v = loadValidator(schemaName);
   if (!v) return { valid: true, errors: [] };
   const ok = v(data);
   if (ok) return { valid: true, errors: [] };
   const errors = (v.errors || []).map((e) => `${e.instancePath || '<root>'} ${e.message}`);
+  const strict = (opts && opts.strict) || process.env.ROUGE_STRICT_SCHEMA === '1';
+  if (strict) {
+    // No warn log — the thrown error carries the same payload and the
+    // caller's stack is more useful than a stray warn line.
+    throw new SchemaViolationError(schemaName, context, errors);
+  }
   const first = errors[0] || 'unknown violation';
   console.warn(`[schema:${schemaName}] ${context}: ${first}`);
   return { valid: false, errors };
 }
 
-module.exports = { validate };
+module.exports = { validate, SchemaViolationError };

--- a/src/launcher/self-heal-applier.js
+++ b/src/launcher/self-heal-applier.js
@@ -1,0 +1,243 @@
+/**
+ * Self-heal applier.
+ *
+ * Takes a plan (from self-heal-planner) and executes it within the
+ * zone enforcer's rules. Runs on a dedicated `rouge-self-heal/...`
+ * branch so the human can always reach the previous state with a
+ * single `git checkout main`.
+ *
+ * Flow:
+ *   1. classifyPlan(plan) — enforce green/yellow/red.
+ *      - green: apply, run tests, commit. Keep branch if tests pass;
+ *        revert and surface if they fail.
+ *      - yellow: DON'T apply — create a plan file in
+ *        `.rouge/self-heal-drafts/<ts>.json` for human review.
+ *      - red: refuse outright. Log and return.
+ *   2. Ensure clean working tree. Refuse to apply over uncommitted
+ *      user work — the revert path depends on a clean baseline.
+ *   3. Create branch, apply patches, run `npm test`, commit + return
+ *      branch name (or revert + return failure).
+ *   4. Every action is recorded to `~/.rouge/audit-log.jsonl` via
+ *      audit-trail.js for traceability.
+ *
+ * Kill switch: src/launcher/self-heal-applier.js#loadConfig reads
+ * rouge.config.json's `self_heal` block. Default is
+ * `{ enabled: true, zones: ['green'] }`. User can set enabled=false
+ * to disable the whole subsystem, or zones=[] to keep classification
+ * active but never apply anything (dry-run mode).
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const ROOT = path.resolve(__dirname, '../..');
+const CONFIG_PATH = path.join(ROOT, 'rouge.config.json');
+const AUDIT_LOG = path.join(process.env.HOME || '/tmp', '.rouge', 'audit-log.jsonl');
+
+const { classifyPlan } = require('./self-heal-zones.js');
+
+function loadConfig() {
+  try {
+    const cfg = JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
+    const sh = cfg.self_heal || {};
+    return {
+      enabled: sh.enabled !== false, // default true
+      zones: Array.isArray(sh.zones) ? sh.zones : ['green'],
+    };
+  } catch {
+    return { enabled: true, zones: ['green'] };
+  }
+}
+
+function audit(entry) {
+  try {
+    fs.mkdirSync(path.dirname(AUDIT_LOG), { recursive: true });
+    fs.appendFileSync(AUDIT_LOG, JSON.stringify({ ts: new Date().toISOString(), ...entry }) + '\n', { mode: 0o600 });
+  } catch {
+    // Audit log is advisory — never block the applier on write failure.
+  }
+}
+
+function runGit(cmd, opts) {
+  return execSync(`git ${cmd}`, { cwd: ROOT, encoding: 'utf8', stdio: 'pipe', ...opts }).trim();
+}
+
+function workingTreeClean() {
+  try {
+    return runGit('status --porcelain') === '';
+  } catch {
+    return false;
+  }
+}
+
+function currentBranch() {
+  try {
+    return runGit('rev-parse --abbrev-ref HEAD');
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Execute a patch against its target file. Returns the new file
+ * contents (or throws if the patch kind is unsupported).
+ */
+function applyPatchToContent(targetPath, patch) {
+  if (patch.kind === 'json-enum-append') {
+    const full = path.join(ROOT, targetPath);
+    const raw = fs.readFileSync(full, 'utf8');
+    const json = JSON.parse(raw);
+    // Navigate to the enum location and mutate.
+    const segments = patch.instance_path.split('/').filter(Boolean);
+    let node = json;
+    for (const seg of segments) {
+      if (node.properties && node.properties[seg]) {
+        node = node.properties[seg];
+      } else {
+        throw new Error(`path ${patch.instance_path} not found in ${targetPath}`);
+      }
+    }
+    if (!Array.isArray(node.enum)) {
+      throw new Error(`no enum at ${patch.instance_path} in ${targetPath}`);
+    }
+    if (node.enum.includes(patch.new_value)) {
+      // Already present — idempotent no-op.
+      return raw;
+    }
+    node.enum = patch.new_enum;
+    return JSON.stringify(json, null, 2) + '\n';
+  }
+  throw new Error(`unsupported patch kind: ${patch.kind}`);
+}
+
+function writeDraft(plan, reason) {
+  const dir = path.join(ROOT, '.rouge', 'self-heal-drafts');
+  fs.mkdirSync(dir, { recursive: true });
+  const fname = `${new Date().toISOString().replace(/[:.]/g, '-')}.json`;
+  const out = path.join(dir, fname);
+  fs.writeFileSync(out, JSON.stringify({ plan, reason, created_at: new Date().toISOString() }, null, 2));
+  return out;
+}
+
+/**
+ * Apply a plan. Returns a result object describing what happened.
+ * This function is the main entry point. Keep the surface area small
+ * and the contract explicit.
+ */
+function applyPlan(plan, opts) {
+  const cfg = loadConfig();
+  const dryRun = !!(opts && opts.dryRun);
+
+  if (!cfg.enabled) {
+    audit({ kind: 'self-heal-skipped', reason: 'disabled-in-config', plan_kind: plan && plan.kind });
+    return { applied: false, reason: 'self-heal disabled via rouge.config.json', zone: null };
+  }
+
+  const zoneResult = classifyPlan(plan);
+  audit({ kind: 'self-heal-zone', zone: zoneResult.zone, reason: zoneResult.reason, plan_kind: plan && plan.kind });
+
+  if (zoneResult.zone === 'red') {
+    return { applied: false, reason: `red-zone plan refused: ${zoneResult.reason}`, zone: 'red' };
+  }
+
+  if (zoneResult.zone === 'yellow') {
+    const draftPath = writeDraft(plan, zoneResult.reason);
+    audit({ kind: 'self-heal-draft', zone: 'yellow', draft_path: draftPath, plan_kind: plan.kind });
+    return {
+      applied: false,
+      reason: 'yellow-zone plan written to draft for human review',
+      zone: 'yellow',
+      draft_path: draftPath,
+    };
+  }
+
+  // Green zone — check config-level zones allowlist.
+  if (!cfg.zones.includes('green')) {
+    audit({ kind: 'self-heal-skipped', reason: 'green-not-enabled-in-config', plan_kind: plan.kind });
+    return { applied: false, reason: 'green zone not enabled in rouge.config.json self_heal.zones', zone: 'green' };
+  }
+
+  if (dryRun) {
+    return { applied: false, reason: 'dry-run', zone: 'green', plan };
+  }
+
+  // Baseline checks.
+  if (!workingTreeClean()) {
+    audit({ kind: 'self-heal-skipped', reason: 'dirty-working-tree', plan_kind: plan.kind });
+    return { applied: false, reason: 'working tree has uncommitted changes — refusing to self-heal on top of user work', zone: 'green' };
+  }
+  const startBranch = currentBranch();
+  if (!startBranch) {
+    return { applied: false, reason: 'could not determine current git branch', zone: 'green' };
+  }
+
+  // Create a dedicated self-heal branch. Use a short slug so branch
+  // names stay readable in git log.
+  const slug = (plan.kind || 'plan').replace(/[^a-z0-9-]+/gi, '-').toLowerCase();
+  const ts = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+  const branchName = `rouge-self-heal/${ts}-${slug}`;
+  try {
+    runGit(`checkout -b ${branchName}`);
+  } catch (err) {
+    return { applied: false, reason: `branch creation failed: ${(err.message || '').slice(0, 200)}`, zone: 'green' };
+  }
+
+  // Apply every patch in the plan.
+  try {
+    for (const f of plan.files) {
+      const newContent = applyPatchToContent(f.path, f.patch);
+      fs.writeFileSync(path.join(ROOT, f.path), newContent);
+    }
+  } catch (err) {
+    // Revert and exit.
+    runGit(`checkout ${startBranch}`, { stdio: 'pipe' });
+    runGit(`branch -D ${branchName}`, { stdio: 'pipe' });
+    audit({ kind: 'self-heal-revert', reason: `patch failed: ${err.message}`, branch: branchName });
+    return { applied: false, reason: `patch application failed: ${(err.message || '').slice(0, 200)}`, zone: 'green' };
+  }
+
+  // Stage and commit the change before running tests so that if the
+  // tests themselves make transient filesystem writes they don't
+  // contaminate the plan's diff.
+  try {
+    runGit('add -A');
+    runGit(`commit -m "rouge self-heal: ${plan.description || plan.kind}"`);
+  } catch (err) {
+    runGit(`checkout ${startBranch}`, { stdio: 'pipe' });
+    runGit(`branch -D ${branchName}`, { stdio: 'pipe' });
+    return { applied: false, reason: `commit failed: ${(err.message || '').slice(0, 200)}`, zone: 'green' };
+  }
+
+  // Run tests.
+  let testsOk = false;
+  let testOutput = '';
+  try {
+    testOutput = execSync('npm test', {
+      cwd: ROOT,
+      encoding: 'utf8',
+      env: { ...process.env, ROUGE_SKIP_CLI_TESTS: '1' },
+      timeout: 300000,
+      stdio: 'pipe',
+    });
+    testsOk = true;
+  } catch (err) {
+    testsOk = false;
+    testOutput = ((err.stdout || '') + '\n' + (err.stderr || '')).slice(-2000);
+  }
+
+  if (!testsOk) {
+    // Revert: checkout back to starting branch and delete the self-heal branch.
+    runGit(`checkout ${startBranch}`, { stdio: 'pipe' });
+    runGit(`branch -D ${branchName}`, { stdio: 'pipe' });
+    audit({ kind: 'self-heal-revert', reason: 'tests-failed', branch: branchName, plan_kind: plan.kind, test_tail: testOutput.slice(-500) });
+    return { applied: false, reason: 'self-heal reverted: tests failed after apply', zone: 'green', test_tail: testOutput.slice(-500) };
+  }
+
+  // Success: leave the branch in place for the user to merge.
+  runGit(`checkout ${startBranch}`, { stdio: 'pipe' });
+  audit({ kind: 'self-heal-applied', branch: branchName, plan_kind: plan.kind, description: plan.description });
+  return { applied: true, zone: 'green', branch: branchName, description: plan.description };
+}
+
+module.exports = { applyPlan, loadConfig, applyPatchToContent };

--- a/src/launcher/self-heal-planner.js
+++ b/src/launcher/self-heal-planner.js
@@ -1,0 +1,204 @@
+/**
+ * Self-heal planner.
+ *
+ * Given triage evidence, produces a fix plan the applier can execute.
+ * Plans are bounded, single-purpose, deterministic — no LLM calls.
+ *
+ * Plan shape:
+ *   {
+ *     kind: string,        // e.g. 'add-enum-value'
+ *     description: string, // human-readable one-liner
+ *     files: [
+ *       {
+ *         path: string,        // repo-relative
+ *         added_lines: number, // approximate
+ *         removed_lines: number,
+ *         patch: { kind, ...args } // how to apply
+ *       }
+ *     ],
+ *     rationale: string,
+ *     evidence: object, // forwarded from triage
+ *   }
+ *
+ * Current fix kinds:
+ *
+ *   add-enum-value — a literal-string assignment in src/launcher/*.js
+ *     writes a value not in the target schema's enum. The evidence
+ *     from triage (schema, instance_path) points at the schema; the
+ *     planner finds the offending assignment in source, reads the
+ *     literal value, and proposes adding it to the enum. This is the
+ *     stack-rank fix pattern.
+ *
+ * Return value:
+ *   - { ok: true, plan } — when a concrete plan was built
+ *   - { ok: false, reason } — when the evidence doesn't match any
+ *     plan kind; the applier falls through and the original
+ *     escalation stays pending for human review.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const acorn = require('acorn');
+
+const ROOT = path.resolve(__dirname, '../..');
+
+/**
+ * Walk src/launcher/*.js, find literal-string assignments whose
+ * member-expression suffix matches `instancePath` (e.g.
+ * '/foundation/status' → suffix 'foundation.status'). Returns the
+ * first non-conforming assignment found as { file, line, value,
+ * suffix } or null.
+ */
+function findOffendingAssignment(instancePath, allowedValues) {
+  const suffix = instancePath.replace(/^\//, '').replace(/\//g, '.');
+  const launcherDir = path.join(ROOT, 'src/launcher');
+  const files = fs.readdirSync(launcherDir).filter((f) => f.endsWith('.js'));
+  for (const f of files) {
+    const filePath = path.join(launcherDir, f);
+    const src = fs.readFileSync(filePath, 'utf8');
+    let ast;
+    try {
+      ast = acorn.parse(src, { ecmaVersion: 'latest', sourceType: 'script', locations: true });
+    } catch {
+      continue;
+    }
+    const hit = findInAst(ast, suffix, allowedValues);
+    if (hit) return { file: path.relative(ROOT, filePath), ...hit };
+  }
+  return null;
+}
+
+function findInAst(ast, suffix, allowedValues) {
+  let found = null;
+  function walk(node) {
+    if (found || !node || typeof node !== 'object') return;
+    if (node.type === 'AssignmentExpression' && node.operator === '=' && node.left && node.left.type === 'MemberExpression') {
+      const nodeSuffix = memberSuffix(node.left);
+      if (nodeSuffix && (nodeSuffix === suffix || nodeSuffix.endsWith('.' + suffix))) {
+        if (node.right && node.right.type === 'Literal' && typeof node.right.value === 'string') {
+          if (!allowedValues.includes(node.right.value)) {
+            found = {
+              line: node.loc.start.line,
+              value: node.right.value,
+              suffix: nodeSuffix,
+            };
+            return;
+          }
+        }
+      }
+    }
+    for (const key of Object.keys(node)) {
+      if (key === 'loc' || key === 'start' || key === 'end') continue;
+      const child = node[key];
+      if (Array.isArray(child)) { for (const c of child) walk(c); }
+      else if (child && typeof child === 'object') walk(child);
+    }
+  }
+  walk(ast);
+  return found;
+}
+
+function memberSuffix(node) {
+  const parts = [];
+  let n = node;
+  while (n && n.type === 'MemberExpression') {
+    if (n.computed) return null;
+    if (n.property.type !== 'Identifier') return null;
+    parts.unshift(n.property.name);
+    n = n.object;
+  }
+  if (!n || n.type !== 'Identifier') return null;
+  return parts.join('.');
+}
+
+/**
+ * Navigate schema to locate the enum at a given instance path.
+ * `/foundation/status` → schema.properties.foundation.properties.status.enum
+ */
+function enumAtPath(schema, instancePath) {
+  const segments = instancePath.split('/').filter(Boolean);
+  let node = schema;
+  for (const seg of segments) {
+    if (!node) return null;
+    if (node.properties && node.properties[seg]) {
+      node = node.properties[seg];
+    } else if (node.items && node.items.properties && node.items.properties[seg]) {
+      node = node.items.properties[seg];
+    } else {
+      return null;
+    }
+  }
+  return node && Array.isArray(node.enum) ? node.enum : null;
+}
+
+/**
+ * Plan an add-enum-value fix from triage schema-enum-drift evidence.
+ * Conservative: only proposes a plan if we can positively identify
+ * the offending assignment in the launcher source AND the schema
+ * has an existing enum at that path.
+ */
+function planAddEnumValue(evidence) {
+  const schemaPath = path.join(ROOT, 'schemas', evidence.schema);
+  if (!fs.existsSync(schemaPath)) {
+    return { ok: false, reason: `schema file not found: schemas/${evidence.schema}` };
+  }
+  let schema;
+  try {
+    schema = JSON.parse(fs.readFileSync(schemaPath, 'utf8'));
+  } catch (err) {
+    return { ok: false, reason: `schema parse failed: ${err.message}` };
+  }
+  const existingEnum = enumAtPath(schema, evidence.instance_path);
+  if (!existingEnum) {
+    return { ok: false, reason: `no enum at ${evidence.instance_path} in schemas/${evidence.schema}` };
+  }
+  const offender = findOffendingAssignment(evidence.instance_path, existingEnum);
+  if (!offender) {
+    return { ok: false, reason: `no literal assignment found in src/launcher/*.js that violates ${evidence.instance_path} enum` };
+  }
+  const newEnum = [...existingEnum, offender.value];
+  return {
+    ok: true,
+    plan: {
+      kind: 'add-enum-value',
+      description: `Add '${offender.value}' to ${evidence.instance_path} enum in schemas/${evidence.schema}`,
+      files: [
+        {
+          path: `schemas/${evidence.schema}`,
+          added_lines: 0,
+          removed_lines: 0,
+          patch: {
+            kind: 'json-enum-append',
+            instance_path: evidence.instance_path,
+            new_value: offender.value,
+            new_enum: newEnum,
+          },
+        },
+      ],
+      rationale:
+        `${offender.file}:${offender.line} writes '${offender.value}' to ${offender.suffix}, which is not in ` +
+        `the schema enum [${existingEnum.join(', ')}]. Every write triggers a schema warning and the state ` +
+        `persists anyway — but this is the stack-rank failure mode (94 identical foundation-eval cycles). ` +
+        `Adding '${offender.value}' to the enum both matches the launcher's intent and prevents the warn ` +
+        `from continuing to fire. Schema edit is yellow-zone; the applier will route this to a draft PR.`,
+      evidence,
+    },
+  };
+}
+
+/**
+ * Build a fix plan from triage evidence, or return { ok: false }
+ * if the triage kind doesn't match any known planner.
+ */
+function planFix(triage) {
+  if (!triage || !triage.evidence) {
+    return { ok: false, reason: 'no triage evidence' };
+  }
+  const kind = triage.evidence.kind;
+  if (kind === 'schema-enum-drift') {
+    return planAddEnumValue(triage.evidence);
+  }
+  return { ok: false, reason: `no planner for evidence kind: ${kind}` };
+}
+
+module.exports = { planFix, planAddEnumValue, findOffendingAssignment, enumAtPath };

--- a/src/launcher/self-heal-zones.js
+++ b/src/launcher/self-heal-zones.js
@@ -1,0 +1,158 @@
+/**
+ * Self-heal zone enforcer.
+ *
+ * Classifies a proposed fix plan into green / yellow / red and
+ * determines whether the applier is permitted to execute it.
+ *
+ * Contract (see docs/plans/2026-04-22-self-heal-and-triage.md):
+ *
+ *   Green — auto-apply permitted (test-gated, git-revertable):
+ *     - file paths matching src/launcher/*.js (non-safety modules)
+ *     - additive schema extensions (new enum values)
+ *     - single-file change ≤ MAX_GREEN_LINES
+ *
+ *   Yellow — draft PR only, never auto-apply:
+ *     - anything in src/prompts/**
+ *     - schema contract changes (shape, removals, required fields)
+ *     - new launcher modules or refactors > MAX_GREEN_LINES
+ *
+ *   Red — never self-heal, always human:
+ *     - safety.js, deploy-blocking.js, self-improve-safety.js,
+ *       audit-trail.js (safety mechanism logic)
+ *     - phase-prompt content
+ *     - agentic actions outside the Rouge repo (account signups, etc.)
+ *
+ * The enforcer is deliberately conservative. When in doubt, yellow
+ * or red — never green. The guardrail is the single most important
+ * property of the self-heal subsystem; getting it wrong means
+ * Rouge can edit its own safety mechanisms or deploy agentic
+ * side-effects the user didn't sanction.
+ */
+
+const path = require('path');
+
+const MAX_GREEN_LINES = 30;
+
+// Files that are always red — self-heal can NEVER modify these.
+const RED_FILES = new Set([
+  'src/launcher/safety.js',
+  'src/launcher/deploy-blocking.js',
+  'src/launcher/self-improve-safety.js',
+  'src/launcher/self-heal-zones.js', // the zone enforcer cannot self-heal itself
+  'src/launcher/audit-trail.js',
+  'src/launcher/rouge-safety-check.sh',
+  'rouge.config.json',
+]);
+
+// Path prefixes (directories) that are always red.
+const RED_PREFIXES = [
+  'src/prompts/',
+  '.github/workflows/', // CI is safety-adjacent — human review required
+];
+
+// Path prefixes that are yellow (draft-PR, not auto-apply).
+const YELLOW_PREFIXES = [
+  'schemas/',              // contract-level changes need review
+  'library/integrations/', // catalog entries affect future products
+  'library/global/',
+  'library/domain/',
+  'library/templates/',
+  'dashboard/',            // dashboard changes need UX review
+];
+
+function normalisePath(repoRelative) {
+  // Strip leading ./ and any accidental leading /
+  return String(repoRelative || '').replace(/^\.\//, '').replace(/^\/+/, '');
+}
+
+/**
+ * Classify a fix plan into a zone.
+ *
+ * @param {object} plan — { kind, files: [{ path, added_lines, removed_lines }] }
+ *   where path is repo-relative.
+ * @returns {{ zone: 'green'|'yellow'|'red', reason: string, files: string[] }}
+ */
+function classifyPlan(plan) {
+  if (!plan || !Array.isArray(plan.files) || plan.files.length === 0) {
+    return { zone: 'red', reason: 'empty plan has no files — refuse', files: [] };
+  }
+  const paths = plan.files.map((f) => normalisePath(f.path));
+
+  // Red: any file in the red set or under a red prefix blocks the
+  // whole plan. A plan that touches one red file is red.
+  const redHits = paths.filter(
+    (p) => RED_FILES.has(p) || RED_PREFIXES.some((prefix) => p.startsWith(prefix)),
+  );
+  if (redHits.length > 0) {
+    return {
+      zone: 'red',
+      reason: `red-zone files present: ${redHits.join(', ')}`,
+      files: paths,
+    };
+  }
+
+  // Yellow: any file under a yellow prefix forces yellow (draft-PR).
+  const yellowHits = paths.filter(
+    (p) => YELLOW_PREFIXES.some((prefix) => p.startsWith(prefix)),
+  );
+  if (yellowHits.length > 0) {
+    return {
+      zone: 'yellow',
+      reason: `touches review-required paths: ${yellowHits.join(', ')}`,
+      files: paths,
+    };
+  }
+
+  // Multi-file plans are yellow by default — we don't have tests for
+  // multi-file green applies yet, and a larger change deserves review.
+  if (paths.length > 1) {
+    return {
+      zone: 'yellow',
+      reason: `multi-file plan (${paths.length} files) — needs review`,
+      files: paths,
+    };
+  }
+
+  // Single-file plan. Check size.
+  const file = plan.files[0];
+  const totalLines = (file.added_lines || 0) + (file.removed_lines || 0);
+  if (totalLines > MAX_GREEN_LINES) {
+    return {
+      zone: 'yellow',
+      reason: `change size ${totalLines} lines > green cap ${MAX_GREEN_LINES}`,
+      files: paths,
+    };
+  }
+
+  // Single-file in src/launcher/*.js and small enough → green.
+  const onlyFile = paths[0];
+  if (!onlyFile.startsWith('src/launcher/') || !onlyFile.endsWith('.js')) {
+    return {
+      zone: 'yellow',
+      reason: `green zone is src/launcher/*.js only; got ${onlyFile}`,
+      files: paths,
+    };
+  }
+
+  return {
+    zone: 'green',
+    reason: `single-file, ${totalLines} lines, in src/launcher/ and not a safety module`,
+    files: paths,
+  };
+}
+
+/**
+ * True iff the plan is permitted for auto-apply.
+ */
+function canAutoApply(plan) {
+  return classifyPlan(plan).zone === 'green';
+}
+
+module.exports = {
+  classifyPlan,
+  canAutoApply,
+  MAX_GREEN_LINES,
+  RED_FILES,
+  RED_PREFIXES,
+  YELLOW_PREFIXES,
+};

--- a/src/launcher/spin-detector.js
+++ b/src/launcher/spin-detector.js
@@ -1,0 +1,131 @@
+/**
+ * Semantic-spin detection.
+ *
+ * Records a fingerprint of each evaluator report into
+ * `<projectDir>/phase-fingerprints.jsonl` and detects when the last N
+ * fingerprints for a phase are identical — the pattern that caused
+ * stack-rank's 94-cycle foundation-eval spiral and testimonial's 87×
+ * milestone-check/fix loop.
+ *
+ * Consumed by:
+ *   - rouge-loop.js after foundation-eval / milestone-check produce
+ *     their reports — passes the report through `recordAndCheck` and
+ *     acts on the returned `isSpin` flag.
+ *   - Wave-3 triage classifier, which reads the recent fingerprint
+ *     history to decide whether a stuck loop is a self-heal candidate
+ *     (identical findings → Rouge-code issue), a human-judgment case
+ *     (drifting findings → real taste call), or something else.
+ *
+ * Why a dedicated JSONL rather than reusing checkpoints.jsonl:
+ * checkpoints snapshot state, not cycle_context. The findings live in
+ * cycle_context and are overwritten each phase, so we'd lose them
+ * after the first write. The fingerprint file is append-only history.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { fingerprintReport, hasIdenticalTail } = require('./findings-fingerprint.js');
+
+const FILE_NAME = 'phase-fingerprints.jsonl';
+const DEFAULT_SPIN_THRESHOLD = 3;
+
+function filePath(projectDir) {
+  return path.join(projectDir, FILE_NAME);
+}
+
+/**
+ * Append a fingerprint record for a phase.
+ *
+ * @param {string} projectDir
+ * @param {string} phase — phase name (e.g. 'foundation-eval', 'milestone-check').
+ * @param {object|null} report — the evaluator report object from cycle_context.
+ * @param {object} [meta] — extra fields stored with the entry for later triage
+ *   (verdict, confidence, finding counts — anything non-sensitive that helps
+ *   a human skim the history).
+ * @returns {string} the fingerprint (empty string if the report was null).
+ */
+function recordFingerprint(projectDir, phase, report, meta) {
+  const fp = fingerprintReport(report);
+  const entry = {
+    phase,
+    ts: new Date().toISOString(),
+    fingerprint: fp,
+    verdict: (report && report.verdict) ? String(report.verdict).toUpperCase() : null,
+    ...(meta || {}),
+  };
+  try {
+    fs.appendFileSync(filePath(projectDir), JSON.stringify(entry) + '\n');
+  } catch {
+    // Non-fatal — fingerprint history is advisory. If we can't write it,
+    // the spin detector degrades to "never detects," which is strictly
+    // safer than crashing the phase.
+  }
+  return fp;
+}
+
+/**
+ * Read the fingerprint file and return the last N entries for a phase.
+ */
+function readRecent(projectDir, phase, n) {
+  const p = filePath(projectDir);
+  if (!fs.existsSync(p)) return [];
+  try {
+    const raw = fs.readFileSync(p, 'utf8');
+    const lines = raw.trim().split('\n').filter(Boolean);
+    const forPhase = [];
+    // Walk from the end backwards to bound the read; cheaper than
+    // parsing the whole file when history is long.
+    for (let i = lines.length - 1; i >= 0 && forPhase.length < n; i--) {
+      try {
+        const entry = JSON.parse(lines[i]);
+        if (entry.phase === phase) forPhase.unshift(entry);
+      } catch {
+        // skip malformed lines
+      }
+    }
+    return forPhase;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * True if the last N fingerprints for this phase are identical
+ * (and non-empty — an empty fingerprint is our sentinel for "no
+ * report," which shouldn't count as spin).
+ */
+function detectSpin(projectDir, phase, threshold) {
+  const n = threshold || DEFAULT_SPIN_THRESHOLD;
+  const recent = readRecent(projectDir, phase, n);
+  if (recent.length < n) return false;
+  const fps = recent.map((e) => e.fingerprint);
+  return hasIdenticalTail(fps, n);
+}
+
+/**
+ * One-shot: append the fingerprint AND return whether this was the
+ * N-th identical tail. Returned object includes:
+ *
+ * - `fingerprint` — the hash that was just recorded
+ * - `isSpin` — true iff the last N entries for this phase are identical
+ * - `recent` — the last N entries (including the one just written),
+ *   useful for synthesising the escalation message with the phase's
+ *   verdict and findings.
+ */
+function recordAndCheck(projectDir, phase, report, opts) {
+  const meta = (opts && opts.meta) || {};
+  const threshold = (opts && opts.threshold) || DEFAULT_SPIN_THRESHOLD;
+  const fingerprint = recordFingerprint(projectDir, phase, report, meta);
+  const recent = readRecent(projectDir, phase, threshold);
+  const fps = recent.map((e) => e.fingerprint);
+  const isSpin = hasIdenticalTail(fps, threshold);
+  return { fingerprint, isSpin, recent };
+}
+
+module.exports = {
+  recordFingerprint,
+  readRecent,
+  detectSpin,
+  recordAndCheck,
+  DEFAULT_SPIN_THRESHOLD,
+};

--- a/src/launcher/triage.js
+++ b/src/launcher/triage.js
@@ -1,0 +1,180 @@
+/**
+ * Triage classifier.
+ *
+ * Given a stuck-loop signal (semantic spin, repeated failure, missing
+ * prerequisite, etc.), decide which layer of the system owns the
+ * problem and route accordingly:
+ *
+ *   - `self-heal-candidate` — Rouge's own code has a bug the applier
+ *     can fix within green-zone bounds. Route to self-heal.
+ *
+ *   - `mechanical-automation-missing` — a pattern that would be
+ *     automated if a catalog entry existed (auto_remediate on a
+ *     prerequisite, a new health-check shape, etc.). Route to a
+ *     draft-PR flow that adds the manifest entry.
+ *
+ *   - `human-judgment-needed` — genuine 1-bit product-taste or
+ *     direction call (testimonial's PO NEEDS_IMPROVEMENT loop).
+ *     Route to the standard escalation UX.
+ *
+ *   - `unknown` — couldn't classify. Conservative default: escalate
+ *     with full context so a human can decide.
+ *
+ * Inputs are the signals we already have on disk:
+ *   - spin-detector fingerprint history (per phase)
+ *   - recent checkpoints (phase + state + costs)
+ *   - state.json escalations array
+ *   - build.log snippet (for schema-violation detection)
+ *
+ * No LLM calls. Pure rule-based classification. The rules are deliberate:
+ * we want this to be auditable and testable. When a class of signal
+ * becomes common enough that rules can't capture it, revisit.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const CLASSES = Object.freeze({
+  SELF_HEAL_CANDIDATE: 'self-heal-candidate',
+  MECHANICAL_AUTOMATION_MISSING: 'mechanical-automation-missing',
+  HUMAN_JUDGMENT_NEEDED: 'human-judgment-needed',
+  UNKNOWN: 'unknown',
+});
+
+/**
+ * Inspect the project's build.log for evidence that Rouge's own code
+ * drifted from its own schema. The signature is a repeated warn line
+ * from the schema validator:
+ *
+ *   [schema:state.json] write /path: /foundation/status must be equal to one of the allowed values
+ *
+ * This is load-bearing: it's exactly the stack-rank failure mode.
+ * Returns the parsed hint if detected, null otherwise.
+ */
+function detectSchemaViolation(projectDir) {
+  const logPath = path.join(projectDir, 'build.log');
+  if (!fs.existsSync(logPath)) return null;
+  let recent;
+  try {
+    const raw = fs.readFileSync(logPath, 'utf8');
+    recent = raw.slice(-20000); // last 20KB
+  } catch {
+    return null;
+  }
+  // Example: [schema:state.json] write /Users/.../state.json: /foundation/status must be equal to one of the allowed values
+  const re = /\[schema:([\w.-]+)\][^\n]*?\s([/\w.-]+)\s+must be equal to one of the allowed values/g;
+  const matches = [];
+  let m;
+  while ((m = re.exec(recent)) !== null) {
+    matches.push({ schema: m[1], instancePath: m[2] });
+  }
+  if (matches.length < 3) return null; // need repeated drift, not one-off
+  // Use the most recent match as canonical.
+  const last = matches[matches.length - 1];
+  return {
+    schema: last.schema,
+    instance_path: last.instancePath,
+    occurrences: matches.length,
+  };
+}
+
+/**
+ * Inspect fingerprint history for a phase. Returns { identical, count,
+ * verdict, drift } where drift=true means findings keep changing but
+ * the phase still isn't converging (testimonial shape).
+ */
+function inspectFingerprintHistory(projectDir, phase, n) {
+  const { readRecent } = require('./spin-detector.js');
+  const recent = readRecent(projectDir, phase, Math.max(n, 5));
+  if (recent.length === 0) return { identical: false, count: 0, drift: false };
+  const fps = recent.map((e) => e.fingerprint).filter(Boolean);
+  const lastN = fps.slice(-n);
+  const identical = lastN.length === n && lastN.every((f) => f === lastN[0]);
+  const uniqueCount = new Set(fps).size;
+  const drift = !identical && fps.length >= 3 && uniqueCount >= 3;
+  const verdict = recent.length > 0 ? recent[recent.length - 1].verdict : null;
+  return { identical, count: fps.length, drift, verdict };
+}
+
+/**
+ * Classify a stuck-loop signal.
+ *
+ * @param {object} signal — { projectDir, phase, escalation }. The
+ *   escalation object (if any) is the one that just fired; phase is
+ *   the phase that produced it.
+ * @returns {{ class: string, reason: string, evidence: object }}
+ */
+function classify(signal) {
+  const { projectDir, phase, escalation } = signal;
+  if (!projectDir) return { class: CLASSES.UNKNOWN, reason: 'no projectDir', evidence: {} };
+
+  // 1. Schema violation in Rouge's own code → self-heal candidate.
+  //    This is the stack-rank shape: the evaluator keeps failing
+  //    because the launcher keeps writing a value the schema doesn't
+  //    allow. Applier can propose adding the enum value.
+  const schema = detectSchemaViolation(projectDir);
+  if (schema) {
+    return {
+      class: CLASSES.SELF_HEAL_CANDIDATE,
+      reason: `Schema violation in Rouge's own code: ${schema.instance_path} fails the ${schema.schema} enum check (${schema.occurrences} repeats in build.log).`,
+      evidence: { kind: 'schema-enum-drift', ...schema },
+    };
+  }
+
+  // 2. Identical evaluator findings across N cycles.
+  //    - If the phase is foundation-eval → likely Rouge-side (foundation
+  //      can't move the needle because the evaluator is flagging a
+  //      launcher-observable issue). Default to self-heal-candidate
+  //      with caveat — Wave 4's classifier learnings will refine this.
+  //    - If the phase is milestone-check / po-review → human judgment.
+  //      The product hit a calibration wall that evaluator + fixer
+  //      together can't resolve.
+  if (phase) {
+    const fp = inspectFingerprintHistory(projectDir, phase, 3);
+    if (fp.identical) {
+      if (phase === 'foundation-eval') {
+        return {
+          class: CLASSES.SELF_HEAL_CANDIDATE,
+          reason: `Foundation-eval returned identical findings ${fp.count} times. Likely a Rouge-side precondition (schema, wiring) the foundation phase can't fix. Self-heal planner will inspect.`,
+          evidence: { kind: 'identical-foundation-eval', fingerprint_count: fp.count, verdict: fp.verdict },
+        };
+      }
+      if (phase === 'milestone-check' || phase === 'po-review') {
+        return {
+          class: CLASSES.HUMAN_JUDGMENT_NEEDED,
+          reason: `${phase} returned identical findings ${fp.count} times with verdict ${fp.verdict}. Evaluator and fixer can't converge — this is a 1-bit taste call (ship as-is or demand a specific fix).`,
+          evidence: { kind: 'identical-po-verdict', fingerprint_count: fp.count, verdict: fp.verdict },
+        };
+      }
+      // Unknown phase with spin — conservative escalate.
+      return {
+        class: CLASSES.UNKNOWN,
+        reason: `Phase ${phase} is in semantic spin but classifier has no rule for it. Escalating for human review.`,
+        evidence: { kind: 'identical-other', phase, fingerprint_count: fp.count, verdict: fp.verdict },
+      };
+    }
+  }
+
+  // 3. Missing prerequisite on a deploy target → mechanical-automation-missing.
+  //    Signal: escalation.classification === 'infrastructure-gap' with
+  //    a deploy_target we have a manifest for. If the manifest declares
+  //    an auto_remediate for the failing prerequisite, self-heal should
+  //    have already handled it; that it didn't means the manifest is
+  //    missing a remediation entry. Route to draft-PR adding one.
+  if (escalation && escalation.classification === 'infrastructure-gap') {
+    return {
+      class: CLASSES.MECHANICAL_AUTOMATION_MISSING,
+      reason: 'Infrastructure gap escalation. If the deploy target has a manifest but no auto_remediate for the failing prerequisite, that is the missing automation. Draft-PR flow adds it.',
+      evidence: { kind: 'missing-remediation', escalation_id: escalation.id },
+    };
+  }
+
+  // 4. Default conservative bucket.
+  return {
+    class: CLASSES.UNKNOWN,
+    reason: 'No classifier rule matched. Escalating to human for review.',
+    evidence: { kind: 'unclassified', phase, escalation_id: escalation ? escalation.id : null },
+  };
+}
+
+module.exports = { classify, CLASSES, detectSchemaViolation };

--- a/tests/cost-tracker.test.js
+++ b/tests/cost-tracker.test.js
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+/**
+ * Tests for src/launcher/cost-tracker.js
+ *
+ * Covers the real/estimated split added 2026-04-22 so heuristic-
+ * fallback estimates can't trip the budget cap. Stack-rank reached
+ * an inflated "budget cap" through heuristic escalation checkpoints;
+ * separating the two streams ensures the cap only fires on real spend.
+ *
+ * Usage: node tests/cost-tracker.test.js
+ */
+
+const os = require('os');
+const fs = require('fs');
+const path = require('path');
+const {
+  trackPhaseCost,
+  trackPhaseCostFromLog,
+  checkBudgetCap,
+  isOverBudget,
+} = require('../src/launcher/cost-tracker.js');
+
+let failures = 0;
+let checks = 0;
+
+function assert(condition, message) {
+  checks++;
+  if (!condition) {
+    failures++;
+    console.error(`  ✗ ${message}`);
+  }
+}
+
+function writeTempLog(content) {
+  const p = path.join(os.tmpdir(), 'cost-test-' + Date.now() + '-' + Math.random().toString(36).slice(2) + '.log');
+  fs.writeFileSync(p, content);
+  return p;
+}
+
+function testTrackPhaseCostIsEstimated() {
+  const state = {};
+  trackPhaseCost(state, 100000, 'opus');
+  assert(state.costs.phase_cost_source === 'estimated', 'trackPhaseCost labels as estimated');
+  assert(state.costs.cumulative_cost_usd_estimated > 0, 'estimated cumulative accrues');
+  assert(state.costs.cumulative_cost_usd_real === 0, 'real cumulative stays at 0');
+  assert(state.costs.cumulative_cost_usd === state.costs.cumulative_cost_usd_estimated, 'total = estimated');
+}
+
+function testParsedCostIsRealNotEstimated() {
+  const state = {};
+  const log = writeTempLog('blah blah\nTotal cost: $1.50\ndone\n');
+  trackPhaseCostFromLog(state, log, 10000, 'opus');
+  fs.unlinkSync(log);
+  assert(state.costs.phase_cost_source === 'parsed', 'parsed from log → source=parsed');
+  assert(state.costs.cumulative_cost_usd_real === 1.50, 'real cumulative = 1.50');
+  assert(state.costs.cumulative_cost_usd_estimated === 0, 'estimated stays 0');
+  assert(state.costs.cumulative_cost_usd === 1.50, 'total = real in this case');
+}
+
+function testParsedTokensIsRealAtPricedRate() {
+  const state = {};
+  const log = writeTempLog('input_tokens: 1000000\noutput_tokens: 1000000\n');
+  trackPhaseCostFromLog(state, log, 10000, 'opus');
+  fs.unlinkSync(log);
+  assert(state.costs.phase_cost_source === 'parsed-tokens', 'tokens-only parse → parsed-tokens');
+  // 1M input * 15 + 1M output * 75 = 90
+  assert(state.costs.cumulative_cost_usd_real === 90, 'real cumulative prices parsed tokens');
+  assert(state.costs.cumulative_cost_usd_estimated === 0, 'estimated stays 0');
+}
+
+function testHeuristicFallbackIsEstimated() {
+  const state = {};
+  const log = writeTempLog('nothing parseable here\n');
+  trackPhaseCostFromLog(state, log, 100000, 'opus');
+  fs.unlinkSync(log);
+  assert(state.costs.phase_cost_source === 'heuristic', 'unparseable log → heuristic');
+  assert(state.costs.cumulative_cost_usd_estimated > 0, 'estimated cumulative accrues');
+  assert(state.costs.cumulative_cost_usd_real === 0, 'real stays 0 on heuristic');
+}
+
+function testCapEnforcesOnRealNotEstimated() {
+  // The pathological case: lots of heuristic "cost" but no real LLM spend.
+  // Cap at $10, heuristic = $500 (testimonial shape), real = $2.
+  const state = { costs: { cumulative_cost_usd: 502, cumulative_cost_usd_real: 2, cumulative_cost_usd_estimated: 500 } };
+  assert(checkBudgetCap(state, 10) === false, 'cap not tripped by phantom heuristic spend');
+  assert(isOverBudget(state, 10) === false, 'isOverBudget = false (real < cap)');
+}
+
+function testCapEnforcesWhenRealExceeds() {
+  const state = { costs: { cumulative_cost_usd: 95, cumulative_cost_usd_real: 95, cumulative_cost_usd_estimated: 0 } };
+  assert(checkBudgetCap(state, 100) === true, 'cap trips within safety margin on real spend');
+  assert(isOverBudget(state, 90) === true, 'isOverBudget at 95 > cap 90');
+}
+
+function testLegacyStateFallsBackToTotal() {
+  // Pre-split state.json has no _real / _estimated fields.
+  const state = { costs: { cumulative_cost_usd: 95 } };
+  assert(checkBudgetCap(state, 100) === true, 'legacy: falls back to total');
+}
+
+function testMultiplePhasesAccumulate() {
+  const state = {};
+  const log1 = writeTempLog('Total cost: $2.00\n');
+  const log2 = writeTempLog('Total cost: $3.50\n');
+  const logH = writeTempLog('no parseable content\n');
+  trackPhaseCostFromLog(state, log1, 10000, 'opus');
+  trackPhaseCostFromLog(state, log2, 10000, 'opus');
+  trackPhaseCostFromLog(state, logH, 50000, 'opus');
+  fs.unlinkSync(log1); fs.unlinkSync(log2); fs.unlinkSync(logH);
+  assert(state.costs.cumulative_cost_usd_real === 5.5, 'real sums two parsed phases');
+  assert(state.costs.cumulative_cost_usd_estimated > 0, 'estimated from heuristic phase');
+  assert(
+    Math.abs(state.costs.cumulative_cost_usd - (state.costs.cumulative_cost_usd_real + state.costs.cumulative_cost_usd_estimated)) < 0.0001,
+    'total = real + estimated (floating tolerance)',
+  );
+}
+
+function main() {
+  console.log('cost-tracker real/estimated split');
+  testTrackPhaseCostIsEstimated();
+  testParsedCostIsRealNotEstimated();
+  testParsedTokensIsRealAtPricedRate();
+  testHeuristicFallbackIsEstimated();
+  testCapEnforcesOnRealNotEstimated();
+  testCapEnforcesWhenRealExceeds();
+  testLegacyStateFallsBackToTotal();
+  testMultiplePhasesAccumulate();
+  console.log(`  ${checks} checks, ${failures} failures`);
+  if (failures > 0) {
+    console.error('FAIL');
+    process.exit(1);
+  }
+  console.log('PASS');
+}
+
+main();

--- a/tests/findings-fingerprint.test.js
+++ b/tests/findings-fingerprint.test.js
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+/**
+ * Tests for src/launcher/findings-fingerprint.js
+ *
+ * Covers the "same finding → same hash" invariant that Wave-2's
+ * semantic-spin detector relies on to decide when to stop retrying.
+ *
+ * Usage: node tests/findings-fingerprint.test.js
+ */
+
+const { fingerprintReport, hasIdenticalTail } = require('../src/launcher/findings-fingerprint.js');
+
+let failures = 0;
+let checks = 0;
+
+function assert(condition, message) {
+  checks++;
+  if (!condition) {
+    failures++;
+    console.error(`  ✗ ${message}`);
+  }
+}
+
+function testNullReturnsEmpty() {
+  assert(fingerprintReport(null) === '', 'null report → empty fingerprint');
+  assert(fingerprintReport(undefined) === '', 'undefined report → empty fingerprint');
+}
+
+function testIdenticalReportsSameHash() {
+  const a = { verdict: 'FAIL', structural_gaps: ['schema missing user.email', 'no migrations/002'] };
+  const b = { verdict: 'FAIL', structural_gaps: ['no migrations/002', 'schema missing user.email'] };
+  assert(fingerprintReport(a) === fingerprintReport(b), 'finding order doesn\'t affect hash');
+}
+
+function testKeyOrderStable() {
+  const a = { verdict: 'FAIL', dimensions: { schema: { status: 'FAIL' }, auth: { status: 'PASS' } } };
+  const b = { verdict: 'FAIL', dimensions: { auth: { status: 'PASS' }, schema: { status: 'FAIL' } } };
+  assert(fingerprintReport(a) === fingerprintReport(b), 'key order doesn\'t affect hash');
+}
+
+function testVerdictCaseInsensitive() {
+  const a = { verdict: 'FAIL' };
+  const b = { verdict: 'fail' };
+  const c = { verdict: 'Fail' };
+  const h = fingerprintReport(a);
+  assert(fingerprintReport(b) === h && fingerprintReport(c) === h, 'verdict case does not matter');
+}
+
+function testWhitespaceNormalisation() {
+  const a = { verdict: 'FAIL', findings: ['schema  missing    user.email'] };
+  const b = { verdict: 'FAIL', findings: [' schema missing user.email  '] };
+  assert(fingerprintReport(a) === fingerprintReport(b), 'collapsed whitespace in findings doesn\'t shift hash');
+}
+
+function testDifferentVerdictsDiffer() {
+  const a = { verdict: 'FAIL', findings: ['x'] };
+  const b = { verdict: 'PASS', findings: ['x'] };
+  assert(fingerprintReport(a) !== fingerprintReport(b), 'different verdicts → different hash');
+}
+
+function testDifferentFindingsDiffer() {
+  const a = { verdict: 'FAIL', structural_gaps: ['missing users table'] };
+  const b = { verdict: 'FAIL', structural_gaps: ['missing products table'] };
+  assert(fingerprintReport(a) !== fingerprintReport(b), 'different findings → different hash');
+}
+
+function testTransientFieldsIgnored() {
+  const a = { verdict: 'FAIL', findings: ['x'], timestamp: '2026-04-21T12:00:00Z', session_id: 'abc' };
+  const b = { verdict: 'FAIL', findings: ['x'], timestamp: '2026-04-22T13:00:00Z', session_id: 'xyz' };
+  assert(fingerprintReport(a) === fingerprintReport(b), 'timestamp/session_id are ignored');
+}
+
+function testConfidenceRoundedToTwoDecimals() {
+  const a = { verdict: 'NEEDS_IMPROVEMENT', confidence: 0.821 };
+  const b = { verdict: 'NEEDS_IMPROVEMENT', confidence: 0.823 };
+  // 0.82 vs 0.82 → same
+  assert(fingerprintReport(a) === fingerprintReport(b), 'tiny confidence drift doesn\'t shift hash (2-decimal rounding)');
+  const c = { verdict: 'NEEDS_IMPROVEMENT', confidence: 0.87 };
+  assert(fingerprintReport(a) !== fingerprintReport(c), 'meaningful confidence delta does shift hash');
+}
+
+function testDimensionFindingsContribute() {
+  // Two reports with the same overall verdict but different
+  // per-dimension findings should still differ. This is the
+  // testimonial case: PO stuck at NEEDS_IMPROVEMENT with shifting
+  // dimension-level findings should be distinguishable from
+  // NEEDS_IMPROVEMENT with unchanging findings.
+  const a = {
+    verdict: 'NEEDS_IMPROVEMENT',
+    dimensions: { ux: { status: 'FAIL', findings: ['nav unclear'] } },
+  };
+  const b = {
+    verdict: 'NEEDS_IMPROVEMENT',
+    dimensions: { ux: { status: 'FAIL', findings: ['empty states missing'] } },
+  };
+  assert(fingerprintReport(a) !== fingerprintReport(b), 'dimension findings contribute to hash');
+}
+
+function testSilentDegradationContributes() {
+  const a = { verdict: 'PASS', silent_degradation_check: { status: 'PASS', evidence: [] } };
+  const b = { verdict: 'PASS', silent_degradation_check: { status: 'FAIL', evidence: ['mock stub in auth'] } };
+  assert(fingerprintReport(a) !== fingerprintReport(b), 'silent-degradation status contributes');
+}
+
+function testHasIdenticalTailPositive() {
+  const h = 'abc123';
+  assert(hasIdenticalTail([h, h, h], 3) === true, 'three identical → tail positive at n=3');
+  assert(hasIdenticalTail(['x', h, h, h], 3) === true, 'last three identical → positive');
+  assert(hasIdenticalTail([h, h], 2) === true, 'two identical → positive at n=2');
+}
+
+function testHasIdenticalTailNegative() {
+  assert(hasIdenticalTail(['a', 'b', 'c'], 3) === false, 'three distinct → negative');
+  assert(hasIdenticalTail(['a', 'a', 'b'], 3) === false, 'tail differs → negative');
+  assert(hasIdenticalTail(['a'], 2) === false, 'too few entries → negative');
+  assert(hasIdenticalTail([], 1) === false, 'empty → negative');
+  assert(hasIdenticalTail(['', '', ''], 3) === false, 'empty-string fingerprints → negative (sentinel)');
+}
+
+function main() {
+  console.log('findings-fingerprint');
+  testNullReturnsEmpty();
+  testIdenticalReportsSameHash();
+  testKeyOrderStable();
+  testVerdictCaseInsensitive();
+  testWhitespaceNormalisation();
+  testDifferentVerdictsDiffer();
+  testDifferentFindingsDiffer();
+  testTransientFieldsIgnored();
+  testConfidenceRoundedToTwoDecimals();
+  testDimensionFindingsContribute();
+  testSilentDegradationContributes();
+  testHasIdenticalTailPositive();
+  testHasIdenticalTailNegative();
+  console.log(`  ${checks} checks, ${failures} failures`);
+  if (failures > 0) {
+    console.error('FAIL');
+    process.exit(1);
+  }
+  console.log('PASS');
+}
+
+main();

--- a/tests/health-report.test.js
+++ b/tests/health-report.test.js
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+/**
+ * Tests for src/launcher/health-report.js
+ *
+ * Uses a temp "projects dir" with synthesised state.json +
+ * phase-fingerprints.jsonl to verify the aggregation logic.
+ *
+ * Usage: node tests/health-report.test.js
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { buildReport, formatReport, fingerprintRepeats, summariseEscalations } = require('../src/launcher/health-report.js');
+
+let failures = 0;
+let checks = 0;
+
+function assert(condition, message) {
+  checks++;
+  if (!condition) {
+    failures++;
+    console.error(`  ✗ ${message}`);
+  }
+}
+
+function makeProject(projectsDir, name, state, fingerprints) {
+  const dir = path.join(projectsDir, name);
+  const rougeDir = path.join(dir, '.rouge');
+  fs.mkdirSync(rougeDir, { recursive: true });
+  fs.writeFileSync(path.join(rougeDir, 'state.json'), JSON.stringify(state));
+  if (fingerprints && fingerprints.length) {
+    fs.writeFileSync(
+      path.join(dir, 'phase-fingerprints.jsonl'),
+      fingerprints.map((e) => JSON.stringify(e)).join('\n') + '\n',
+    );
+  }
+}
+
+function testEmptyProjectsDir() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'health-'));
+  try {
+    const report = buildReport({ projectsDir: tmp });
+    assert(report.fleet.project_count === 0, 'empty dir → 0 projects');
+    assert(report.projects.length === 0, 'no project entries');
+  } finally { fs.rmSync(tmp, { recursive: true, force: true }); }
+}
+
+function testHealthyProject() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'health-'));
+  try {
+    makeProject(tmp, 'happy', { current_state: 'story-building', budget_cap_usd: 100, costs: { cumulative_cost_usd_real: 5.5, cumulative_cost_usd_estimated: 0 } }, []);
+    const report = buildReport({ projectsDir: tmp });
+    assert(report.fleet.project_count === 1, '1 project found');
+    assert(report.fleet.stuck_project_count === 0, 'no stuck projects');
+    assert(report.fleet.cumulative_cost_usd_real === 5.5, 'fleet spend aggregated');
+    assert(report.projects[0].early_warnings.length === 0, 'no early warnings');
+  } finally { fs.rmSync(tmp, { recursive: true, force: true }); }
+}
+
+function testSpinningProjectFlagged() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'health-'));
+  try {
+    const fps = [
+      { phase: 'foundation-eval', ts: '2026-04-22T10:00:00Z', fingerprint: 'abc', verdict: 'FAIL' },
+      { phase: 'foundation-eval', ts: '2026-04-22T10:01:00Z', fingerprint: 'abc', verdict: 'FAIL' },
+    ];
+    makeProject(tmp, 'spinner', { current_state: 'foundation-eval' }, fps);
+    const report = buildReport({ projectsDir: tmp, spinWarnThreshold: 2 });
+    assert(report.fleet.stuck_project_count === 1, 'spinning project counted as stuck');
+    assert(report.projects[0].early_warnings.length === 1, 'one early warning');
+    assert(report.projects[0].early_warnings[0].repeats === 2, 'warning counts 2 identical');
+  } finally { fs.rmSync(tmp, { recursive: true, force: true }); }
+}
+
+function testEscalationHistogramAggregates() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'health-'));
+  try {
+    makeProject(tmp, 'a', {
+      current_state: 'escalation',
+      escalations: [
+        { id: '1', classification: 'semantic-spin', status: 'pending', summary: 'stuck' },
+        { id: '2', classification: 'budget-exceeded', status: 'resolved' },
+      ],
+    });
+    makeProject(tmp, 'b', {
+      current_state: 'escalation',
+      escalations: [
+        { id: '3', classification: 'semantic-spin', status: 'pending', summary: 'also stuck' },
+      ],
+    });
+    const report = buildReport({ projectsDir: tmp });
+    assert(report.fleet.escalation_histogram['semantic-spin'] === 2, 'semantic-spin count aggregated across projects');
+    assert(report.fleet.escalation_histogram['budget-exceeded'] === 1, 'budget-exceeded counted');
+  } finally { fs.rmSync(tmp, { recursive: true, force: true }); }
+}
+
+function testFingerprintRepeatCounting() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'health-'));
+  try {
+    const fps = [
+      { phase: 'foundation-eval', fingerprint: 'A' },
+      { phase: 'foundation-eval', fingerprint: 'B' },
+      { phase: 'foundation-eval', fingerprint: 'C' },
+      { phase: 'foundation-eval', fingerprint: 'C' },
+      { phase: 'foundation-eval', fingerprint: 'C' },
+      { phase: 'milestone-check', fingerprint: 'X' },
+    ];
+    makeProject(tmp, 'proj', { current_state: 'foundation-eval' }, fps);
+    const result = fingerprintRepeats(tmp, 'proj');
+    assert(result['foundation-eval'].repeats === 3, 'foundation-eval trailing 3 identical');
+    assert(result['milestone-check'].repeats === 1, 'milestone-check has 1 entry');
+  } finally { fs.rmSync(tmp, { recursive: true, force: true }); }
+}
+
+function testFormatReportIsReadable() {
+  const report = {
+    generated_at: '2026-04-22T10:00:00Z',
+    projects_dir: '/tmp/projects',
+    projects: [
+      {
+        name: 'stack-rank',
+        state: 'foundation-eval',
+        budget_cap_usd: 100,
+        cumulative_cost_usd: 90,
+        cumulative_cost_usd_real: 90,
+        cumulative_cost_usd_estimated: 0,
+        escalations: { byClass: { 'semantic-spin': 1 }, pending: [{ id: '1', classification: 'semantic-spin', summary: 'stuck at foundation-eval' }], total: 1 },
+        fingerprint_repeats: { 'foundation-eval': { repeats: 5, last_verdict: 'FAIL' } },
+        early_warnings: [{ phase: 'foundation-eval', repeats: 5, last_verdict: 'FAIL' }],
+      },
+    ],
+    fleet: {
+      project_count: 1,
+      stuck_project_count: 1,
+      stuck_projects: ['stack-rank'],
+      escalation_histogram: { 'semantic-spin': 1 },
+      cumulative_cost_usd_real: 90,
+      cumulative_cost_usd_estimated: 0,
+      self_heal: { applied: 0, drafted: 0, refused: 0, reverted: 0, total: 0 },
+    },
+  };
+  const text = formatReport(report);
+  assert(text.includes('stack-rank'), 'project name in output');
+  assert(text.includes('Escalation histogram'), 'histogram header present');
+  assert(text.includes('5 identical cycles'), 'warning line rendered');
+}
+
+function main() {
+  console.log('health-report');
+  testEmptyProjectsDir();
+  testHealthyProject();
+  testSpinningProjectFlagged();
+  testEscalationHistogramAggregates();
+  testFingerprintRepeatCounting();
+  testFormatReportIsReadable();
+  console.log(`  ${checks} checks, ${failures} failures`);
+  if (failures > 0) {
+    console.error('FAIL');
+    process.exit(1);
+  }
+  console.log('PASS');
+}
+
+main();

--- a/tests/integration-catalog.test.js
+++ b/tests/integration-catalog.test.js
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+/**
+ * Tests for src/launcher/integration-catalog.js
+ *
+ * Covers manifest resolution + prerequisite runners + URL templating.
+ * The shipped manifests (github-pages, vercel, cloudflare-pages,
+ * docker-compose) must all load cleanly and their aliases resolve.
+ *
+ * Usage: node tests/integration-catalog.test.js
+ */
+
+const path = require('path');
+const fs = require('fs');
+const {
+  getManifest,
+  runCheck,
+  resolveTemplate,
+  resolveHealthCheckUrl,
+  _resetCache,
+} = require('../src/launcher/integration-catalog.js');
+
+let failures = 0;
+let checks = 0;
+
+function assert(condition, message) {
+  checks++;
+  if (!condition) {
+    failures++;
+    console.error(`  ✗ ${message}`);
+  }
+}
+
+function testGithubPagesManifestLoads() {
+  const m = getManifest('github-pages');
+  assert(!!m, 'github-pages manifest resolves');
+  assert(m.kind === 'deploy', 'github-pages kind=deploy');
+  assert(Array.isArray(m.prerequisites), 'has prerequisites');
+  assert(m.health_check.url_template.includes('{owner}'), 'url_template uses owner placeholder');
+}
+
+function testGhPagesAliasResolves() {
+  const m1 = getManifest('github-pages');
+  const m2 = getManifest('gh-pages');
+  assert(m1 === m2, 'gh-pages alias resolves to the same manifest object');
+}
+
+function testCloudflarePagesAliases() {
+  const m1 = getManifest('cloudflare-pages');
+  const m2 = getManifest('cloudflare');
+  const m3 = getManifest('cloudflare-workers');
+  assert(m1 && m1 === m2 && m1 === m3, 'cloudflare-pages resolves via all three aliases');
+}
+
+function testVercelManifestLoads() {
+  const m = getManifest('vercel');
+  assert(!!m, 'vercel manifest resolves');
+  assert(m.human_name === 'Vercel', 'human_name is set');
+}
+
+function testDockerComposeManifestLoads() {
+  const m = getManifest('docker-compose');
+  assert(!!m, 'docker-compose manifest resolves');
+  const aliased = getManifest('docker');
+  assert(aliased === m, 'docker alias resolves');
+}
+
+function testUnknownTargetReturnsNull() {
+  const m = getManifest('never-heard-of-it');
+  assert(m === null, 'unknown target → null');
+  const empty = getManifest('');
+  assert(empty === null, 'empty target → null');
+}
+
+function testResolveTemplate() {
+  const out = resolveTemplate('repos/{owner}/{repo}/pages', { owner: 'gregario', repo: 'foo' });
+  assert(out === 'repos/gregario/foo/pages', 'template substitution works');
+  const partial = resolveTemplate('hello {missing}', {});
+  assert(partial === 'hello {missing}', 'unknown placeholder is left alone');
+}
+
+function testResolveHealthCheckUrl() {
+  const m = getManifest('github-pages');
+  const url = resolveHealthCheckUrl(m, { owner: 'gregario', repo: 'testproj' });
+  assert(url === 'https://gregario.github.io/testproj/', 'github-pages URL templating');
+}
+
+function testFileExistsCheck() {
+  // Use this repo's own package.json as a known-present file.
+  const ok = runCheck({ kind: 'file-exists', path: 'package.json' }, { projectDir: path.resolve(__dirname, '..') });
+  assert(ok.ok === true, 'file-exists: present file → ok');
+  const missing = runCheck({ kind: 'file-exists', path: 'no-such-file' }, { projectDir: path.resolve(__dirname, '..') });
+  assert(missing.ok === false, 'file-exists: missing file → not ok');
+}
+
+function testEnvVarCheck() {
+  const prev = process.env.ROUGE_CATALOG_TEST;
+  process.env.ROUGE_CATALOG_TEST = '1';
+  try {
+    const ok = runCheck({ kind: 'env-var-present', env_var: 'ROUGE_CATALOG_TEST' }, {});
+    assert(ok.ok === true, 'env-var-present: set var → ok');
+  } finally {
+    if (prev === undefined) delete process.env.ROUGE_CATALOG_TEST;
+    else process.env.ROUGE_CATALOG_TEST = prev;
+  }
+  const missing = runCheck({ kind: 'env-var-present', env_var: 'ROUGE_NEVER_SET_PLEASE' }, {});
+  assert(missing.ok === false, 'env-var-present: unset → not ok');
+}
+
+function testSecretsPresentCheckDefers() {
+  // Secrets checks are handled by the caller (secrets module) to avoid
+  // circular requires. Catalog returns {ok:false} with a hint.
+  const r = runCheck({ kind: 'secret-present', secret_key: 'SOMETHING' }, {});
+  assert(r.ok === false, 'secret-present defers with ok:false');
+  assert(r.detail && r.detail.includes('secret-present'), 'detail explains deferral');
+}
+
+function testUnknownCheckKind() {
+  const r = runCheck({ kind: 'mystery-protocol' }, {});
+  assert(r.ok === false, 'unknown check kind → not ok');
+}
+
+function main() {
+  _resetCache();
+  console.log('integration-catalog reader');
+  testGithubPagesManifestLoads();
+  testGhPagesAliasResolves();
+  testCloudflarePagesAliases();
+  testVercelManifestLoads();
+  testDockerComposeManifestLoads();
+  testUnknownTargetReturnsNull();
+  testResolveTemplate();
+  testResolveHealthCheckUrl();
+  testFileExistsCheck();
+  testEnvVarCheck();
+  testSecretsPresentCheckDefers();
+  testUnknownCheckKind();
+  console.log(`  ${checks} checks, ${failures} failures`);
+  if (failures > 0) {
+    console.error('FAIL');
+    process.exit(1);
+  }
+  console.log('PASS');
+}
+
+main();

--- a/tests/integration-manifest.test.js
+++ b/tests/integration-manifest.test.js
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+/**
+ * Tests for schemas/integration-manifest.json
+ *
+ * The schema itself should compile cleanly, and the example manifest
+ * we ship for github-pages should validate. Wave 2 will add the four
+ * real manifests (github-pages, vercel, cloudflare-pages, docker-compose)
+ * and these same shape tests cover them.
+ *
+ * Usage: node tests/integration-manifest.test.js
+ */
+
+const fs = require('fs');
+const path = require('path');
+const Ajv = require('ajv');
+
+const ROOT = path.resolve(__dirname, '..');
+const SCHEMA_PATH = path.join(ROOT, 'schemas/integration-manifest.json');
+
+let failures = 0;
+let checks = 0;
+
+function assert(condition, message) {
+  checks++;
+  if (!condition) {
+    failures++;
+    console.error(`  ✗ ${message}`);
+  }
+}
+
+const schema = JSON.parse(fs.readFileSync(SCHEMA_PATH, 'utf8'));
+const ajv = new Ajv({ allErrors: true, strict: false });
+const validate = ajv.compile(schema);
+
+function testMinimalManifestValidates() {
+  const m = { target: 'none', kind: 'deploy', version: 1 };
+  const ok = validate(m);
+  assert(ok, `minimal manifest rejected: ${ajv.errorsText(validate.errors)}`);
+}
+
+function testGithubPagesExampleValidates() {
+  // Shape that Wave 2's github-pages manifest will take. Validating
+  // now so the schema supports it end-to-end before we author it.
+  const m = {
+    target: 'github-pages',
+    aliases: ['gh-pages'],
+    kind: 'deploy',
+    version: 1,
+    human_name: 'GitHub Pages',
+    summary: 'Static site hosting on the gh-pages branch of the project repo.',
+    prerequisites: [
+      {
+        id: 'pages-enabled',
+        label: 'GitHub Pages is enabled on the repo',
+        check: { kind: 'gh-api', endpoint: 'repos/{owner}/{repo}/pages' },
+        auto_remediate: {
+          kind: 'gh-api-post',
+          endpoint: 'repos/{owner}/{repo}/pages',
+          body: { source: { branch: 'gh-pages', path: '/' } },
+          grace_seconds: 30
+        }
+      }
+    ],
+    build_output_dirs: ['dist', 'build', 'out', 'public'],
+    env_vars: [],
+    secrets_required: [],
+    health_check: {
+      kind: 'http-200',
+      url_template: 'https://{owner}.github.io/{repo}/',
+      timeout_ms: 10000,
+      first_deploy_grace_ms: 30000,
+      first_deploy_poll_window_ms: 150000,
+      poll_interval_ms: 15000
+    },
+    notes_for_prompt: 'Static-only. No API routes, no server components that read secrets at request time.'
+  };
+  const ok = validate(m);
+  assert(ok, `github-pages example rejected: ${ajv.errorsText(validate.errors)}`);
+}
+
+function testSupabaseExampleValidates() {
+  // Database kind — different shape. Ensures the schema isn't secretly
+  // deploy-only.
+  const m = {
+    target: 'supabase',
+    kind: 'database',
+    version: 1,
+    human_name: 'Supabase',
+    summary: 'Hosted Postgres with a generous free tier.',
+    prerequisites: [
+      {
+        id: 'supabase-token',
+        label: 'Supabase access token is configured',
+        check: { kind: 'secret-present', secret_key: 'SUPABASE_ACCESS_TOKEN' }
+      }
+    ],
+    env_vars: [
+      { name: 'SUPABASE_URL', required: true, secret_provider: 'supabase' },
+      { name: 'SUPABASE_ANON_KEY', required: true, secret_provider: 'supabase' },
+      { name: 'SUPABASE_SERVICE_KEY', required: false, secret_provider: 'supabase' }
+    ],
+    secrets_required: [
+      { provider: 'supabase', key: 'SUPABASE_ACCESS_TOKEN' }
+    ]
+  };
+  const ok = validate(m);
+  assert(ok, `supabase example rejected: ${ajv.errorsText(validate.errors)}`);
+}
+
+function testRejectsMissingRequiredFields() {
+  const m = { kind: 'deploy', version: 1 }; // no target
+  const ok = validate(m);
+  assert(!ok, 'missing target is rejected');
+}
+
+function testRejectsInvalidTargetPattern() {
+  const m = { target: 'Not Valid', kind: 'deploy', version: 1 };
+  const ok = validate(m);
+  assert(!ok, 'target with spaces/caps is rejected');
+}
+
+function testRejectsUnknownKind() {
+  const m = { target: 'x', kind: 'nonsense', version: 1 };
+  const ok = validate(m);
+  assert(!ok, 'unknown kind is rejected');
+}
+
+function testRejectsUnknownPrerequisiteCheckKind() {
+  const m = {
+    target: 'x',
+    kind: 'deploy',
+    version: 1,
+    prerequisites: [{ id: 'p', label: 'x', check: { kind: 'mystery-method' } }]
+  };
+  const ok = validate(m);
+  assert(!ok, 'unknown prerequisite check kind is rejected');
+}
+
+function testAdditionalPropertiesAreRejected() {
+  const m = { target: 'x', kind: 'deploy', version: 1, rogueField: 'oops' };
+  const ok = validate(m);
+  assert(!ok, 'extra top-level field is rejected');
+}
+
+function main() {
+  console.log('integration-manifest schema');
+  testMinimalManifestValidates();
+  testGithubPagesExampleValidates();
+  testSupabaseExampleValidates();
+  testRejectsMissingRequiredFields();
+  testRejectsInvalidTargetPattern();
+  testRejectsUnknownKind();
+  testRejectsUnknownPrerequisiteCheckKind();
+  testAdditionalPropertiesAreRejected();
+  console.log(`  ${checks} checks, ${failures} failures`);
+  if (failures > 0) {
+    console.error('FAIL');
+    process.exit(1);
+  }
+  console.log('PASS');
+}
+
+main();

--- a/tests/schema-assignments.test.js
+++ b/tests/schema-assignments.test.js
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+/**
+ * Schema/code alignment invariant.
+ *
+ * Walks every JS file in src/launcher/, finds string-literal assignments
+ * to enum-constrained properties (e.g. `state.foundation.status = 'X'`),
+ * and asserts the value is in the schema enum.
+ *
+ * Catches drift like the 2026-04-21 `state.foundation.status = 'evaluating'`
+ * bug where the launcher wrote a value the schema didn't allow — every
+ * write logged a warn, the state persisted anyway, and foundation-eval
+ * looped 94 times on stack-rank before the budget cap finally fired.
+ *
+ * Scope: static analysis. Dynamic assignments (variables, computed
+ * expressions) are out of scope — the test only catches literal-to-enum
+ * drift, which is 80% of the failure mode. Full enforcement at runtime
+ * is the job of schema-validator.js in strict mode.
+ *
+ * Usage: node tests/schema-assignments.test.js
+ */
+
+const fs = require('fs');
+const path = require('path');
+const acorn = require('acorn');
+
+const ROOT = path.resolve(__dirname, '..');
+const LAUNCHER_DIR = path.join(ROOT, 'src/launcher');
+const SCHEMAS_DIR = path.join(ROOT, 'schemas');
+
+let failures = 0;
+let checks = 0;
+
+function assert(condition, message) {
+  checks++;
+  if (!condition) {
+    failures++;
+    console.error(`  ✗ ${message}`);
+  }
+}
+
+// Enum targets — (property-path-suffix → allowed-values). Property path
+// suffix matches the tail of the member-expression chain, so we catch
+// whether the root variable is `state`, `phaseState`, `s`, etc.
+function loadEnumTargets() {
+  const stateSchema = JSON.parse(
+    fs.readFileSync(path.join(SCHEMAS_DIR, 'state.json'), 'utf8'),
+  );
+  const targets = new Map();
+  targets.set('current_state', {
+    schemaPath: 'properties.current_state.enum',
+    values: new Set(stateSchema.properties.current_state.enum),
+  });
+  targets.set('foundation.status', {
+    schemaPath: 'properties.foundation.properties.status.enum',
+    values: new Set(stateSchema.properties.foundation.properties.status.enum),
+  });
+  targets.set('costs.phase_cost_source', {
+    schemaPath: 'properties.costs.properties.phase_cost_source.enum',
+    values: new Set(stateSchema.properties.costs.properties.phase_cost_source.enum),
+  });
+  return targets;
+}
+
+// Walk a MemberExpression chain top-down and emit the dotted suffix if
+// the chain is static. `state.foundation.status` → `foundation.status`.
+// `state.milestones[i].status` → null (has computed index, non-static).
+function memberSuffix(node) {
+  // Collect property names in order, innermost-first.
+  const parts = [];
+  let n = node;
+  while (n && n.type === 'MemberExpression') {
+    if (n.computed) return null; // foo[bar] — not a static path
+    if (n.property.type !== 'Identifier') return null;
+    parts.unshift(n.property.name);
+    n = n.object;
+  }
+  // The root (innermost object) is an Identifier; we don't constrain its
+  // name — works for `state.X`, `phaseState.X`, `s.X` alike.
+  if (!n || n.type !== 'Identifier') return null;
+  return parts.join('.');
+}
+
+function checkFile(filePath, targets) {
+  const src = fs.readFileSync(filePath, 'utf8');
+  let ast;
+  try {
+    ast = acorn.parse(src, { ecmaVersion: 'latest', sourceType: 'script', locations: true });
+  } catch (err) {
+    console.error(`  ! failed to parse ${path.relative(ROOT, filePath)}: ${err.message}`);
+    failures++;
+    return;
+  }
+
+  // Minimal recursive walker — no dep on acorn-walk.
+  const assignments = [];
+  function walk(node) {
+    if (!node || typeof node !== 'object') return;
+    if (node.type === 'AssignmentExpression' && node.operator === '=') {
+      if (node.left && node.left.type === 'MemberExpression') {
+        const suffix = memberSuffix(node.left);
+        if (suffix && node.right && node.right.type === 'Literal' && typeof node.right.value === 'string') {
+          assignments.push({ suffix, value: node.right.value, loc: node.loc });
+        }
+      }
+    }
+    for (const key of Object.keys(node)) {
+      if (key === 'loc' || key === 'start' || key === 'end') continue;
+      const child = node[key];
+      if (Array.isArray(child)) child.forEach(walk);
+      else if (child && typeof child === 'object') walk(child);
+    }
+  }
+  walk(ast);
+
+  for (const { suffix, value, loc } of assignments) {
+    // Match the longest suffix that registers as an enum target. e.g.
+    // `phaseState.foundation.status` has suffix 'foundation.status';
+    // `ctx.costs.phase_cost_source` has 'costs.phase_cost_source'.
+    for (const [key, target] of targets) {
+      if (suffix === key || suffix.endsWith('.' + key)) {
+        const rel = path.relative(ROOT, filePath);
+        assert(
+          target.values.has(value),
+          `${rel}:${loc.start.line} assigns ${suffix}='${value}' — not in schema enum (allowed: ${[...target.values].join(', ')})`,
+        );
+      }
+    }
+  }
+}
+
+function main() {
+  console.log('schema-assignments invariant');
+  const targets = loadEnumTargets();
+  const files = fs
+    .readdirSync(LAUNCHER_DIR)
+    .filter((f) => f.endsWith('.js'))
+    .map((f) => path.join(LAUNCHER_DIR, f));
+
+  for (const f of files) checkFile(f, targets);
+
+  console.log(`  ${checks} checks, ${failures} failures`);
+  if (failures > 0) {
+    console.error('FAIL — schema/code drift detected');
+    process.exit(1);
+  }
+  console.log('PASS');
+}
+
+main();

--- a/tests/schema-validator.test.js
+++ b/tests/schema-validator.test.js
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+/**
+ * Tests for src/launcher/schema-validator.js
+ *
+ * Covers the warn/strict dual-mode introduced 2026-04-22 to surface
+ * schema drift at the write site rather than letting bad shapes land
+ * on disk and compound across phase cycles.
+ *
+ * Usage: node tests/schema-validator.test.js
+ */
+
+const { validate, SchemaViolationError } = require('../src/launcher/schema-validator.js');
+
+let failures = 0;
+let checks = 0;
+
+function assert(condition, message) {
+  checks++;
+  if (!condition) {
+    failures++;
+    console.error(`  ✗ ${message}`);
+  }
+}
+
+function assertThrows(fn, errorType, message) {
+  checks++;
+  try {
+    fn();
+    failures++;
+    console.error(`  ✗ ${message} — expected throw, got no-op`);
+  } catch (err) {
+    if (!(err instanceof errorType)) {
+      failures++;
+      console.error(`  ✗ ${message} — threw ${err.constructor.name}, expected ${errorType.name}`);
+    }
+  }
+}
+
+// Mute warn lines during the warn-mode cases so test output stays clean.
+const originalWarn = console.warn;
+function silenceWarns(fn) {
+  console.warn = () => {};
+  try { fn(); } finally { console.warn = originalWarn; }
+}
+
+function testWarnModeReturnsValid() {
+  const valid = { current_state: 'seeding' };
+  const res = validate('state.json', valid, 'unit-test');
+  assert(res.valid === true, 'warn: valid state returns {valid: true}');
+  assert(res.errors.length === 0, 'warn: valid state has no errors');
+}
+
+function testWarnModeReturnsInvalidWithoutThrowing() {
+  const invalid = { current_state: 'not-a-real-state' };
+  let res;
+  silenceWarns(() => {
+    res = validate('state.json', invalid, 'unit-test');
+  });
+  assert(res.valid === false, 'warn: invalid state returns {valid: false}');
+  assert(res.errors.length > 0, 'warn: invalid state has errors');
+}
+
+function testStrictModeThrowsOnInvalid() {
+  const invalid = { current_state: 'not-a-real-state' };
+  assertThrows(
+    () => validate('state.json', invalid, 'unit-test', { strict: true }),
+    SchemaViolationError,
+    'strict: invalid state throws SchemaViolationError',
+  );
+}
+
+function testStrictModeDoesNotThrowOnValid() {
+  const valid = { current_state: 'seeding' };
+  const res = validate('state.json', valid, 'unit-test', { strict: true });
+  assert(res.valid === true, 'strict: valid state returns {valid: true}');
+}
+
+function testStrictModeViaEnvVar() {
+  const invalid = { current_state: 'bogus' };
+  const prev = process.env.ROUGE_STRICT_SCHEMA;
+  process.env.ROUGE_STRICT_SCHEMA = '1';
+  try {
+    assertThrows(
+      () => validate('state.json', invalid, 'unit-test'),
+      SchemaViolationError,
+      'strict (env): invalid state throws when ROUGE_STRICT_SCHEMA=1',
+    );
+  } finally {
+    if (prev === undefined) delete process.env.ROUGE_STRICT_SCHEMA;
+    else process.env.ROUGE_STRICT_SCHEMA = prev;
+  }
+}
+
+function testFoundationEvaluatingPasses() {
+  // The exact case from stack-rank's 94-cycle spiral. With the enum
+  // expansion in schemas/state.json, this must now be accepted.
+  const state = {
+    current_state: 'foundation-eval',
+    foundation: { status: 'evaluating' },
+  };
+  const res = validate('state.json', state, 'unit-test', { strict: true });
+  assert(res.valid === true, 'strict: foundation.status=evaluating is valid (stack-rank regression)');
+}
+
+function testErrorCarriesPayload() {
+  const invalid = { current_state: 'nope' };
+  try {
+    validate('state.json', invalid, 'write /path/to/state.json', { strict: true });
+    failures++;
+    console.error('  ✗ error: strict mode did not throw');
+    checks++;
+  } catch (err) {
+    checks += 3;
+    if (!(err instanceof SchemaViolationError)) { failures++; console.error('  ✗ error: wrong type'); }
+    if (err.schemaName !== 'state.json') { failures++; console.error('  ✗ error: wrong schemaName'); }
+    if (!err.context.includes('/path/to/state.json')) { failures++; console.error('  ✗ error: wrong context'); }
+  }
+}
+
+function main() {
+  console.log('schema-validator warn/strict modes');
+  testWarnModeReturnsValid();
+  testWarnModeReturnsInvalidWithoutThrowing();
+  testStrictModeThrowsOnInvalid();
+  testStrictModeDoesNotThrowOnValid();
+  testStrictModeViaEnvVar();
+  testFoundationEvaluatingPasses();
+  testErrorCarriesPayload();
+  console.log(`  ${checks} checks, ${failures} failures`);
+  if (failures > 0) {
+    console.error('FAIL');
+    process.exit(1);
+  }
+  console.log('PASS');
+}
+
+main();

--- a/tests/self-heal-applier.test.js
+++ b/tests/self-heal-applier.test.js
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+/**
+ * Tests for src/launcher/self-heal-applier.js
+ *
+ * Covers the non-git parts: config loading, patch application, and
+ * red/yellow zone refusal + draft writing. Green-zone apply paths
+ * require a real git branch and are exercised via the e2e fixture
+ * (tests/fixtures/stuck-project) rather than here — unit tests
+ * must not run git operations on the working repo.
+ *
+ * Usage: node tests/self-heal-applier.test.js
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { applyPlan, loadConfig, applyPatchToContent } = require('../src/launcher/self-heal-applier.js');
+
+let failures = 0;
+let checks = 0;
+
+function assert(condition, message) {
+  checks++;
+  if (!condition) {
+    failures++;
+    console.error(`  ✗ ${message}`);
+  }
+}
+
+function testLoadConfigDefaults() {
+  // If rouge.config.json doesn't define self_heal, we default to
+  // enabled=true zones=['green'].
+  const cfg = loadConfig();
+  assert(cfg.enabled === true, 'default enabled=true');
+  assert(Array.isArray(cfg.zones), 'zones is an array');
+  assert(cfg.zones.includes('green'), 'green is in the default zones allowlist');
+}
+
+function testRedZoneRefused() {
+  const plan = {
+    kind: 'bad',
+    description: 'should never apply',
+    files: [{ path: 'src/launcher/safety.js', added_lines: 1, removed_lines: 0, patch: { kind: 'noop' } }],
+  };
+  const result = applyPlan(plan, { dryRun: true });
+  assert(result.applied === false, 'red-zone plan not applied');
+  assert(result.zone === 'red', 'zone=red recorded');
+  assert(/refused/i.test(result.reason), 'reason mentions refusal');
+}
+
+function testYellowZoneWritesDraft() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'draft-'));
+  // Redirect the draft output to a temp dir by making the applier
+  // think it's operating from there — easier: let it write into the
+  // repo's .rouge/self-heal-drafts and then clean up.
+  const plan = {
+    kind: 'add-enum-value',
+    description: 'Add evaluating to enum',
+    files: [{
+      path: 'schemas/state.json',
+      added_lines: 0,
+      removed_lines: 0,
+      patch: { kind: 'json-enum-append', instance_path: '/foundation/status', new_value: 'test', new_enum: ['a', 'test'] },
+    }],
+  };
+  const result = applyPlan(plan, { dryRun: true });
+  assert(result.applied === false, 'yellow plan is not auto-applied');
+  assert(result.zone === 'yellow', 'zone=yellow recorded');
+  assert(!!result.draft_path, 'draft_path returned');
+  if (result.draft_path) {
+    assert(fs.existsSync(result.draft_path), 'draft file exists on disk');
+    // Clean up the draft we just created so this test stays hermetic.
+    try { fs.unlinkSync(result.draft_path); } catch {}
+  }
+  fs.rmSync(tmp, { recursive: true, force: true });
+}
+
+function testDryRunOnGreenReturnsPlan() {
+  const plan = {
+    kind: 'tiny-fix',
+    description: 'no-op',
+    files: [{ path: 'src/launcher/rouge-loop.js', added_lines: 1, removed_lines: 0, patch: { kind: 'noop' } }],
+  };
+  const result = applyPlan(plan, { dryRun: true });
+  assert(result.zone === 'green', 'green zone classified');
+  assert(result.applied === false, 'dry-run does not apply');
+  assert(result.reason === 'dry-run', 'reason=dry-run');
+  assert(result.plan === plan, 'plan returned for inspection');
+}
+
+function testApplyPatchToContentAppendsEnum() {
+  const tmpFile = path.join(os.tmpdir(), 'schema-' + Date.now() + '.json');
+  const schema = {
+    type: 'object',
+    properties: {
+      foundation: {
+        type: 'object',
+        properties: {
+          status: { type: 'string', enum: ['a', 'b'] },
+        },
+      },
+    },
+  };
+  fs.writeFileSync(tmpFile, JSON.stringify(schema, null, 2));
+  try {
+    // applyPatchToContent resolves paths relative to ROOT, so we
+    // need to temporarily use a path inside the repo. We create a
+    // temp file inside ROOT's tmp area.
+    const repoRoot = path.resolve(__dirname, '..');
+    const rel = 'tmp-test-schema-' + Date.now() + '.json';
+    const inside = path.join(repoRoot, rel);
+    fs.writeFileSync(inside, JSON.stringify(schema, null, 2));
+    try {
+      const result = applyPatchToContent(rel, {
+        kind: 'json-enum-append',
+        instance_path: '/foundation/status',
+        new_value: 'c',
+        new_enum: ['a', 'b', 'c'],
+      });
+      const parsed = JSON.parse(result);
+      assert(parsed.properties.foundation.properties.status.enum.join(',') === 'a,b,c', 'enum extended correctly');
+    } finally {
+      fs.unlinkSync(inside);
+    }
+  } finally {
+    fs.unlinkSync(tmpFile);
+  }
+}
+
+function testDisabledConfigShortCircuits() {
+  // Simulate a disabled config by writing rouge.config.json with
+  // self_heal.enabled=false, then restoring it after the test.
+  const cfgPath = path.resolve(__dirname, '..', 'rouge.config.json');
+  const prev = fs.readFileSync(cfgPath, 'utf8');
+  const parsed = JSON.parse(prev);
+  parsed.self_heal = { enabled: false };
+  fs.writeFileSync(cfgPath, JSON.stringify(parsed, null, 2));
+  try {
+    const plan = {
+      kind: 'noop',
+      description: 'x',
+      files: [{ path: 'src/launcher/rouge-loop.js', added_lines: 1, removed_lines: 0, patch: { kind: 'noop' } }],
+    };
+    const result = applyPlan(plan, { dryRun: true });
+    assert(result.applied === false, 'disabled config: not applied');
+    assert(/disabled/i.test(result.reason), 'reason mentions disabled');
+  } finally {
+    fs.writeFileSync(cfgPath, prev);
+  }
+}
+
+function main() {
+  console.log('self-heal-applier');
+  testLoadConfigDefaults();
+  testRedZoneRefused();
+  testYellowZoneWritesDraft();
+  testDryRunOnGreenReturnsPlan();
+  testApplyPatchToContentAppendsEnum();
+  testDisabledConfigShortCircuits();
+  console.log(`  ${checks} checks, ${failures} failures`);
+  if (failures > 0) {
+    console.error('FAIL');
+    process.exit(1);
+  }
+  console.log('PASS');
+}
+
+main();

--- a/tests/self-heal-planner.test.js
+++ b/tests/self-heal-planner.test.js
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+/**
+ * Tests for src/launcher/self-heal-planner.js
+ *
+ * Covers enumAtPath (pure), planFix for unknown evidence kinds, and
+ * planFix for schema-enum-drift when no offending assignment exists
+ * in source (since the repo is clean post-Wave-1). Positive-case
+ * end-to-end for an actual in-source drift is exercised by the
+ * applier's integration test fixture, not here.
+ *
+ * Usage: node tests/self-heal-planner.test.js
+ */
+
+const { planFix, enumAtPath } = require('../src/launcher/self-heal-planner.js');
+
+let failures = 0;
+let checks = 0;
+
+function assert(condition, message) {
+  checks++;
+  if (!condition) {
+    failures++;
+    console.error(`  ✗ ${message}`);
+  }
+}
+
+function testEnumAtPathSimple() {
+  const schema = {
+    properties: { foundation: { properties: { status: { enum: ['a', 'b'] } } } },
+  };
+  const result = enumAtPath(schema, '/foundation/status');
+  assert(Array.isArray(result) && result.length === 2, 'nested enum found');
+  assert(result[0] === 'a' && result[1] === 'b', 'values preserved');
+}
+
+function testEnumAtPathMissing() {
+  const schema = { properties: { foo: { properties: { bar: {} } } } };
+  const result = enumAtPath(schema, '/foo/bar');
+  assert(result === null, 'no enum at path → null');
+  const result2 = enumAtPath(schema, '/missing/path');
+  assert(result2 === null, 'missing path → null');
+}
+
+function testEnumAtPathEmptyPath() {
+  const schema = { enum: ['a', 'b'] };
+  const result = enumAtPath(schema, '/');
+  assert(Array.isArray(result) && result.length === 2, 'empty segments returns root enum');
+}
+
+function testPlanFixNoEvidenceKind() {
+  const result = planFix({ evidence: { kind: 'mystery-shape' } });
+  assert(result.ok === false, 'unknown evidence kind → no plan');
+  assert(/no planner/i.test(result.reason), 'reason mentions no planner');
+}
+
+function testPlanFixMissingSchema() {
+  const result = planFix({ evidence: { kind: 'schema-enum-drift', schema: 'no-such-file.json', instance_path: '/x' } });
+  assert(result.ok === false, 'missing schema file → no plan');
+}
+
+function testPlanFixCleanRepo() {
+  // The repo has no live schema-enum drift post-Wave-1; the planner
+  // should not find an offending assignment for an already-healthy
+  // path and return {ok:false}.
+  const result = planFix({
+    evidence: { kind: 'schema-enum-drift', schema: 'state.json', instance_path: '/foundation/status', occurrences: 5 },
+  });
+  assert(result.ok === false, 'no drift in clean repo → no plan');
+  assert(/no literal assignment/i.test(result.reason), 'reason mentions no violating assignment');
+}
+
+function testPlanFixNoTriage() {
+  assert(planFix(null).ok === false, 'null triage → no plan');
+  assert(planFix({}).ok === false, 'missing evidence → no plan');
+}
+
+function main() {
+  console.log('self-heal-planner');
+  testEnumAtPathSimple();
+  testEnumAtPathMissing();
+  testEnumAtPathEmptyPath();
+  testPlanFixNoEvidenceKind();
+  testPlanFixMissingSchema();
+  testPlanFixCleanRepo();
+  testPlanFixNoTriage();
+  console.log(`  ${checks} checks, ${failures} failures`);
+  if (failures > 0) {
+    console.error('FAIL');
+    process.exit(1);
+  }
+  console.log('PASS');
+}
+
+main();

--- a/tests/self-heal-zones.test.js
+++ b/tests/self-heal-zones.test.js
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+/**
+ * Tests for src/launcher/self-heal-zones.js
+ *
+ * Zone enforcement is the guardrail for the self-heal subsystem.
+ * These tests are deliberately adversarial — the goal is to prove
+ * that the classifier refuses to auto-apply anything that might
+ * modify safety mechanisms, prompts, or agentic side-effects.
+ *
+ * Usage: node tests/self-heal-zones.test.js
+ */
+
+const { classifyPlan, canAutoApply, MAX_GREEN_LINES, RED_FILES } = require('../src/launcher/self-heal-zones.js');
+
+let failures = 0;
+let checks = 0;
+
+function assert(condition, message) {
+  checks++;
+  if (!condition) {
+    failures++;
+    console.error(`  ✗ ${message}`);
+  }
+}
+
+function testSimpleLauncherFixIsGreen() {
+  const plan = {
+    kind: 'add-enum-value',
+    files: [{ path: 'src/launcher/rouge-loop.js', added_lines: 1, removed_lines: 0 }],
+  };
+  const result = classifyPlan(plan);
+  assert(result.zone === 'green', 'small launcher fix → green');
+  assert(canAutoApply(plan) === true, 'canAutoApply true');
+}
+
+function testSafetyModuleRedZone() {
+  for (const file of RED_FILES) {
+    const plan = {
+      kind: 'anything',
+      files: [{ path: file, added_lines: 1, removed_lines: 0 }],
+    };
+    const result = classifyPlan(plan);
+    assert(result.zone === 'red', `${file} → red`);
+    assert(canAutoApply(plan) === false, `${file} never auto-applies`);
+  }
+}
+
+function testPromptChangeIsRed() {
+  const plan = {
+    kind: 'edit-prompt',
+    files: [{ path: 'src/prompts/loop/00-foundation-building.md', added_lines: 5, removed_lines: 2 }],
+  };
+  const result = classifyPlan(plan);
+  assert(result.zone === 'red', 'prompt change → red');
+}
+
+function testSchemaChangeIsYellow() {
+  const plan = {
+    kind: 'add-enum-value',
+    files: [{ path: 'schemas/state.json', added_lines: 1, removed_lines: 0 }],
+  };
+  const result = classifyPlan(plan);
+  assert(result.zone === 'yellow', 'schema change → yellow (review required)');
+}
+
+function testLibraryIntegrationIsYellow() {
+  const plan = {
+    kind: 'add-manifest',
+    files: [{ path: 'library/integrations/tier-2/netlify/manifest.json', added_lines: 20, removed_lines: 0 }],
+  };
+  const result = classifyPlan(plan);
+  assert(result.zone === 'yellow', 'new catalog manifest → yellow');
+}
+
+function testDashboardChangeIsYellow() {
+  const plan = {
+    kind: 'fix-ui',
+    files: [{ path: 'dashboard/src/components/foo.tsx', added_lines: 5, removed_lines: 2 }],
+  };
+  const result = classifyPlan(plan);
+  assert(result.zone === 'yellow', 'dashboard change → yellow');
+}
+
+function testLargeChangeIsYellow() {
+  const plan = {
+    kind: 'refactor',
+    files: [{ path: 'src/launcher/rouge-loop.js', added_lines: 50, removed_lines: 20 }],
+  };
+  const result = classifyPlan(plan);
+  assert(result.zone === 'yellow', 'big change (50+20 > 30) → yellow');
+}
+
+function testBoundaryAtMaxGreenLines() {
+  const plan = {
+    kind: 'fix',
+    files: [{ path: 'src/launcher/rouge-loop.js', added_lines: MAX_GREEN_LINES, removed_lines: 0 }],
+  };
+  const result = classifyPlan(plan);
+  assert(result.zone === 'green', `exactly ${MAX_GREEN_LINES} lines → green`);
+  const over = {
+    kind: 'fix',
+    files: [{ path: 'src/launcher/rouge-loop.js', added_lines: MAX_GREEN_LINES + 1, removed_lines: 0 }],
+  };
+  assert(classifyPlan(over).zone === 'yellow', 'one line over → yellow');
+}
+
+function testMultiFileIsYellow() {
+  const plan = {
+    kind: 'multi-file-fix',
+    files: [
+      { path: 'src/launcher/rouge-loop.js', added_lines: 1, removed_lines: 0 },
+      { path: 'src/launcher/cost-tracker.js', added_lines: 1, removed_lines: 0 },
+    ],
+  };
+  const result = classifyPlan(plan);
+  assert(result.zone === 'yellow', 'multi-file → yellow (even if all green-zone paths)');
+}
+
+function testNonLauncherJsIsYellow() {
+  const plan = {
+    kind: 'fix',
+    files: [{ path: 'dashboard/src/bridge/seed-handler.ts', added_lines: 1, removed_lines: 0 }],
+  };
+  const result = classifyPlan(plan);
+  assert(result.zone === 'yellow', 'non-src/launcher/*.js files → yellow');
+}
+
+function testEmptyPlanIsRed() {
+  const result = classifyPlan({ files: [] });
+  assert(result.zone === 'red', 'empty plan → red (refuse)');
+  const result2 = classifyPlan(null);
+  assert(result2.zone === 'red', 'null plan → red (refuse)');
+}
+
+function testCiWorkflowIsRed() {
+  const plan = {
+    kind: 'fix-ci',
+    files: [{ path: '.github/workflows/test.yml', added_lines: 3, removed_lines: 0 }],
+  };
+  const result = classifyPlan(plan);
+  assert(result.zone === 'red', '.github/workflows/ → red');
+}
+
+function testPathNormalisation() {
+  // Leading ./ shouldn't cause misclassification.
+  const plan = {
+    kind: 'fix',
+    files: [{ path: './src/launcher/safety.js', added_lines: 1, removed_lines: 0 }],
+  };
+  const result = classifyPlan(plan);
+  assert(result.zone === 'red', 'leading ./ still matches red list');
+}
+
+function main() {
+  console.log('self-heal-zones enforcement');
+  testSimpleLauncherFixIsGreen();
+  testSafetyModuleRedZone();
+  testPromptChangeIsRed();
+  testSchemaChangeIsYellow();
+  testLibraryIntegrationIsYellow();
+  testDashboardChangeIsYellow();
+  testLargeChangeIsYellow();
+  testBoundaryAtMaxGreenLines();
+  testMultiFileIsYellow();
+  testNonLauncherJsIsYellow();
+  testEmptyPlanIsRed();
+  testCiWorkflowIsRed();
+  testPathNormalisation();
+  console.log(`  ${checks} checks, ${failures} failures`);
+  if (failures > 0) {
+    console.error('FAIL');
+    process.exit(1);
+  }
+  console.log('PASS');
+}
+
+main();

--- a/tests/spin-detector.test.js
+++ b/tests/spin-detector.test.js
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+/**
+ * Tests for src/launcher/spin-detector.js
+ *
+ * Covers the end-to-end record-and-detect path that Wave-2's triage
+ * classifier relies on. The fingerprint helper itself has its own
+ * test file; this one tests the JSONL layer and spin detection.
+ *
+ * Usage: node tests/spin-detector.test.js
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { recordFingerprint, detectSpin, recordAndCheck, readRecent } = require('../src/launcher/spin-detector.js');
+
+let failures = 0;
+let checks = 0;
+
+function assert(condition, message) {
+  checks++;
+  if (!condition) {
+    failures++;
+    console.error(`  ✗ ${message}`);
+  }
+}
+
+function makeTempProject() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'spin-'));
+}
+
+function cleanup(dir) {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+function testFirstFingerprintNoSpin() {
+  const dir = makeTempProject();
+  try {
+    const report = { verdict: 'FAIL', findings: ['schema missing'] };
+    const result = recordAndCheck(dir, 'foundation-eval', report);
+    assert(result.fingerprint.length === 64, 'fingerprint is sha256 hex');
+    assert(result.isSpin === false, 'first fingerprint is never spin');
+  } finally { cleanup(dir); }
+}
+
+function testThreeIdenticalFingerprintsTripsSpin() {
+  const dir = makeTempProject();
+  try {
+    const report = { verdict: 'FAIL', findings: ['schema missing'] };
+    const r1 = recordAndCheck(dir, 'foundation-eval', report);
+    const r2 = recordAndCheck(dir, 'foundation-eval', report);
+    const r3 = recordAndCheck(dir, 'foundation-eval', report);
+    assert(r1.isSpin === false, 'cycle 1: no spin');
+    assert(r2.isSpin === false, 'cycle 2: no spin');
+    assert(r3.isSpin === true, 'cycle 3: spin detected on 3rd identical');
+  } finally { cleanup(dir); }
+}
+
+function testDriftingFindingsResetSpin() {
+  const dir = makeTempProject();
+  try {
+    const a = { verdict: 'FAIL', findings: ['schema missing'] };
+    const b = { verdict: 'FAIL', findings: ['auth broken'] };
+    recordAndCheck(dir, 'foundation-eval', a);
+    recordAndCheck(dir, 'foundation-eval', a);
+    const r3 = recordAndCheck(dir, 'foundation-eval', b);
+    assert(r3.isSpin === false, 'tail differs → spin not detected');
+  } finally { cleanup(dir); }
+}
+
+function testPerPhaseIsolation() {
+  const dir = makeTempProject();
+  try {
+    const same = { verdict: 'FAIL', findings: ['x'] };
+    recordAndCheck(dir, 'foundation-eval', same);
+    recordAndCheck(dir, 'foundation-eval', same);
+    // Interleave a milestone-check write — should NOT affect
+    // foundation-eval's tail.
+    recordAndCheck(dir, 'milestone-check', same);
+    const r3 = recordAndCheck(dir, 'foundation-eval', same);
+    assert(r3.isSpin === true, 'foundation-eval tail unaffected by milestone-check writes');
+    // milestone-check itself has only 1 fingerprint → no spin yet.
+    assert(detectSpin(dir, 'milestone-check', 3) === false, 'milestone-check: 1 entry ≠ spin');
+  } finally { cleanup(dir); }
+}
+
+function testCustomThreshold() {
+  const dir = makeTempProject();
+  try {
+    const same = { verdict: 'NEEDS_IMPROVEMENT', findings: ['x'] };
+    const r1 = recordAndCheck(dir, 'po-review', same, { threshold: 2 });
+    const r2 = recordAndCheck(dir, 'po-review', same, { threshold: 2 });
+    assert(r1.isSpin === false, 'threshold=2, cycle 1: no spin');
+    assert(r2.isSpin === true, 'threshold=2, cycle 2: spin detected');
+  } finally { cleanup(dir); }
+}
+
+function testMetaFieldsPersisted() {
+  const dir = makeTempProject();
+  try {
+    const report = { verdict: 'FAIL', findings: ['x'] };
+    recordAndCheck(dir, 'foundation-eval', report, { meta: { cycle_number: 42 } });
+    const recent = readRecent(dir, 'foundation-eval', 1);
+    assert(recent.length === 1, 'one entry recorded');
+    assert(recent[0].cycle_number === 42, 'meta field persisted');
+    assert(recent[0].verdict === 'FAIL', 'verdict extracted + uppercased');
+  } finally { cleanup(dir); }
+}
+
+function testMalformedFileDegradesGracefully() {
+  const dir = makeTempProject();
+  try {
+    // Write a deliberately-broken fingerprint file. detectSpin should
+    // skip the bad line, not crash.
+    fs.writeFileSync(path.join(dir, 'phase-fingerprints.jsonl'), 'not json\n');
+    const report = { verdict: 'FAIL', findings: ['x'] };
+    const r = recordAndCheck(dir, 'foundation-eval', report);
+    assert(r.fingerprint.length === 64, 'still produces fingerprint');
+    assert(r.isSpin === false, 'degrades to no-spin on malformed history');
+  } finally { cleanup(dir); }
+}
+
+function testEmptyReportHandled() {
+  const dir = makeTempProject();
+  try {
+    const r = recordAndCheck(dir, 'foundation-eval', null);
+    assert(r.fingerprint === '', 'null report → empty fingerprint');
+    assert(r.isSpin === false, 'null report never counts as spin');
+  } finally { cleanup(dir); }
+}
+
+function main() {
+  console.log('spin-detector');
+  testFirstFingerprintNoSpin();
+  testThreeIdenticalFingerprintsTripsSpin();
+  testDriftingFindingsResetSpin();
+  testPerPhaseIsolation();
+  testCustomThreshold();
+  testMetaFieldsPersisted();
+  testMalformedFileDegradesGracefully();
+  testEmptyReportHandled();
+  console.log(`  ${checks} checks, ${failures} failures`);
+  if (failures > 0) {
+    console.error('FAIL');
+    process.exit(1);
+  }
+  console.log('PASS');
+}
+
+main();

--- a/tests/triage.test.js
+++ b/tests/triage.test.js
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+/**
+ * Tests for src/launcher/triage.js
+ *
+ * Confirms each classification rule fires on the right signal shape
+ * and the default bucket catches unclassified cases. Uses a temp
+ * project directory so tests don't depend on real Rouge projects.
+ *
+ * Usage: node tests/triage.test.js
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { classify, CLASSES, detectSchemaViolation } = require('../src/launcher/triage.js');
+const { recordAndCheck } = require('../src/launcher/spin-detector.js');
+
+let failures = 0;
+let checks = 0;
+
+function assert(condition, message) {
+  checks++;
+  if (!condition) {
+    failures++;
+    console.error(`  ✗ ${message}`);
+  }
+}
+
+function makeTempProject() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'triage-'));
+}
+
+function cleanup(dir) {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+function writeSchemaViolationLog(dir, count) {
+  const line = `[2026-04-22T00:00:00Z] [schema:state.json] write /path/state.json: /foundation/status must be equal to one of the allowed values\n`;
+  fs.writeFileSync(path.join(dir, 'build.log'), line.repeat(count));
+}
+
+function testSchemaViolationBecomesSelfHealCandidate() {
+  const dir = makeTempProject();
+  try {
+    writeSchemaViolationLog(dir, 5);
+    const result = classify({ projectDir: dir, phase: 'foundation-eval' });
+    assert(result.class === CLASSES.SELF_HEAL_CANDIDATE, 'schema violation → self-heal-candidate');
+    assert(result.evidence.kind === 'schema-enum-drift', 'evidence kind recorded');
+    assert(result.evidence.occurrences === 5, 'occurrence count captured');
+    assert(result.evidence.instance_path === '/foundation/status', 'instance path parsed');
+  } finally { cleanup(dir); }
+}
+
+function testSingleSchemaWarnIsNotEnough() {
+  const dir = makeTempProject();
+  try {
+    writeSchemaViolationLog(dir, 1);
+    const schema = detectSchemaViolation(dir);
+    assert(schema === null, 'single warn line is not enough to classify');
+  } finally { cleanup(dir); }
+}
+
+function testIdenticalFoundationEvalIsSelfHeal() {
+  const dir = makeTempProject();
+  try {
+    // No schema violation in log — pure fingerprint spin.
+    const report = { verdict: 'FAIL', findings: ['schema missing user table'] };
+    recordAndCheck(dir, 'foundation-eval', report);
+    recordAndCheck(dir, 'foundation-eval', report);
+    recordAndCheck(dir, 'foundation-eval', report);
+    const result = classify({ projectDir: dir, phase: 'foundation-eval' });
+    assert(result.class === CLASSES.SELF_HEAL_CANDIDATE, 'identical foundation-eval → self-heal');
+    assert(result.evidence.kind === 'identical-foundation-eval', 'evidence kind matches');
+  } finally { cleanup(dir); }
+}
+
+function testIdenticalMilestoneCheckIsHumanJudgment() {
+  const dir = makeTempProject();
+  try {
+    const report = { verdict: 'NEEDS_IMPROVEMENT', findings: ['empty states missing'] };
+    recordAndCheck(dir, 'milestone-check', report);
+    recordAndCheck(dir, 'milestone-check', report);
+    recordAndCheck(dir, 'milestone-check', report);
+    const result = classify({ projectDir: dir, phase: 'milestone-check' });
+    assert(result.class === CLASSES.HUMAN_JUDGMENT_NEEDED, 'identical milestone-check → human-judgment');
+    assert(result.evidence.verdict === 'NEEDS_IMPROVEMENT', 'verdict preserved');
+  } finally { cleanup(dir); }
+}
+
+function testInfrastructureGapIsMechanicalAutomation() {
+  const dir = makeTempProject();
+  try {
+    const result = classify({
+      projectDir: dir,
+      escalation: { id: 'esc-123', classification: 'infrastructure-gap' },
+    });
+    assert(result.class === CLASSES.MECHANICAL_AUTOMATION_MISSING, 'infrastructure-gap → mechanical-automation-missing');
+  } finally { cleanup(dir); }
+}
+
+function testUnclassifiedFallsThrough() {
+  const dir = makeTempProject();
+  try {
+    const result = classify({ projectDir: dir });
+    assert(result.class === CLASSES.UNKNOWN, 'no signal → unknown');
+  } finally { cleanup(dir); }
+}
+
+function testNoProjectDirIsUnknown() {
+  const result = classify({});
+  assert(result.class === CLASSES.UNKNOWN, 'missing projectDir → unknown');
+}
+
+function testSchemaViolationTakesPrecedenceOverFingerprintSpin() {
+  // If both conditions exist, schema violation is the stronger signal —
+  // it points directly at the fix. We should classify self-heal with
+  // schema-enum-drift evidence, not identical-foundation-eval.
+  const dir = makeTempProject();
+  try {
+    writeSchemaViolationLog(dir, 5);
+    const report = { verdict: 'FAIL', findings: ['anything'] };
+    recordAndCheck(dir, 'foundation-eval', report);
+    recordAndCheck(dir, 'foundation-eval', report);
+    recordAndCheck(dir, 'foundation-eval', report);
+    const result = classify({ projectDir: dir, phase: 'foundation-eval' });
+    assert(result.class === CLASSES.SELF_HEAL_CANDIDATE, 'still self-heal');
+    assert(result.evidence.kind === 'schema-enum-drift', 'schema evidence wins over fingerprint spin');
+  } finally { cleanup(dir); }
+}
+
+function main() {
+  console.log('triage classifier');
+  testSchemaViolationBecomesSelfHealCandidate();
+  testSingleSchemaWarnIsNotEnough();
+  testIdenticalFoundationEvalIsSelfHeal();
+  testIdenticalMilestoneCheckIsHumanJudgment();
+  testInfrastructureGapIsMechanicalAutomation();
+  testUnclassifiedFallsThrough();
+  testNoProjectDirIsUnknown();
+  testSchemaViolationTakesPrecedenceOverFingerprintSpin();
+  console.log(`  ${checks} checks, ${failures} failures`);
+  if (failures > 0) {
+    console.error('FAIL');
+    process.exit(1);
+  }
+  console.log('PASS');
+}
+
+main();


### PR DESCRIPTION
## Summary

Implements the full plan at `docs/plans/2026-04-22-self-heal-and-triage.md` — four waves, one branch. Replaces the "every stuck loop is an escalation to the human" model with triage-aware routing:

- **Rouge's own code is buggy** → self-heal auto-applies (green-zone) or drafts a PR (yellow-zone)
- **Product taste call** → 1-bit escalation at cycle 3, not cycle 87
- **Missing automation** → catalog draft PR
- **Ambiguous** → conservative human escalation

## What landed

**Wave 1 — contracts:**
- Schema enum fix for `foundation.status='evaluating'` (stack-rank root cause)
- CI invariant: acorn-walks every launcher `.js` for literal-string assignments to enum-constrained state paths
- Strict-mode schema validator; state.json writes enforce, cycle_context/task_ledger stay warn pending separate reconciliation
- Findings-fingerprint helper (deterministic SHA-256, ignores transient fields)
- Integration-manifest schema (`schemas/integration-manifest.json`)
- Checkpoint proliferation fix — `advanceState` no longer writes on no-op ticks

**Wave 2 — consume contracts:**
- Semantic-spin detector (`phase-fingerprints.jsonl` + 3-identical trigger), wired into foundation-eval + milestone-check
- Four deploy-target manifests (github-pages, vercel, cloudflare-pages, docker-compose)
- `integration-catalog.js` with prerequisites + auto_remediate + first-deploy grace health-checks
- `deployGithubPages` now catalog-driven — GH Pages auto-enable + CDN propagation wait live in the manifest, not hardcoded
- Secrets unified: provisioner merges from Rouge's keychain store at startup; target-aware infrastructure-gap escalation message
- Cost-tracker splits real vs estimated; cap enforcement uses real only so heuristic inflation can't trip it

**Wave 3 — triage + self-heal:**
- `triage.js` — 4-class rule-based classifier (no LLM)
- `self-heal-planner.js` — AST-finds the offending assignment, proposes bounded fix
- `self-heal-zones.js` — green/yellow/red with 29 adversarial tests
- `self-heal-applier.js` — branch + patch + test + commit or revert, full audit trail
- `rouge.config.json` kill switch (`self_heal.enabled`, `self_heal.zones`)
- `rouge doctor` surfaces self-heal activity

**Wave 4 — observability:**
- `health-report.js` + `rouge health [--json]` — fleet-wide stuck-loop + escalation-trend view

## Test plan

- [x] 458 existing launcher tests pass (`ROUGE_SKIP_CLI_TESTS=1`)
- [x] 178 new unit-test assertions across 12 new test files (see plan doc for matrix)
- [x] `rouge health` smoke-tested against the 10 real projects — surfaces stack-rank / testimonial / irish-planning / uat-test escalations with the right classifications
- [ ] End-to-end fixture test (intentionally-broken project → self-heal applies a real green-zone fix) — deferred to a follow-up; red/yellow zone paths are fully covered in unit tests

## Notes

- The kill switch defaults to `enabled: true, zones: ['green']`. Operator can flip to `enabled: false` to disable the whole subsystem, or `zones: []` to keep classification active but never apply.
- Every self-heal action goes to `~/.rouge/audit-log.jsonl` (chmod 600) via the existing `audit-trail.js` pattern.
- Green-zone applies commit to a dedicated `rouge-self-heal/<ts>-<slug>` branch; on test failure the applier checks out the starting branch and deletes the self-heal branch — nothing auto-merges to main.
- PR #199 and PR #200 are superseded by this branch; the same concerns (spec-discipline strictness, github-pages auto-enable, docs sweep) are handled here via the catalog + invariant tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)