### PR TITLE
feat(types): gen:facade-types snapshot + drift CI gate

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -14,7 +14,11 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+      - name: Install root deps (typescript needed by gen:facade-types)
+        run: npm ci
       - name: Link + command check
         run: node scripts/check-docs.js
       - name: CLI reference in sync
         run: node scripts/generate-cli-reference.js --check
+      - name: Facade types snapshot in sync
+        run: node scripts/gen-facade-types.mjs --check

--- a/dashboard/src/types/facade.snapshot.d.ts
+++ b/dashboard/src/types/facade.snapshot.d.ts
@@ -1,0 +1,154 @@
+/**
+ * AUTO-GENERATED snapshot of the JSDoc-derived facade shape.
+ *
+ * Source: src/launcher/facade.js + facade/lock.js + facade/events.js.
+ * Generator: scripts/gen-facade-types.mjs.
+ *
+ * DO NOT EDIT BY HAND. Run `bun run gen:facade-types` to refresh.
+ * CI runs `bun run gen:facade-types -- --check` to detect drift.
+ *
+ * This file is the drift-detector. The dashboard imports from
+ * facade.d.ts (hand-authored named interfaces); when this snapshot
+ * disagrees with the JSDoc on the launcher facade, CI fails and a
+ * reviewer decides whether to update facade.d.ts to match.
+ */
+
+// ----- from src/launcher/facade.d.ts -----
+/**
+ * Atomic read-modify-write of state.json with event emission.
+ *
+ * @param {object} opts
+ *   - projectDir: required, absolute path
+ *   - mutator: (state) => state | void — applied in-place or returns new state
+ *   - source: required, one of VALID_SOURCES
+ *   - eventDetail: optional payload for the emitted 'state.write' event
+ *   - timeoutMs: lock timeout (default 5000)
+ *   - allowSlow: skip the slow-mutator guard
+ *   - validate: set to false to bypass strict schema validation (tests / migrations)
+ * @returns {Promise<{state: object, event: object}>}
+ */
+export function writeState(opts: object): Promise<{
+    state: object;
+    event: object;
+}>;
+/**
+ * Read the current state without locking (atomic byte-level write
+ * already protects readers).
+ */
+export function readState(projectDir: any): any;
+/**
+ * Dispatch an AI phase invocation. Long-running — does NOT hold the
+ * state lock. Emits phase.start / phase.end events.
+ *
+ * @param {object} opts
+ *   - projectDir: required
+ *   - phase: required, the phase id (e.g. 'loop.building')
+ *   - mode: 'subprocess' | 'sdk' (required)
+ *   - prompt: text passed to the dispatch strategy
+ *   - source: required
+ *   - dispatchOpts: forwarded to the chosen strategy
+ *   - signal: AbortSignal forwarded to the strategy
+ * @returns {Promise<{ result, startEvent, endEvent }>}
+ */
+export function runPhase(opts: object): Promise<{
+    result: any;
+    startEvent: any;
+    endEvent: any;
+}>;
+import { emit } from "./facade/events.js";
+import { readEvents } from "./facade/events.js";
+import { subscribeEvents } from "./facade/events.js";
+import { eventsPath } from "./facade/events.js";
+export const VALID_SOURCES: Set<string>;
+export const VALID_MODES: Set<string>;
+export { emit, readEvents, subscribeEvents, eventsPath };
+
+// ----- from src/launcher/facade/lock.d.ts -----
+/**
+ * Acquire the per-project state lock.
+ *
+ * @param {string} projectDir
+ * @param {object} [opts]
+ *   - timeoutMs: max time to wait (default 5000)
+ * @returns {Promise<() => void>} release function. Always release in finally.
+ */
+export function acquireLock(projectDir: string, opts?: object): Promise<() => void>;
+/**
+ * Run `fn` while holding the lock. Releases on normal return AND on throw.
+ *
+ * Mutator-duration guard (FORK E):
+ *   - In dev/test (NODE_ENV !== 'production'), throws if `fn` takes
+ *     longer than 100ms. The intended discipline is "mutator is a
+ *     synchronous in-memory transform" — anything slower means I/O
+ *     leaked into the critical section, which is the bug pattern this
+ *     guard catches.
+ *   - In production, logs a warning instead of throwing — a real edge
+ *     case at 3 AM oncall is worse than a slow mutator.
+ *   - Caller can opt out via `opts.allowSlow: true` for legitimate
+ *     long-running uses (e.g. one-shot migration scripts).
+ *
+ * @param {string} projectDir
+ * @param {Function} fn — the mutator. May be sync or async.
+ * @param {object} [opts]
+ *   - timeoutMs: lock acquire timeout
+ *   - allowSlow: skip the slow-mutator guard (default false)
+ * @returns {Promise<*>} fn's return value
+ */
+export function withLock(projectDir: string, fn: Function, opts?: object): Promise<any>;
+export function lockPath(projectDir: any): string;
+export const DEFAULT_TIMEOUT_MS: 5000;
+export const STALE_LOCK_MS: 30000;
+export const SLOW_MUTATOR_MS: 100;
+
+// ----- from src/launcher/facade/events.d.ts -----
+/**
+ * Emit one event to the project's event log.
+ *
+ * Atomic at the byte level (single write call). The file is opened in
+ * append mode so concurrent emitters from different processes
+ * interleave without overwriting each other (POSIX guarantees writes
+ * <= PIPE_BUF / 4096 bytes are atomic in append mode on local fs).
+ * Event payloads stay well under that.
+ *
+ * @param {object} opts
+ *   - projectDir: required
+ *   - source: 'loop' | 'cli' | 'dashboard' | 'slack' | 'self-improve' | 'test'
+ *   - event: short stable name like 'state.write', 'phase.start'
+ *   - detail: free-form object (must JSON-serialize)
+ */
+export function emit(opts: object): {
+    ts: string;
+    source: any;
+    event: any;
+    project: string;
+    detail: any;
+};
+/**
+ * Read the events file from a given byte offset onward.
+ *
+ * Returns { entries, nextOffset }. `nextOffset` is the byte position
+ * after the last fully-read entry — pass it back on the next call to
+ * avoid re-reading.
+ *
+ * Partial trailing line (writer in flight) is not returned in
+ * `entries`; the caller will pick it up on the next poll.
+ */
+export function readEvents(projectDir: any, fromOffset?: number): {
+    entries: any[];
+    nextOffset: number;
+};
+/**
+ * Async iterator that yields events as they arrive.
+ *
+ * Polls the file at `intervalMs` (default 250ms). The iterator never
+ * terminates on its own — caller breaks out with `return` or by
+ * passing an AbortSignal.
+ *
+ * @param {object} opts
+ *   - projectDir: required
+ *   - fromOffset: byte offset to start from (default 0)
+ *   - intervalMs: poll interval (default 250)
+ *   - signal: AbortSignal to terminate the iterator
+ */
+export function subscribeEvents(opts: object): AsyncGenerator<any, void, unknown>;
+export function eventsPath(projectDir: any): string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "rouge": "src/launcher/rouge-cli.js"
       },
       "devDependencies": {
-        "acorn": "^8.16.0"
+        "acorn": "^8.16.0",
+        "typescript": "^5.9.0"
       },
       "engines": {
         "node": ">=18"
@@ -1531,6 +1532,20 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -31,13 +31,16 @@
     "ajv": "^8.18.0"
   },
   "devDependencies": {
-    "acorn": "^8.16.0"
+    "acorn": "^8.16.0",
+    "typescript": "^5.9.0"
   },
   "scripts": {
     "test": "node tests/secrets.test.js && node tests/cli.test.js && node tests/self-improve.test.js && node tests/auth-mode.test.js && node tests/schema-assignments.test.js && node tests/schema-validator.test.js && node tests/findings-fingerprint.test.js && node tests/integration-manifest.test.js && node tests/spin-detector.test.js && node tests/integration-catalog.test.js && node tests/cost-tracker.test.js && node tests/triage.test.js && node tests/self-heal-zones.test.js && node tests/self-heal-planner.test.js && node tests/self-heal-applier.test.js && node tests/health-report.test.js && node tests/config-protection.test.js && node tests/mcp-health-check.test.js && node tests/variant-tracker.test.js && node tests/amendify.test.js && node tests/profile-loader.test.js && node tests/governance.test.js && node tests/structured-retro.test.js && node tests/persist-heuristic-runs.test.js && node tests/post-retrospective-hook.test.js && node tests/audit-recommender.test.js && node tests/finding-validator.test.js && node tests/capability-check.test.js && node tests/capability-check-runner.test.js && node tests/capability-check-flag.test.js && node tests/quote-match-validator.test.js && node tests/rubric-product-quality.test.js && node tests/doctor-mcp-check.test.js && node --test tests/gold-set-calibrator.test.js && node --test tests/gold-set-synth.test.js && node --test tests/eval-calibrate-cli.test.js && node --test tests/project-sizer.test.js && node --test tests/size-project-cli.test.js && node --test tests/discipline-registry.test.js && node --test tests/tier-defaults.test.js && bash tests/safety-check-config-protection.test.sh && node scripts/ci/validate-catalog.js && node scripts/ci/validate-mcp-configs.js && node scripts/ci/validate-profiles.js && node --test test/launcher/*.test.js test/launcher/harness/*.test.js test/launcher/facade/*.test.js test/prompts/*.test.js test/integration/*.test.js test/library/*.test.js",
     "test:all": "npm test && npm run dashboard:test",
     "test:boundaries": "node --test test/launcher/gc-boundaries.test.js test/launcher/self-improve-safety.test.js test/prompts/gc2-mcp-vs-cli-boundary.test.js",
     "test:boundaries:enforce": "ROUGE_BOUNDARY_ENFORCE=true node --test test/launcher/gc-boundaries.test.js test/launcher/self-improve-safety.test.js test/prompts/gc2-mcp-vs-cli-boundary.test.js",
+    "gen:facade-types": "node scripts/gen-facade-types.mjs",
+    "check:facade-types": "node scripts/gen-facade-types.mjs --check",
     "lint:catalog": "node scripts/ci/validate-catalog.js",
     "lint:md": "npx --yes markdownlint-cli \"**/*.md\" --ignore-path .markdownlintignore || true",
     "coverage": "npx --yes c8 --config .c8rc.json npm test",

--- a/scripts/gen-facade-types.mjs
+++ b/scripts/gen-facade-types.mjs
@@ -1,0 +1,194 @@
+#!/usr/bin/env node
+/**
+ * Snapshot the JSDoc-derived TypeScript shape of the launcher facade
+ * for drift detection.
+ *
+ * Two files coexist:
+ *
+ *   dashboard/src/types/facade.d.ts          — HAND-AUTHORED. The
+ *                                              dashboard-facing named
+ *                                              interfaces (Facade,
+ *                                              FacadeMode, etc.) the
+ *                                              bridge/facade.ts shim
+ *                                              imports.
+ *
+ *   dashboard/src/types/facade.snapshot.d.ts — AUTO-GENERATED. Captures
+ *                                              what the JSDoc on the
+ *                                              actual launcher facade
+ *                                              currently emits via tsc.
+ *                                              Committed so CI can
+ *                                              detect when the JSDoc
+ *                                              has changed.
+ *
+ * The script:
+ *
+ *   1. Uses tsc programmatically with `allowJs: true`, `declaration:
+ *      true`, `emitDeclarationOnly: true` against the three facade
+ *      source files (facade.js + facade/lock.js + facade/events.js).
+ *   2. Concatenates the emitted .d.ts content into one snapshot file
+ *      with a regen-warning header.
+ *   3. Compares against the on-disk snapshot. If different, writes
+ *      and exits 0; if `--check` was passed, exits 1 instead so CI
+ *      can flag drift.
+ *
+ * The drift-detection contract: when this script's `--check` mode
+ * fails, the JSDoc on facade.js has changed since the last snapshot.
+ * Reviewer:
+ *   - Decides whether the change matters for dashboard consumers.
+ *   - If yes, updates the hand-authored `facade.d.ts` to match.
+ *   - Re-runs without `--check` to refresh the snapshot.
+ *
+ * Usage:
+ *
+ *   bun run gen:facade-types         # refresh snapshot
+ *   bun run gen:facade-types -- --check  # exit 1 on drift
+ */
+
+import { createRequire } from 'node:module'
+import { readFileSync, writeFileSync, existsSync } from 'node:fs'
+import { dirname, resolve as pathResolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const require = createRequire(import.meta.url)
+// Resolves either to the root devDep (preferred) or, as a fallback,
+// the dashboard's already-installed copy. Either is fine — TypeScript
+// is API-compatible across the 5.x line we use.
+let ts
+try {
+  ts = require('typescript')
+} catch {
+  ts = require('../dashboard/node_modules/typescript')
+}
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+const ROOT = pathResolve(__dirname, '..')
+
+const SOURCES = [
+  pathResolve(ROOT, 'src/launcher/facade.js'),
+  pathResolve(ROOT, 'src/launcher/facade/lock.js'),
+  pathResolve(ROOT, 'src/launcher/facade/events.js'),
+]
+
+const OUT_PATH = pathResolve(ROOT, 'dashboard/src/types/facade.snapshot.d.ts')
+
+const COMPILER_OPTIONS = {
+  allowJs: true,
+  declaration: true,
+  emitDeclarationOnly: true,
+  module: ts.ModuleKind.CommonJS,
+  target: ts.ScriptTarget.ES2022,
+  moduleResolution: ts.ModuleResolutionKind.NodeJs,
+  esModuleInterop: true,
+  skipLibCheck: true,
+  strict: false,
+}
+
+const HEADER = `/**
+ * AUTO-GENERATED snapshot of the JSDoc-derived facade shape.
+ *
+ * Source: src/launcher/facade.js + facade/lock.js + facade/events.js.
+ * Generator: scripts/gen-facade-types.mjs.
+ *
+ * DO NOT EDIT BY HAND. Run \`bun run gen:facade-types\` to refresh.
+ * CI runs \`bun run gen:facade-types -- --check\` to detect drift.
+ *
+ * This file is the drift-detector. The dashboard imports from
+ * facade.d.ts (hand-authored named interfaces); when this snapshot
+ * disagrees with the JSDoc on the launcher facade, CI fails and a
+ * reviewer decides whether to update facade.d.ts to match.
+ */
+
+`
+
+function emit() {
+  const host = ts.createCompilerHost(COMPILER_OPTIONS)
+  const outputs = new Map()
+
+  // Override writeFile so we capture artifacts in memory rather than
+  // letting tsc write them next to the source files.
+  host.writeFile = (fileName, contents) => {
+    outputs.set(fileName, contents)
+  }
+
+  const program = ts.createProgram(SOURCES, COMPILER_OPTIONS, host)
+  const emitResult = program.emit()
+
+  const diagnostics = ts
+    .getPreEmitDiagnostics(program)
+    .concat(emitResult.diagnostics)
+
+  if (diagnostics.length > 0) {
+    for (const d of diagnostics) {
+      const message = ts.flattenDiagnosticMessageText(d.messageText, '\n')
+      if (d.file) {
+        const { line, character } = ts.getLineAndCharacterOfPosition(
+          d.file,
+          d.start ?? 0,
+        )
+        console.error(`${d.file.fileName}:${line + 1}:${character + 1} — ${message}`)
+      } else {
+        console.error(message)
+      }
+    }
+  }
+
+  // Concatenate the .d.ts emits in source order, dropping reference
+  // comments tsc adds (the dashboard imports the file directly; we
+  // don't need to point at the .js sources from the .d.ts).
+  const parts = []
+  for (const src of SOURCES) {
+    const baseName = src
+      .replace(ROOT + '/', '')
+      .replace(/\.js$/, '.d.ts')
+    // tsc names the emit by the source path; locate it in our map.
+    let emitted
+    for (const [name, content] of outputs) {
+      if (name.endsWith(baseName.replace(/^src\//, ''))) {
+        emitted = content
+        break
+      }
+      if (name.endsWith('/' + baseName.split('/').pop())) {
+        emitted = content
+        break
+      }
+    }
+    if (!emitted) {
+      console.error(`gen-facade-types: missing emit for ${baseName}`)
+      process.exit(1)
+    }
+    // Strip /// reference directives + the export {} sentinel tsc adds.
+    const cleaned = emitted
+      .split('\n')
+      .filter((line) => !line.startsWith('/// <reference'))
+      .join('\n')
+    parts.push(`// ----- from ${baseName} -----\n${cleaned}`)
+  }
+
+  return HEADER + parts.join('\n')
+}
+
+function main() {
+  const checkOnly = process.argv.includes('--check')
+  const generated = emit()
+
+  if (checkOnly) {
+    if (!existsSync(OUT_PATH)) {
+      console.error(`gen-facade-types --check: ${OUT_PATH} does not exist; run without --check to regenerate.`)
+      process.exit(1)
+    }
+    const onDisk = readFileSync(OUT_PATH, 'utf8')
+    if (onDisk !== generated) {
+      console.error(`gen-facade-types --check: ${OUT_PATH} is out of date.`)
+      console.error(`Run: node scripts/gen-facade-types.mjs`)
+      process.exit(1)
+    }
+    console.log(`gen-facade-types: ${OUT_PATH} is up to date.`)
+    return
+  }
+
+  writeFileSync(OUT_PATH, generated)
+  console.log(`gen-facade-types: wrote ${OUT_PATH}`)
+}
+
+main()


### PR DESCRIPTION
## Summary

#7 from the post-reconciliation queue. Auto-generates a TypeScript declaration snapshot from the JSDoc on `src/launcher/facade.js` + `facade/lock.js` + `facade/events.js`, then has CI compare it against the committed snapshot — drift between JSDoc and the dashboard's typed contract is caught at PR time rather than discovered later as a runtime shape mismatch.

**Two `.d.ts` files in dashboard/src/types/:**

- `facade.d.ts` — HAND-AUTHORED. The dashboard-facing named interfaces (`Facade`, `FacadeMode`, `FacadeWriteStateOpts`, etc.) the bridge shim imports. Stable surface the dashboard compiles against.
- `facade.snapshot.d.ts` — AUTO-GENERATED. Captures what the JSDoc currently emits via `tsc --allowJs --declaration --emitDeclarationOnly`. Committed so CI can compare.

**npm scripts:**
- `npm run gen:facade-types` — refresh the snapshot
- `npm run check:facade-types` — CI's drift detector

**CI wiring:** the Docs check workflow now runs `--check`. Drift fails the docs job, blocking merge until a reviewer either refreshes the snapshot (intentional JSDoc change) or reverts (unintentional).

**Why a snapshot rather than direct generation:** the auto-generated output uses `any` for several JSDoc `{object}` types, which is weaker than the hand-authored named-interface surface the dashboard wants. Keeping both files: hand-authored is the surface the dashboard imports, snapshot is the drift detector. When they disagree, a human decides which moves.

TypeScript is now a root devDep so the docs CI job doesn't need to install the entire dashboard tree.

## Test plan

- [x] Launcher: 1975/1976 pass (1 flake)
- [x] `npm run gen:facade-types` writes the snapshot
- [x] `npm run check:facade-types` passes when in sync, exits 1 when drifted (verified by manually deleting a JSDoc line)
- [x] TypeScript clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)