### PR TITLE
docs(safety): general framing, drop the budget-cap-as-circuit-breaker overclaim

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,17 @@ rouge status
 ```
 
 > [!CAUTION]
-> **Open source, experimental, runs with `--dangerously-skip-permissions`. Misconfiguration can cost thousands of dollars.**
+> **Open source, experimental, runs with `--dangerously-skip-permissions`.**
 >
-> Rouge spawns Claude Code with no permission checks, no workspace boundaries, and full read/write access to your entire machine. It deploys to real infrastructure, makes real git commits, manages real cloud resources, and burns real Anthropic API credits — there is no sandbox around it.
+> Rouge spawns Claude Code with no permission checks, no workspace boundaries, and full read/write access to your machine. It can wipe your filesystem, force-push over your git history, deploy code you didn't review, and run up thousands of dollars in Anthropic API charges in a single session. Real cloud resources. Real money. No sandbox.
 >
-> **Before any real build:** set `budget_cap_usd` in `rouge.config.json` so the loop escalates instead of running away. Run on a dedicated machine, VM, or user account — not a machine with sensitive personal data. Keep your work committed; git is your undo button.
+> Rouge has mitigations, but **none of them are guarantees**:
 >
-> Rouge includes safety hooks (`rouge-safety-check.sh`) that block some destructive patterns, and prompt-level isolation rules that instruct the model not to touch other projects' infrastructure. These reduce the likelihood of accidents but cannot prevent a determined or confused model from accessing anything on the filesystem.
+> - `budget_cap_usd` in `rouge.config.json` is supposed to halt the loop when spend exceeds the cap. Bugs in cap enforcement have shipped before and may again — treat the cap as a soft guardrail, not a circuit breaker.
+> - `rouge-safety-check.sh` blocks some destructive Bash and Write patterns at the spawn boundary. It can't catch what it doesn't recognise.
+> - Prompt-level isolation rules instruct the model not to touch other projects' infrastructure. These are convention, not enforcement.
+> - Running on a dedicated machine, VM, or fresh user account limits blast radius. It doesn't prevent damage to that machine.
+> - Committing your work frequently gives you git as an undo button for code changes. It does not undo cloud deploys, force-pushed remotes, or charges to your API account.
 >
 > Use at your own risk.
 

--- a/dashboard/src/components/safety-banner.tsx
+++ b/dashboard/src/components/safety-banner.tsx
@@ -72,14 +72,17 @@ export function SafetyBanner() {
             <code className="rounded bg-red-100 px-1 py-0.5 font-mono text-xs">
               --dangerously-skip-permissions
             </code>
-            . Misconfiguration can cost thousands of dollars.
+            .
           </p>
           <p className="mt-1 text-red-800">
             Full filesystem access, real cloud resources, real API credits, no
-            sandbox. Set <code className="font-mono text-xs">budget_cap_usd</code>{' '}
-            in <code className="font-mono text-xs">rouge.config.json</code>{' '}
-            before any real build, run on a dedicated machine, and keep your
-            work committed.
+            sandbox. It can wipe your filesystem, force-push your git history,
+            and run up <strong>thousands of dollars</strong> in API charges in
+            a single session.{' '}
+            <code className="font-mono text-xs">budget_cap_usd</code>,
+            dedicated-machine isolation, and frequent commits all reduce risk
+            but <strong>none guarantee</strong> safety — bugs in the cap path
+            and other mitigations have shipped before.
           </p>
         </div>
         <button

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # The Rouge — Documentation
 
-> ⚠️ **Open source, experimental, runs with `--dangerously-skip-permissions`.** Rouge gives Claude Code full filesystem access on your machine and burns real Anthropic API credits. Misconfiguration can cost thousands of dollars. Set a budget cap. Run on a dedicated machine or VM. Read the safety section in the [README](../README.md#safety) first.
+> ⚠️ **Open source, experimental, runs with `--dangerously-skip-permissions`.** Rouge gives Claude Code full filesystem access. It can wipe your filesystem, force-push over your git history, and run up thousands of dollars in API charges in a single session. `budget_cap_usd`, dedicated-machine isolation, and frequent commits reduce risk but **don't guarantee** safety — bugs in the cap path and other mitigations have shipped before. Read the safety section in the [README](../README.md#safety) first.
 
 Docs follow the [Diátaxis](https://diataxis.fr/) framework. Four purposes, four folders:
 

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-> ⚠️ **Open source, experimental, runs with `--dangerously-skip-permissions`.** Read the safety section in the [README](../../README.md#safety) before starting a real build. Misconfiguration can cost thousands of dollars and produce unexpected commits or deploys. Set a budget cap.
+> ⚠️ **Open source, experimental, runs with `--dangerously-skip-permissions`.** Rouge can wipe your filesystem, force-push over your git history, and run up thousands of dollars in API charges in a single session. The mitigations described in this doc reduce risk but **don't guarantee** safety — bugs in the cap path and other safety mechanisms have shipped before. Read the [README's safety section](../../README.md#safety) first.
 
 A short tour of how Rouge is put together. For the user-facing story (what Rouge does, how it judges, what it costs), read [how-rouge-works.md](how-rouge-works.md). This doc covers the parts a contributor or maintainer needs.
 

--- a/docs/explanation/how-rouge-works.md
+++ b/docs/explanation/how-rouge-works.md
@@ -1,6 +1,6 @@
 # How Rouge Works
 
-> ⚠️ **Open source, experimental, runs with `--dangerously-skip-permissions`.** Rouge gives Claude Code full filesystem access on your machine and burns real Anthropic API credits. Misconfiguration can cost thousands of dollars and produce unexpected commits, deploys, or data loss. Run it on a dedicated machine or VM, set a budget cap, and read the safety section in the [README](../../README.md#safety) before starting a real build.
+> ⚠️ **Open source, experimental, runs with `--dangerously-skip-permissions`.** Rouge gives Claude Code full filesystem access. It can wipe your filesystem, force-push over your git history, and run up thousands of dollars in API charges in a single session. `budget_cap_usd`, dedicated-machine isolation, and frequent commits reduce risk but **don't guarantee** safety — bugs in the cap path and other mitigations have shipped before. Read the [README's safety section](../../README.md#safety) before starting a real build.
 
 ## The name
 

--- a/docs/how-to/setup.md
+++ b/docs/how-to/setup.md
@@ -1,6 +1,6 @@
 # The Rouge — Setup Guide
 
-> ⚠️ **Open source, experimental, runs with `--dangerously-skip-permissions`.** Rouge gives Claude Code full filesystem access and burns real Anthropic API credits. Misconfiguration can cost thousands of dollars. Set `budget_cap_usd` in `rouge.config.json` before any real build. Run on a dedicated machine or VM. Read the [README's safety section](../../README.md#safety) first.
+> ⚠️ **Open source, experimental, runs with `--dangerously-skip-permissions`.** Rouge gives Claude Code full filesystem access. It can wipe your filesystem, force-push over your git history, and run up thousands of dollars in API charges in a single session. `budget_cap_usd`, dedicated-machine isolation, and frequent commits reduce risk but **don't guarantee** safety — bugs in the cap path and other mitigations have shipped before. Read the [README's safety section](../../README.md#safety) first.
 
 > **Dashboard-first.** The fast path for new users is `rouge setup` → `rouge dashboard start` → open the URL Rouge prints → **New Project**. The CLI steps below cover the per-integration configuration (OS keychain, Cloudflare, Supabase, Sentry, GitHub). Slack remains as a notification-only sidecar for pre-existing setups; new installs should use the dashboard.
 

--- a/docs/how-to/troubleshooting.md
+++ b/docs/how-to/troubleshooting.md
@@ -1,6 +1,6 @@
 # FAQ & Troubleshooting
 
-> ⚠️ **Open source, experimental, runs with `--dangerously-skip-permissions`.** Misconfiguration can cost thousands of dollars. Set a budget cap. Read the [README's safety section](../../README.md#safety) before starting a real build.
+> ⚠️ **Open source, experimental, runs with `--dangerously-skip-permissions`.** Rouge can wipe your filesystem, force-push over your git history, and run up thousands of dollars in API charges in a single session. `budget_cap_usd`, dedicated-machine isolation, and frequent commits reduce risk but **don't guarantee** safety — bugs in the cap path and other mitigations have shipped before. Read the [README's safety section](../../README.md#safety) first.
 
 Quick answers to common questions and fixes for common problems. For the full walkthrough, see [your-first-product.md](../tutorials/your-first-product.md). For Slack-specific issues, see the [Slack setup troubleshooting section](slack-setup.md#troubleshooting).
 

--- a/docs/tutorials/quickstart.md
+++ b/docs/tutorials/quickstart.md
@@ -1,6 +1,6 @@
 # Quick Start
 
-> ⚠️ **Open source, experimental, runs with `--dangerously-skip-permissions`.** Rouge gives Claude Code full filesystem access and burns real Anthropic API credits. Misconfiguration can cost thousands of dollars. Set `budget_cap_usd` in `rouge.config.json` before any real build. Run on a dedicated machine or VM, not your daily-driver. Read the [README's safety section](../../README.md#safety) before starting.
+> ⚠️ **Open source, experimental, runs with `--dangerously-skip-permissions`.** Rouge gives Claude Code full filesystem access. It can wipe your filesystem, force-push over your git history, and run up thousands of dollars in API charges in a single session. `budget_cap_usd`, dedicated-machine isolation, and frequent commits reduce risk but **don't guarantee** safety — bugs in the cap path and other mitigations have shipped before. Read the [README's safety section](../../README.md#safety) before starting.
 
 Get from zero to your first Rouge-built product in about 5 minutes (plus an interactive seeding session).
 

--- a/docs/tutorials/your-first-product.md
+++ b/docs/tutorials/your-first-product.md
@@ -1,6 +1,6 @@
 # Your first product
 
-> ⚠️ **Open source, experimental, runs with `--dangerously-skip-permissions`.** Rouge gives Claude Code full filesystem access and burns real Anthropic API credits. Misconfiguration can cost thousands of dollars. Set `budget_cap_usd` in `rouge.config.json` before any real build. Run on a dedicated machine or VM, not your daily-driver. Read the [README's safety section](../../README.md#safety) before starting.
+> ⚠️ **Open source, experimental, runs with `--dangerously-skip-permissions`.** Rouge gives Claude Code full filesystem access. It can wipe your filesystem, force-push over your git history, and run up thousands of dollars in API charges in a single session. `budget_cap_usd`, dedicated-machine isolation, and frequent commits reduce risk but **don't guarantee** safety — bugs in the cap path and other mitigations have shipped before. Read the [README's safety section](../../README.md#safety) before starting.
 
 You've installed Rouge, run `rouge doctor`, and read the [seeding example](seeding-example.md). Now you want to actually build something. Here's what happens end to end.
 

--- a/src/launcher/rouge-cli.js
+++ b/src/launcher/rouge-cli.js
@@ -131,13 +131,17 @@ function showSafetyBanner() {
   console.error(`\n${RED}${BOLD}┌─ SAFETY ──────────────────────────────────────────────────────────────┐${RESET}`);
   console.error(`${RED}${BOLD}│${RESET}                                                                       ${RED}${BOLD}│${RESET}`);
   console.error(`${RED}${BOLD}│${RESET}  Rouge spawns Claude Code with ${BOLD}--dangerously-skip-permissions${RESET}.        ${RED}${BOLD}│${RESET}`);
-  console.error(`${RED}${BOLD}│${RESET}  Full filesystem access. No sandbox. Real cloud resources. Real API   ${RED}${BOLD}│${RESET}`);
-  console.error(`${RED}${BOLD}│${RESET}  credits. Misconfiguration ${BOLD}can cost thousands of dollars${RESET}.            ${RED}${BOLD}│${RESET}`);
+  console.error(`${RED}${BOLD}│${RESET}  Full filesystem access. No sandbox. It can wipe your filesystem,    ${RED}${BOLD}│${RESET}`);
+  console.error(`${RED}${BOLD}│${RESET}  force-push your git history, and run up ${BOLD}thousands of dollars${RESET} in    ${RED}${BOLD}│${RESET}`);
+  console.error(`${RED}${BOLD}│${RESET}  API charges in a single session.                                     ${RED}${BOLD}│${RESET}`);
   console.error(`${RED}${BOLD}│${RESET}                                                                       ${RED}${BOLD}│${RESET}`);
-  console.error(`${RED}${BOLD}│${RESET}  • Set ${BOLD}budget_cap_usd${RESET} in rouge.config.json before any real build.    ${RED}${BOLD}│${RESET}`);
-  console.error(`${RED}${BOLD}│${RESET}  • Run on a dedicated machine or VM, not your daily-driver.           ${RED}${BOLD}│${RESET}`);
-  console.error(`${RED}${BOLD}│${RESET}  • Keep your work committed. Git is your undo button.                 ${RED}${BOLD}│${RESET}`);
+  console.error(`${RED}${BOLD}│${RESET}  Mitigations are guardrails, ${BOLD}not guarantees${RESET}:                         ${RED}${BOLD}│${RESET}`);
+  console.error(`${RED}${BOLD}│${RESET}    • budget_cap_usd reduces runaway-spend risk; cap-enforcement       ${RED}${BOLD}│${RESET}`);
+  console.error(`${RED}${BOLD}│${RESET}      bugs have shipped before                                         ${RED}${BOLD}│${RESET}`);
+  console.error(`${RED}${BOLD}│${RESET}    • dedicated machine / VM limits blast radius, not damage           ${RED}${BOLD}│${RESET}`);
+  console.error(`${RED}${BOLD}│${RESET}    • git is undo for code, not for cloud deploys or API charges       ${RED}${BOLD}│${RESET}`);
   console.error(`${RED}${BOLD}│${RESET}                                                                       ${RED}${BOLD}│${RESET}`);
+  console.error(`${RED}${BOLD}│${RESET}  Use at your own risk.                                                ${RED}${BOLD}│${RESET}`);
   console.error(`${RED}${BOLD}│${RESET}  Suppress this banner with ROUGE_SUPPRESS_SAFETY_BANNER=1.            ${RED}${BOLD}│${RESET}`);
   console.error(`${RED}${BOLD}└───────────────────────────────────────────────────────────────────────┘${RESET}\n`);
 }


### PR DESCRIPTION
## Why

Two corrections from review:

**1. The danger framing was too narrow.** Said "misconfiguration can cost thousands of dollars" — that's user-error framing. Reality is broader: Rouge can wipe your filesystem, force-push over your git history, deploy code you didn't review, AND run up thousands of dollars in charges. And not just from misconfiguration — bugs have caused these too.

**2. The mitigations were oversold.** The README and several doc blockquotes told users to "set budget_cap_usd before any real build" with the implication it's a circuit breaker. We've shipped bugs in cap enforcement before, and may again. Every mitigation is a guardrail, not a guarantee.

## What changed

- **README.md** `[!CAUTION]` block: rewritten as a 5-bullet "mitigations exist but **none of them are guarantees**" list. Each bullet names what the mitigation does AND what it doesn't.
- **CLI safety banner** (`showSafetyBanner()`): "wipe your filesystem, force-push your git history, and run up thousands of dollars in API charges in a single session", "Mitigations are guardrails, not guarantees", concrete example "cap-enforcement bugs have shipped before".
- **Dashboard banner** (`SafetyBanner.tsx`): same framing — "none guarantee" explicit.
- **Doc safety blockquotes** unified across docs/README.md, docs/explanation/{how-rouge-works,architecture}.md, docs/how-to/{setup,troubleshooting}.md, docs/tutorials/{quickstart,your-first-product}.md.

## Test plan

- [x] Launcher: 1975/1976 (same documented flake)
- [x] TS clean
- [x] CLI banner renders the new text
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)