### PR TITLE
chore(phase-11): closeout — V2 doc deprecation banners + audit findings

### DIFF
--- a/docs/design/grand-unified-reconciliation.md
+++ b/docs/design/grand-unified-reconciliation.md
@@ -775,14 +775,33 @@ should be driven by dogfood signal — the GUI affordances people
 actually want, not a checklist swept through. Default per the plan:
 keep CLI-only unless GUI affordance is obviously valuable.
 
-**Phase 11 deferral note.** The plan called for removing the legacy
-`.rouge/state.json` back-compat path (gated on V3 in the wild for
-≥ 90 days), removing `seeding-state.json` if folded into
-`task_ledger.json`, and removing v1/v2 design docs. Each of these
-needs a project-by-project audit (no in-the-wild legacy state files
-remaining, schema fully migrated, no live references to v2 docs).
-Doing this safely warrants a separate PR with explicit before/after
-checks per item.
+**Phase 11 closeout (post-audit).** The plan called for three
+deletions; the audit found none of them are clean delete candidates:
+
+- *Legacy `state.json` (root) back-compat path*: still needed.
+  `state-path.js`'s fallback handles unmigrated projects; removing it
+  would break any user with a pre-V3 project who hasn't run
+  `migrate-state-to-rouge-dir.js`. The audit can only verify the
+  local machine, not the wild. Conservative: leave the fallback in
+  place. Re-evaluate after a release where ≥90 days of dogfood show
+  no legacy state files arriving.
+
+- *`seeding-state.json` fold into `task_ledger.json`*: contingent on
+  a not-yet-done migration. 18 active references across `src/` and
+  `dashboard/src/`; the file isn't vestigial, it's load-bearing.
+  Folding it is a separate design effort, not Phase 11 cleanup.
+
+- *V1/V2 design docs*: explicitly preserved as historical reference
+  by the V3 plans (`docs/plans/2026-04-04-v3-execution-plan.md` says
+  "Keep `state-schema-v2.md` and `state-machine-v2-transitions.md`
+  as historical reference"). `state-schema-v3.md` actively cites
+  `state-schema-v2.md` § global_improvements. Deleting them would
+  break inbound links and lose context. Done in this PR: added
+  deprecation banners to the three V2 docs so readers see they're
+  superseded at a glance, without losing the content.
+
+Phase 11 closeout: docs deprecation banners only. The deletion items
+deferred for cause, not for laziness.
 
 **What's now architecturally hard.** The 10/10 commitments from the
 plan-eng-review are all in place:

--- a/docs/design/state-machine-v2-transitions.md
+++ b/docs/design/state-machine-v2-transitions.md
@@ -1,5 +1,7 @@
 # V2 State Machine — Complete Transition Map
 
+> ⚠️ **Historical reference (V2).** Superseded by [`state-machine-v3-transitions.md`](state-machine-v3-transitions.md). Kept as background context for the V2→V3 transition history. New work should reference the V3 doc.
+
 > Generated from code analysis of `src/launcher/rouge-loop.js`. Use this to produce diagrams.
 
 ## States

--- a/docs/design/state-schema-v2.md
+++ b/docs/design/state-schema-v2.md
@@ -1,5 +1,7 @@
 # State Schema V2
 
+> ⚠️ **Historical reference (V2).** Superseded by [`state-schema-v3.md`](state-schema-v3.md). Still cited by the V3 doc for the `global_improvements.json` shape (§ global_improvements), which carries forward unchanged. New work should reference the V3 doc; this file remains for the cross-reference and for V2→V3 transition history.
+
 > Canonical schema reference for the V2 granularity refactor. All launcher code and prompts reference this document.
 
 **Supersedes:** The state.json schema documented in `docs/architecture.md` (V1).

--- a/docs/design/v2-process-map.md
+++ b/docs/design/v2-process-map.md
@@ -1,5 +1,7 @@
 # V2 Process Map — End-to-End Pipeline
 
+> ⚠️ **Historical reference (V2).** Pre-V3 process map. Most of the pipeline shape carried forward to V3 with the additions documented in `state-machine-v3-transitions.md` (cost tracking, spin detection, capability checks, harness PoC, facade boundary). Read this for the V2 baseline before the reconciliation; read the V3 docs for current behavior.
+
 > Every process step, artifact, input, output, and transformation from first spec input through final delivered product. Use this as the source of truth for reviewing the pipeline and generating Excalidraw diagrams.
 >
 > Generated: 2026-04-03. Supersedes the V1 flow diagram at `docs/plans/2026-03-17-rouge-flow-diagram.md`.


### PR DESCRIPTION
## Summary

Phase 11 of the grand unified reconciliation called for three deletions. The audit found none are clean delete candidates today:

1. **Legacy `<projectDir>/state.json` (root) back-compat path** — still needed. `state-path.js` falls back to it for unmigrated projects. Removing would break any pre-V3 project that hasn't run `migrate-state-to-rouge-dir.js`.
2. **`seeding-state.json` fold into `task_ledger.json`** — contingent on a not-yet-done migration. 18 active references; the file is load-bearing, not vestigial.
3. **V1/V2 design docs** — explicitly preserved by older plans as historical reference. `state-schema-v3.md` actively cites `state-schema-v2.md` § global_improvements.

**What this PR does instead** — light-touch:

- Deprecation banners on `state-machine-v2-transitions.md`, `state-schema-v2.md`, `v2-process-map.md` so readers see "historical V2" at a glance and follow the link to V3.
- Updates the reconciliation plan's Phase 11 section to record the audit findings: deletion deferred *for cause*, not laziness, with per-item re-evaluation triggers.

No code changes; no test impact. Pure docs.

## Test plan

- [x] No code touched; existing CI suffices to confirm no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)