### PR TITLE
feat(dashboard): Phase 10 — feasibility API + CLI-vs-dashboard inventory

### DIFF
--- a/dashboard/src/app/api/__tests__/feasibility.test.ts
+++ b/dashboard/src/app/api/__tests__/feasibility.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from 'vitest'
+
+// assertLoopback() reads next/server `headers()` which only exists
+// inside a Next request scope. Unit tests run outside that scope, so
+// we stub the guard to always allow.
+vi.mock('@/lib/localhost-guard', () => ({
+  assertLoopback: async () => null,
+}))
+
+import { POST } from '../feasibility/route'
+
+function makeRequest(body: unknown): Request {
+  return new Request('http://localhost/api/feasibility', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+function makeBadJsonRequest(): Request {
+  return new Request('http://localhost/api/feasibility', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: '{ this is not json',
+  })
+}
+
+describe('POST /api/feasibility', () => {
+  it('returns 400 when body is not valid JSON', async () => {
+    const res = await POST(makeBadJsonRequest())
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.error).toMatch(/invalid JSON/i)
+  })
+
+  it('returns 400 when title is missing', async () => {
+    const res = await POST(makeRequest({ description: 'no title' }))
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.error).toMatch(/title.*required/i)
+  })
+
+  it('returns 400 when title is empty string', async () => {
+    const res = await POST(makeRequest({ title: '   ' }))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns a feasibility result for a valid proposal', async () => {
+    const res = await POST(
+      makeRequest({
+        title: 'Add a Stripe checkout flow',
+        description: 'Standard one-time payment with webhook',
+      }),
+    )
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    // Shape contract — these four fields must always be present for the dashboard
+    // UI to render without conditional fallbacks.
+    expect(body).toHaveProperty('verdict')
+    expect(['proceed', 'proceed-with-caveats', 'escalate', 'defer']).toContain(body.verdict)
+    expect(body).toHaveProperty('reasoning')
+    expect(typeof body.reasoning).toBe('string')
+    expect(Array.isArray(body.checks)).toBe(true)
+    expect(Array.isArray(body.missing)).toBe(true)
+  })
+})

--- a/dashboard/src/app/api/feasibility/route.ts
+++ b/dashboard/src/app/api/feasibility/route.ts
@@ -1,0 +1,96 @@
+/**
+ * POST /api/feasibility — assess whether Rouge can take on a proposed
+ * change.
+ *
+ * Phase 10 of the grand unified reconciliation. The `rouge feasibility`
+ * CLI command runs `src/launcher/feasibility.js`'s `assess()` against
+ * a proposal description. This route surfaces the same capability via
+ * HTTP so the dashboard (or any HTTP client on the loopback interface)
+ * can pre-flight a build before kicking off the loop.
+ *
+ * The actual UI for feasibility is dogfood-driven follow-up. This
+ * route is the API foundation; once the dashboard team knows what
+ * UX the affordance needs, the React component is a small addition.
+ *
+ * Request body:
+ *   {
+ *     "title": "Add Stripe checkout flow",
+ *     "description": "..." (optional)
+ *   }
+ *
+ * Response 200:
+ *   {
+ *     "verdict": "proceed" | "proceed-with-caveats" | "escalate" | "defer",
+ *     "reasoning": "...",
+ *     "checks": [{ name, status, detail }],
+ *     "missing": [string]
+ *   }
+ *
+ * Response 400 on missing/malformed body. Response 500 on assess() error.
+ *
+ * Localhost-guarded — the launcher's feasibility.js reads
+ * rouge-vision.json and runs subprocess probes for tool installation;
+ * we don't expose that to the open internet.
+ */
+import { NextResponse } from 'next/server'
+import { assertLoopback } from '@/lib/localhost-guard'
+import { sanitizedErrorResponse } from '@/lib/error-response'
+
+export const dynamic = 'force-dynamic'
+
+interface FeasibilityProposal {
+  title: string
+  description?: string
+}
+
+interface FeasibilityCheck {
+  name: string
+  status: string
+  detail: string
+}
+
+interface FeasibilityResult {
+  verdict: 'proceed' | 'proceed-with-caveats' | 'escalate' | 'defer'
+  reasoning: string
+  checks: FeasibilityCheck[]
+  missing: string[]
+}
+
+interface FeasibilityModule {
+  assess(proposal: FeasibilityProposal): FeasibilityResult
+}
+
+export async function POST(req: Request): Promise<NextResponse> {
+  const guard = await assertLoopback()
+  if (guard) return guard
+
+  let body: unknown
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json(
+      { error: 'invalid JSON body' },
+      { status: 400 },
+    )
+  }
+
+  const proposal = body as Partial<FeasibilityProposal>
+  if (!proposal || typeof proposal.title !== 'string' || proposal.title.trim() === '') {
+    return NextResponse.json(
+      { error: 'proposal.title (string) is required' },
+      { status: 400 },
+    )
+  }
+
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const feasibility = require('../../../../../src/launcher/feasibility.js') as FeasibilityModule
+    const result = feasibility.assess({
+      title: proposal.title,
+      description: proposal.description,
+    })
+    return NextResponse.json(result)
+  } catch (err) {
+    return sanitizedErrorResponse(err, 'feasibility.assess failed')
+  }
+}

--- a/docs/design/cli-vs-dashboard-surfaces.md
+++ b/docs/design/cli-vs-dashboard-surfaces.md
@@ -1,0 +1,55 @@
+# CLI vs Dashboard Surfaces
+
+**Status:** living document. Updated 2026-04-25 as Phase 10 of the grand unified reconciliation closeout.
+
+This doc records the deliberate split between commands that have a dashboard equivalent and commands that stay CLI-only. Per Fork A (hybrid), Rouge keeps both surfaces; per Phase 10's deferred-by-default rule, dashboard equivalents are added only when the GUI affordance is obviously valuable, not as a checklist sweep.
+
+## Both surfaces
+
+Commands that have a UX in both the dashboard AND the CLI. The dashboard is the canonical onboarding; the CLI is the automation surface.
+
+| Command | Dashboard route | Why it has both |
+|---|---|---|
+| `rouge init <name>` | `New Project` button + `POST /api/projects` | Project creation is core flow; both surfaces matter for new users vs. scripted setup. |
+| `rouge seed <name> "<msg>"` | Seeding chat panel | Interactive seeding is the primary use case; CLI exists for re-seed automation. |
+| `rouge build [name]` | `Start Build` button + `POST /api/projects/[name]/start-build` | Triggering the loop is the most-used action in both. |
+| `rouge status` | Project list + per-project detail | Primary "what's happening" surface for the GUI. |
+| `rouge cost` | Per-project cost card | Always visible in the dashboard; CLI useful for quick check or scripts. |
+| `rouge dashboard start/stop` | Self-referential — controls the dashboard daemon | CLI by definition (you can't start the dashboard from itself). |
+| `rouge resume-escalation <slug>` | `Resolve Escalation` panel | Both: dashboard owns the common case; CLI hand-off mode primes a Claude Code session. |
+| `rouge setup <integration>` | `Integrations` settings panel | Setup wizard fits both surfaces. |
+| `rouge slack start/test` | `Slack` settings panel | Slack notifications are operator-facing — surface in both. |
+
+**New in this PR:** `rouge feasibility "<description>"` now has a dashboard API counterpart at `POST /api/feasibility`. The React UI for it is dogfood-driven follow-up; the API is the foundation so when the UI lands it's a small addition, not a backend redesign.
+
+## CLI-only by design
+
+Commands where a dashboard equivalent would be theatre — niche developer tools, CI/release tooling, or one-shot internal commands. Documenting the rationale here so future cleanups know not to add a UI just because the inventory said so.
+
+| Command | Why CLI-only |
+|---|---|
+| `rouge contribute <path>` | Niche developer command: opens a draft PR for a community-contributed integration pattern. Used by ~one human per quarter. UI overhead exceeds value. |
+| `rouge improve [--max-iterations N]` | Internal Rouge management — runs the self-improvement loop against open issues. Operator-only; dashboard surface would be confusing for end users. |
+| `rouge eval-calibrate` | CI/release tooling — gates the gold-set calibration on quadratic-weighted Kappa. Run from CI workflow, not by humans. |
+| `rouge eval-seed-gold` | CI/release tooling — regenerates the synthetic gold set. Same audience as eval-calibrate. |
+| `rouge size-project` | SIZING sub-phase driver — invoked programmatically by the seeding orchestrator, not by humans. |
+| `rouge harness probe` | Test/debug tool for the SDK harness adapter. Used by Rouge developers, not end users. |
+| `rouge secrets list` | Trivially supplanted by the dashboard `Integrations` panel which shows the same data. CLI kept for terminal users. |
+| `rouge secrets check <project>` | One-shot diagnostic — operator runs it, reads output, moves on. UI affordance unnecessary. |
+| `rouge secrets validate <integration>` | CI/CD hook — validates the keychain entries match the catalogue. Not an interactive flow. |
+| `rouge secrets expiry [list/set]` | Operator housekeeping — surfaces secrets with expiry windows. Could be added to the dashboard if dogfood signal asks; not obviously valuable today. |
+| `rouge doctor` | Operator diagnostic — full system health check including catalogue + MCP + auth. Run on demand from terminal. |
+| `rouge feasibility` | CLI persists; the new `POST /api/feasibility` route is the dashboard counterpart for when the UI is built. |
+
+## Adding a dashboard equivalent later
+
+When dogfood signal proves a CLI-only command actually wants a dashboard surface:
+
+1. Add the API route under `dashboard/src/app/api/<command>/route.ts`.
+2. Use `assertLoopback()` for guard, `sanitizedErrorResponse()` for errors.
+3. Wrap the existing `src/launcher/<module>.js` export rather than reimplementing logic.
+4. Add a unit test under `dashboard/src/app/api/__tests__/`.
+5. Move the entry from `CLI-only by design` to `Both surfaces` in this doc with the new route + rationale.
+6. Commit the React component for the actual UI in a separate PR — the API is reusable; the UI is taste-driven.
+
+The point of keeping both surfaces is automation parity — anything you can do in the dashboard, you can script. Anything you can script, you can also point a human at if it makes sense. The split above is the working answer to "which side should this live on?" not a permanent fence.


### PR DESCRIPTION
## Summary

#6 from the post-reconciliation queue. Phase 10's "dashboard parity for CLI-only commands" — but per the plan, scoped to the one command that's clearly worth surfacing today plus an inventory of what stays CLI-only and why.

**What this PR adds:**

- `POST /api/feasibility` — wraps `src/launcher/feasibility.js`'s `assess()` so the dashboard (or any HTTP client on loopback) can pre-flight a build before kicking the loop. Same { verdict, reasoning, checks, missing } shape as the CLI returns. `assertLoopback()` guard; `sanitizedErrorResponse()` on faults.

- 4 unit tests for the route covering invalid JSON, missing title, empty title, valid proposal.

- `docs/design/cli-vs-dashboard-surfaces.md` — living inventory of which commands have both surfaces (init, seed, build, status, cost, etc.) vs. CLI-only by design (contribute, improve, eval-calibrate, harness probe, secrets validate/expiry, doctor) with rationale per command. Includes a "Adding a dashboard equivalent later" recipe so future additions follow one pattern.

**What's intentionally NOT in this PR:** the feasibility React UI. Per the Phase 10 deferral logic, UI affordance choices should be driven by dogfood signal (what users actually want to see, where, how), not a sweep through the inventory. The API foundation means that when the UI lands it's a small frontend addition, not a backend redesign.

## Test plan

- [x] Launcher: 1975/1976 pass (1 documented flake)
- [x] Dashboard: 481/481 pass (4 new feasibility-route tests)
- [x] TypeScript: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)