### PR TITLE
feat: human-gated discipline transitions

### DIFF
--- a/dashboard/src/app/api/projects/[name]/approve-discipline/route.ts
+++ b/dashboard/src/app/api/projects/[name]/approve-discipline/route.ts
@@ -4,12 +4,16 @@ import { loadServerConfig } from '@/lib/server-config'
 import { guardMutation } from '@/lib/route-guards'
 import {
   readSeedingState,
+  writeSeedingState,
   clearAwaitingApproval,
   markDisciplineComplete,
   isAwaitingApproval,
-  updateDisciplineStatusInState,
 } from '@/bridge/seeding-state'
+import { appendChatMessage } from '@/bridge/chat-reader'
 import { handleSeedMessage } from '@/bridge/seed-handler'
+import { runAutoClassifier } from '@/bridge/auto-classifier'
+import { listApplicableDisciplines } from '@/bridge/tier-registry'
+import { DISCIPLINE_SEQUENCE } from '@/bridge/types'
 
 export const dynamic = 'force-dynamic'
 
@@ -66,10 +70,43 @@ export async function POST(
     return NextResponse.json({ ok: true, killed: true })
   }
 
-  // Fire a kickoff turn into the next discipline
-  const postState = readSeedingState(projectDir)
-  const nextDisc = postState.current_discipline
-  if (nextDisc && !(postState.disciplines_complete ?? []).includes(nextDisc) && nextDisc !== 'sizing') {
+  // After brainstorming: run auto-classifier + tier-based auto-skipping.
+  // This normally runs inside runSeedingTurn, but the approval endpoint
+  // needs to do it before the kickoff so the next discipline is correct.
+  let midState = readSeedingState(projectDir)
+  if (body.discipline === 'brainstorming' && !midState.applicable_disciplines) {
+    const classResult = runAutoClassifier(projectDir)
+    if (classResult.ok) {
+      await markDisciplineComplete(projectDir, 'sizing')
+      const applicable = listApplicableDisciplines(classResult.projectSize)
+      const ss = readSeedingState(projectDir)
+      ss.applicable_disciplines = applicable
+      ss.project_size = classResult.projectSize
+      writeSeedingState(projectDir, ss)
+
+      for (const disc of DISCIPLINE_SEQUENCE) {
+        if (disc === 'brainstorming' || disc === 'sizing') continue
+        if (!applicable.includes(disc)) {
+          await markDisciplineComplete(projectDir, disc)
+        }
+      }
+
+      const genId = () => `msg-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`
+      appendChatMessage(projectDir, {
+        id: genId(),
+        role: 'rouge',
+        content: `Project classified as **${classResult.projectSize}** tier. ${applicable.length} discipline(s) applicable: ${applicable.join(', ')}.`,
+        timestamp: new Date().toISOString(),
+        kind: 'system_note',
+        metadata: { discipline: 'sizing' },
+      })
+    }
+    midState = readSeedingState(projectDir)
+  }
+
+  // Fire a kickoff turn into the next applicable discipline
+  const nextDisc = midState.current_discipline
+  if (nextDisc && !(midState.disciplines_complete ?? []).includes(nextDisc) && nextDisc !== 'sizing') {
     try {
       await handleSeedMessage(projectDir, [
         `[SYSTEM] Discipline ${body.discipline} approved by user. State has advanced.`,
@@ -81,5 +118,6 @@ export async function POST(
     }
   }
 
-  return NextResponse.json({ ok: true, nextDiscipline: nextDisc })
+  const postState = readSeedingState(projectDir)
+  return NextResponse.json({ ok: true, nextDiscipline: postState.current_discipline })
 }

--- a/dashboard/src/app/api/projects/[name]/approve-discipline/route.ts
+++ b/dashboard/src/app/api/projects/[name]/approve-discipline/route.ts
@@ -1,0 +1,85 @@
+import { NextResponse } from 'next/server'
+import { join } from 'node:path'
+import { loadServerConfig } from '@/lib/server-config'
+import { guardMutation } from '@/lib/route-guards'
+import {
+  readSeedingState,
+  clearAwaitingApproval,
+  markDisciplineComplete,
+  isAwaitingApproval,
+  updateDisciplineStatusInState,
+} from '@/bridge/seeding-state'
+import { handleSeedMessage } from '@/bridge/seed-handler'
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ name: string }> },
+) {
+  const { name } = await params
+  const guard = await guardMutation(name)
+  if (!guard.ok) return guard.response
+
+  const { projectsRoot } = loadServerConfig()
+  const projectDir = join(projectsRoot, name)
+
+  const body = (await request.json().catch(() => ({}))) as {
+    discipline?: string
+  }
+  if (!body.discipline || typeof body.discipline !== 'string') {
+    return NextResponse.json(
+      { error: 'Missing required field: discipline' },
+      { status: 400 },
+    )
+  }
+
+  const state = readSeedingState(projectDir)
+
+  // Idempotent: already complete
+  if ((state.disciplines_complete ?? []).includes(body.discipline)) {
+    return NextResponse.json({ ok: true, nextDiscipline: state.current_discipline })
+  }
+
+  if (!isAwaitingApproval(state)) {
+    return NextResponse.json(
+      { error: 'No discipline is awaiting approval' },
+      { status: 400 },
+    )
+  }
+
+  if (state.discipline_awaiting_approval !== body.discipline) {
+    return NextResponse.json(
+      {
+        error: `Discipline ${body.discipline} is not awaiting approval (${state.discipline_awaiting_approval} is)`,
+      },
+      { status: 409 },
+    )
+  }
+
+  // Clear the approval gate, then complete the discipline
+  clearAwaitingApproval(projectDir)
+  await markDisciplineComplete(projectDir, body.discipline)
+
+  // Handle taste kill: don't kick off the next discipline
+  if (body.discipline === 'taste' && state.taste_kill) {
+    return NextResponse.json({ ok: true, killed: true })
+  }
+
+  // Fire a kickoff turn into the next discipline
+  const postState = readSeedingState(projectDir)
+  const nextDisc = postState.current_discipline
+  if (nextDisc && !(postState.disciplines_complete ?? []).includes(nextDisc) && nextDisc !== 'sizing') {
+    try {
+      await handleSeedMessage(projectDir, [
+        `[SYSTEM] Discipline ${body.discipline} approved by user. State has advanced.`,
+        `You are now entering ${nextDisc.toUpperCase()}. The sub-prompt for that discipline is attached to this turn; follow its rules exactly.`,
+        `Begin the new discipline by asking its first question to the human.`,
+      ].join(' '))
+    } catch (err) {
+      console.error(`[approve-discipline] kickoff for ${nextDisc} failed:`, err)
+    }
+  }
+
+  return NextResponse.json({ ok: true, nextDiscipline: nextDisc })
+}

--- a/dashboard/src/app/api/projects/[name]/approve-seeding/route.ts
+++ b/dashboard/src/app/api/projects/[name]/approve-seeding/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from 'next/server'
+import { join } from 'node:path'
+import { loadServerConfig } from '@/lib/server-config'
+import { guardMutation } from '@/lib/route-guards'
+import {
+  readSeedingState,
+  markSeedingComplete,
+  writeSeedingState,
+} from '@/bridge/seeding-state'
+import { validateTierCompletion } from '@/bridge/tier-registry'
+import { finalizeSeeding } from '@/bridge/seeding-finalize'
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<{ name: string }> },
+) {
+  const { name } = await params
+  const guard = await guardMutation(name)
+  if (!guard.ok) return guard.response
+
+  const { projectsRoot } = loadServerConfig()
+  const projectDir = join(projectsRoot, name)
+
+  const state = readSeedingState(projectDir)
+
+  // Idempotent: already complete
+  if (state.seeding_complete) {
+    return NextResponse.json({ ok: true })
+  }
+
+  // Tier validation
+  const tierCheck = validateTierCompletion(projectDir)
+  if (!tierCheck.ok) {
+    return NextResponse.json(
+      { ok: false, error: tierCheck.reason, missingArtifacts: tierCheck.missing },
+      { status: 422 },
+    )
+  }
+
+  // Finalize
+  const result = await finalizeSeeding(projectDir)
+  if (!result.ok) {
+    return NextResponse.json(
+      { ok: false, error: 'Finalization failed', missingArtifacts: result.missingArtifacts },
+      { status: 422 },
+    )
+  }
+
+  markSeedingComplete(projectDir)
+
+  // Clear the final approval flag
+  const ss = readSeedingState(projectDir)
+  delete ss.seeding_awaiting_final_approval
+  writeSeedingState(projectDir, ss)
+
+  return NextResponse.json({ ok: true })
+}

--- a/dashboard/src/bridge/__tests__/seeding-finalize.test.ts
+++ b/dashboard/src/bridge/__tests__/seeding-finalize.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, afterEach } from 'vitest'
 import { finalizeSeeding } from '../seeding-finalize'
-import { mkdirSync, rmSync, writeFileSync, readFileSync } from 'fs'
+import { mkdirSync, rmSync, writeFileSync, readFileSync, existsSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 
@@ -38,11 +38,42 @@ describe('finalizeSeeding', () => {
     ],
   }, null, 2)
 
+  const VALID_MILESTONES = JSON.stringify({
+    milestones: [{
+      name: 'MVP',
+      stories: [
+        { id: 's-1', name: 'First story', status: 'pending', acceptance_criteria: ['AC 1', 'AC 2'] },
+        { id: 's-2', name: 'Second story', status: 'pending', acceptance_criteria: ['AC 3'] },
+      ],
+    }],
+  }, null, 2)
+
+  const VALID_BRAINSTORMING = [
+    '# Test Product — a comprehensive test application',
+    '',
+    '## The Problem',
+    'Testing needs to be reliable and comprehensive.',
+    '',
+    '## The User',
+    '',
+    '**Developers** who need automated testing for their projects.',
+    '',
+    'x'.repeat(300),
+    '',
+    '## Classifier Signals',
+    '- entity_count: 2',
+    '- integration_count: 0',
+    '- role_count: 1',
+    '- journey_count: 1',
+    '- screen_count: 1',
+  ].join('\n')
+
   function seedCompleteProject(): void {
     mkdirSync(join(testDir, 'seed_spec'), { recursive: true })
     mkdirSync(join(testDir, '.rouge'), { recursive: true })
+    writeFileSync(join(testDir, 'seed_spec', 'brainstorming.md'), VALID_BRAINSTORMING)
     writeFileSync(join(testDir, 'task_ledger.json'), VALID_LEDGER)
-    writeFileSync(join(testDir, 'seed_spec', 'milestones.json'), '{}')
+    writeFileSync(join(testDir, 'seed_spec', 'milestones.json'), VALID_MILESTONES)
     writeFileSync(join(testDir, 'vision.json'), VALID_VISION)
     writeFileSync(join(testDir, 'product_standard.json'), VALID_STANDARD)
     // state.json lives under .rouge/ (#135 / #143). Previous test
@@ -52,28 +83,40 @@ describe('finalizeSeeding', () => {
     writeFileSync(join(testDir, '.rouge', 'state.json'), JSON.stringify({ current_state: 'seeding', name: 'test' }))
   }
 
-  it('returns missingArtifacts when task_ledger.json is missing', async () => {
+  it('auto-generates task_ledger.json from milestones.json when missing', async () => {
     seedCompleteProject()
     rmSync(join(testDir, 'task_ledger.json'))
     const result = await finalizeSeeding(testDir)
-    expect(result.ok).toBe(false)
-    expect(result.missingArtifacts).toContain('task_ledger.json')
+    // ensureTaskLedger generates from milestones.json
+    const exists = existsSync(join(testDir, 'task_ledger.json'))
+    expect(exists).toBe(true)
+    const ledger = JSON.parse(readFileSync(join(testDir, 'task_ledger.json'), 'utf-8'))
+    expect(ledger.milestones).toBeDefined()
+    expect(ledger.seeded_by).toBe('bridge')
   })
 
   it('returns missingArtifacts when seed_spec/ has no files', async () => {
     seedCompleteProject()
-    rmSync(join(testDir, 'seed_spec', 'milestones.json'))
+    // Remove ALL files in seed_spec (brainstorming + milestones)
+    rmSync(join(testDir, 'seed_spec'), { recursive: true })
+    mkdirSync(join(testDir, 'seed_spec'), { recursive: true })
     const result = await finalizeSeeding(testDir)
     expect(result.ok).toBe(false)
     expect(result.missingArtifacts).toContain('seed_spec/')
   })
 
-  it('returns missingArtifacts when vision.json is missing', async () => {
+  it('auto-generates vision.json from brainstorming when missing', async () => {
     seedCompleteProject()
+    // Write a brainstorming artifact so ensureVision has source data
+    writeFileSync(join(testDir, 'seed_spec', 'brainstorming.md'),
+      '# Test Product — a test thing\n\n## The Problem\nSomething needs testing.\n\n## The User\n\n**Testers** who need to verify code.\n\n' + 'x'.repeat(300))
     rmSync(join(testDir, 'vision.json'))
-    const result = await finalizeSeeding(testDir)
-    expect(result.ok).toBe(false)
-    expect(result.missingArtifacts).toContain('vision.json')
+    await finalizeSeeding(testDir)
+    const exists = existsSync(join(testDir, 'vision.json'))
+    expect(exists).toBe(true)
+    const vision = JSON.parse(readFileSync(join(testDir, 'vision.json'), 'utf-8'))
+    expect(vision.product_name).toBe('Test Product')
+    expect(vision.generated).toBe(true)
   })
 
   it('auto-generates product_standard.json from library when missing', async () => {
@@ -94,13 +137,15 @@ describe('finalizeSeeding', () => {
     }
   })
 
-  it('returns missingArtifacts when vision.json is a stub (below byte floor)', async () => {
+  it('overwrites vision.json stub with generated content when below byte floor', async () => {
     seedCompleteProject()
+    writeFileSync(join(testDir, 'seed_spec', 'brainstorming.md'),
+      '# Stub Test — minimal\n\n## The Problem\nStub.\n\n## The User\n\n**Users** who test.\n\n' + 'x'.repeat(300))
     writeFileSync(join(testDir, 'vision.json'), '{ "stub": true }')
-    const result = await finalizeSeeding(testDir)
-    expect(result.ok).toBe(false)
-    // Either rejected for being too small or for missing required fields
-    expect(result.missingArtifacts?.some(m => m.includes('vision.json'))).toBe(true)
+    await finalizeSeeding(testDir)
+    const vision = JSON.parse(readFileSync(join(testDir, 'vision.json'), 'utf-8'))
+    expect(vision.product_name).toBe('Stub Test')
+    expect(vision.generated).toBe(true)
   })
 
   it('transitions state to ready when all required artifacts exist', async () => {
@@ -225,7 +270,7 @@ describe('finalizeSeeding', () => {
       expect(vision.infrastructure).toEqual({})
     })
 
-    it('is a no-op when manifest has no deploy.target', async () => {
+    it('is a no-op for propagation when manifest has no deploy.target', async () => {
       seedCompleteProject()
       writeVision()
       writeFileSync(
@@ -236,7 +281,9 @@ describe('finalizeSeeding', () => {
       await finalizeSeeding(testDir)
 
       const vision = JSON.parse(readFileSync(join(testDir, 'vision.json'), 'utf-8'))
-      expect(vision.infrastructure).toEqual({})
+      // propagateInfrastructureFromManifest returns early with no target,
+      // but ensureVision may have set needs_database/needs_auth from the manifest
+      expect(vision.infrastructure.deployment_target).toBeUndefined()
     })
   })
 })

--- a/dashboard/src/bridge/seed-handler.ts
+++ b/dashboard/src/bridge/seed-handler.ts
@@ -478,15 +478,45 @@ async function runSeedingTurn(
           kind: 'system_note',
           metadata: { discipline: disc },
         })
-        // Fire a continuation that triggers the classifier (after
-        // brainstorming) and kicks off the next applicable discipline.
-        try {
-          await runContinuationTurn(projectDir, [
-            `[SYSTEM] Discipline ${disc} approved by user. State has advanced.`,
-            `Continue with the next discipline.`,
-          ].join(' '), 0, `post-approval-${disc}`)
-        } catch (err) {
-          console.error(`[seeding] post-approval kickoff failed:`, err)
+        // After brainstorming: run classifier + tier gating inline
+        // before the kickoff, same as the approval endpoint does.
+        let postApprovalState = readSeedingState(projectDir)
+        if (disc === 'brainstorming' && !postApprovalState.applicable_disciplines) {
+          const classResult = runAutoClassifier(projectDir)
+          if (classResult.ok) {
+            await markDisciplineComplete(projectDir, 'sizing')
+            const applicable = listApplicableDisciplines(classResult.projectSize)
+            const ss = readSeedingState(projectDir)
+            ss.applicable_disciplines = applicable
+            ss.project_size = classResult.projectSize
+            writeSeedingState(projectDir, ss)
+            for (const d2 of DISCIPLINE_SEQUENCE) {
+              if (d2 === 'brainstorming' || d2 === 'sizing') continue
+              if (!applicable.includes(d2)) {
+                await markDisciplineComplete(projectDir, d2)
+              }
+            }
+            appendChatMessage(projectDir, {
+              id: genId(), role: 'rouge',
+              content: `Project classified as **${classResult.projectSize}** tier. ${applicable.length} discipline(s) applicable: ${applicable.join(', ')}.`,
+              timestamp: new Date().toISOString(), kind: 'system_note',
+              metadata: { discipline: 'sizing' },
+            })
+          }
+          postApprovalState = readSeedingState(projectDir)
+        }
+
+        const nextDisc = postApprovalState.current_discipline
+        if (nextDisc && !(postApprovalState.disciplines_complete ?? []).includes(nextDisc) && nextDisc !== 'sizing') {
+          try {
+            await runContinuationTurn(projectDir, [
+              `[SYSTEM] Discipline ${disc} approved by user. State has advanced.`,
+              `You are now entering ${nextDisc.toUpperCase()}. Follow its sub-prompt rules exactly.`,
+              `Begin the new discipline by asking its first question to the human.`,
+            ].join(' '), 0, `kickoff-${nextDisc}`)
+          } catch (err) {
+            console.error(`[seeding] post-approval kickoff failed:`, err)
+          }
         }
         return { ok: true, status: 200, disciplineComplete: [disc], seedingComplete: false, readyTransition: false }
       }

--- a/dashboard/src/bridge/seed-handler.ts
+++ b/dashboard/src/bridge/seed-handler.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync } from 'fs'
 import { resolve } from 'path'
 import { runClaude, detectRateLimit, extractMarkers, segmentMarkers, type MessageSegment } from './claude-runner'
 import { appendChatMessage } from './chat-reader'
-import { readSeedingState, writeSeedingState, updateSessionId, markDisciplineComplete, markDisciplinePrompted, markSeedingComplete, setStatus, appendPendingCorrection, peekPendingCorrection, clearPendingCorrection, isAwaitingGateFor, setAwaitingGate, clearPendingGate, updateHeartbeat, effectiveMode } from './seeding-state'
+import { readSeedingState, writeSeedingState, updateSessionId, markDisciplineComplete, markDisciplinePrompted, markSeedingComplete, setStatus, appendPendingCorrection, peekPendingCorrection, clearPendingCorrection, isAwaitingGateFor, setAwaitingGate, clearPendingGate, updateHeartbeat, effectiveMode, setAwaitingApproval, clearAwaitingApproval, isAwaitingApproval, updateDisciplineStatusInState } from './seeding-state'
 import type { SeedingMessageKind } from './types'
 import { finalizeSeeding } from './seeding-finalize'
 import { maybeDeriveWorkingTitle } from './derive-title'
@@ -424,7 +424,7 @@ async function runSeedingTurn(
       // Strip the [SYSTEM NOTE] prefix — the new `kind: 'system_note'`
       // drives UI styling, making the inline bracket tag redundant and
       // visually naff.
-      const note = `Reconciled earlier discipline state: ${reconciled.join(', ')} now marked complete (artifact verified on disk). Seeding continues.`
+      const note = `Reconciled earlier discipline state: ${reconciled.join(', ')} artifact verified on disk. Accept to continue or reply with feedback to revise.`
       appendChatMessage(projectDir, {
         id: genId(),
         role: 'rouge',
@@ -441,33 +441,41 @@ async function runSeedingTurn(
       clearPendingGate(projectDir)
     }
 
-    // Fallback finalization: if every discipline is complete on disk
-    // but `seeding_complete` was never set (the orchestrator prompt
-    // went silent after marketing without emitting SEEDING_COMPLETE,
-    // as happened with colour-contrast), auto-call finalizeSeeding.
-    // Without this the project sits in state=seeding forever with
-    // 8/8 disciplines done.
-    const postReconcileState = readSeedingState(projectDir)
-    const allDone =
-      (postReconcileState.disciplines_complete?.length ?? 0) >= DISCIPLINE_SEQUENCE.length
-    if (allDone && !postReconcileState.seeding_complete) {
-      const finalizeResult = await finalizeSeeding(projectDir)
-      if (finalizeResult.ok) {
-        markSeedingComplete(projectDir)
-        const totalDisc = DISCIPLINE_SEQUENCE.length
-        appendChatMessage(projectDir, {
-          id: genId(),
-          role: 'rouge',
-          content:
-            `All ${totalDisc} disciplines complete. Seeding finalized — project is now ready to build. ` +
-            'Click "Build this" in the specs table when you want the build loop to start.',
-          timestamp: new Date().toISOString(),
-          kind: 'system_note',
-        })
+    // If a discipline is awaiting approval and the user sends a message
+    // (instead of clicking Accept), treat it as revision feedback.
+    // Clear the approval state so the discipline reverts to active.
+    const preApprovalState = readSeedingState(projectDir)
+    if (isAwaitingApproval(preApprovalState)) {
+      console.log(`[seeding] user sent message while ${preApprovalState.discipline_awaiting_approval} awaiting approval — treating as revision`)
+      clearAwaitingApproval(projectDir)
+      // Also clear the final approval flag if set
+      if (preApprovalState.seeding_awaiting_final_approval) {
+        const ss = readSeedingState(projectDir)
+        delete ss.seeding_awaiting_final_approval
+        writeSeedingState(projectDir, ss)
       }
-      // If finalizeResult.ok is false, artifacts are genuinely missing
-      // — let the normal flow handle that; we don't want to surface a
-      // noisy system note here because the user hasn't triggered this.
+    }
+
+    // Final seeding approval: if every discipline is user-approved
+    // (in disciplines_complete) but seeding_complete was never set,
+    // surface a final approval card instead of auto-finalizing.
+    const postReconcileState = readSeedingState(projectDir)
+    const applicable = postReconcileState.applicable_disciplines ?? DISCIPLINE_SEQUENCE as unknown as string[]
+    const allApproved = applicable.every(
+      (d: string) => (postReconcileState.disciplines_complete ?? []).includes(d),
+    )
+    if (allApproved && !postReconcileState.seeding_complete && !postReconcileState.seeding_awaiting_final_approval) {
+      const ss = readSeedingState(projectDir)
+      ss.seeding_awaiting_final_approval = true
+      writeSeedingState(projectDir, ss)
+      appendChatMessage(projectDir, {
+        id: genId(),
+        role: 'rouge',
+        content:
+          `All disciplines complete. Review the seeding summary and approve to start building, or select a discipline to revise.`,
+        timestamp: new Date().toISOString(),
+        kind: 'seeding_summary',
+      })
     }
   }
 
@@ -478,6 +486,13 @@ async function runSeedingTurn(
   // artifacts, or clarify decisions. Claude remembers context via session_id.
 
   const activeDiscipline = resolveActiveDiscipline(state.current_discipline)
+  // For message tagging: prefer the gate's discipline or the approval
+  // discipline over current_discipline. This prevents gate answers and
+  // revision feedback from being tagged with the wrong discipline when
+  // the server has already advanced current_discipline.
+  const messageTagDiscipline = resolveActiveDiscipline(
+    state.pending_gate?.discipline ?? state.discipline_awaiting_approval ?? state.current_discipline,
+  )
   const alreadyPrompted = state.disciplines_prompted ?? []
   const isFirstTurn = state.session_id === null
   // Sizing is auto-completed by the classifier — never inject its prompt
@@ -664,18 +679,24 @@ async function runSeedingTurn(
     }
     const check = verifyDisciplineArtifact(projectDir, d)
     if (check.ok) {
-      await markDisciplineComplete(projectDir, d)
+      // Don't complete immediately — enter awaiting_approval so the
+      // user must click "Accept & continue" before state advances.
+      setAwaitingApproval(projectDir, d)
+      await updateDisciplineStatusInState(projectDir, d, 'awaiting_approval')
       acceptedDisciplines.push(d)
-      // Taste kill verdict: the idea failed the taste gate. Mark the
-      // project for archival so seeding doesn't continue into spec/design.
-      if (d === 'taste' && check.killVerdict) {
-        console.log(`[seeding] taste verdict is KILL for ${projectDir} — seeding should stop`)
-        const { writeSeedingState, readSeedingState } = await import('./seeding-state')
-        const ss = readSeedingState(projectDir)
-        ss.taste_kill = true
-        ss.taste_kill_at = new Date().toISOString()
-        writeSeedingState(projectDir, ss)
-      }
+
+      const isKill = d === 'taste' && check.killVerdict
+      const approvalContent = isKill
+        ? `**Taste verdict: KILL.** The idea didn't pass the taste gate. Review the graveyard entry and archive this project, or revise to continue.`
+        : `**${d}** artifact verified on disk. Accept to continue to the next discipline, or reply with feedback to revise.`
+      appendChatMessage(projectDir, {
+        id: genId(),
+        role: 'rouge',
+        content: approvalContent,
+        timestamp: new Date().toISOString(),
+        kind: 'approve_prompt',
+        metadata: { discipline: d, killVerdict: isKill || undefined },
+      })
     } else {
       console.warn(
         `[seeding] rejecting DISCIPLINE_COMPLETE(${d}) — ${check.reason}`,
@@ -818,7 +839,7 @@ async function runSeedingTurn(
       role: 'human',
       content: text,
       timestamp: new Date().toISOString(),
-      metadata: activeDiscipline ? { discipline: activeDiscipline } : undefined,
+      metadata: messageTagDiscipline ? { discipline: messageTagDiscipline } : undefined,
     })
   }
   // Reuse the segments parsed above for the gate-and-complete guard.
@@ -864,38 +885,19 @@ async function runSeedingTurn(
     void maybeDeriveWorkingTitle(projectDir, text)
   }
 
-  // Check for SEEDING_COMPLETE — tier validation gate.
-  // Before delegating to finalizeSeeding, run the deterministic tier check.
-  // If the tier check fails, REJECT the marker with a system note and
-  // pending correction so the LLM knows what's still missing.
-  let readyTransition = false
-  let missingArtifacts: string[] | undefined
+  // SEEDING_COMPLETE is now code-controlled via the approve-seeding
+  // endpoint. If the LLM emits it, ignore and correct.
   if (markers.seedingComplete) {
-    const tierCheck = validateTierCompletion(projectDir)
-    if (!tierCheck.ok) {
-      // Tier validation failed — reject SEEDING_COMPLETE
-      const tierNote =
-        `SEEDING_COMPLETE rejected — tier validation failed: ${tierCheck.reason}. ` +
-        `Complete the missing disciplines before emitting SEEDING_COMPLETE.`
-      appendChatMessage(projectDir, {
-        id: genId(),
-        role: 'rouge',
-        content: tierNote,
-        timestamp: new Date().toISOString(),
-        kind: 'system_note',
-        metadata: { discipline: activeDiscipline ?? undefined },
-      })
-      appendPendingCorrection(projectDir, `[SYSTEM NOTE] ${tierNote}`)
-      missingArtifacts = tierCheck.missing
-    } else {
-      const finalizeResult = await finalizeSeeding(projectDir)
-      if (finalizeResult.ok) {
-        markSeedingComplete(projectDir)
-        readyTransition = true
-      } else {
-        missingArtifacts = finalizeResult.missingArtifacts
-      }
-    }
+    const ignoreNote = 'SEEDING_COMPLETE ignored — seeding finalization is controlled by user approval. Do not emit this marker.'
+    appendChatMessage(projectDir, {
+      id: genId(),
+      role: 'rouge',
+      content: ignoreNote,
+      timestamp: new Date().toISOString(),
+      kind: 'system_note',
+      metadata: { discipline: activeDiscipline ?? undefined },
+    })
+    appendPendingCorrection(projectDir, `[SYSTEM NOTE] ${ignoreNote}`)
   }
 
   // Auto-continuation. Two shapes:
@@ -916,10 +918,12 @@ async function runSeedingTurn(
   // chat note so the user knows to nudge with a message.
   const atDepthLimit = chunkDepth + 1 >= MAX_CHUNK_DEPTH
   const postContinuationState = readSeedingState(projectDir)
+  const isNowAwaitingApproval = isAwaitingApproval(postContinuationState)
   const shouldContinueForAdvance =
     acceptedDisciplines.length > 0 &&
     !markers.seedingComplete &&
-    !atDepthLimit
+    !atDepthLimit &&
+    !isNowAwaitingApproval
   // Only auto-continue a non-advancing turn if Claude actually emitted
   // decision/heartbeat markers — that's the signal it's in the middle
   // of autonomous work. A turn that was pure prose (no markers) is
@@ -935,6 +939,7 @@ async function runSeedingTurn(
     rejectedDisciplines.length === 0 &&
     emittedAutonomousMarkers &&
     postContinuationState.mode !== 'awaiting_gate' &&
+    !isNowAwaitingApproval &&
     postContinuationState.status === 'active' &&
     !atDepthLimit
 
@@ -988,9 +993,8 @@ async function runSeedingTurn(
     ok: true,
     status: 200,
     disciplineComplete: acceptedDisciplines.length > 0 ? acceptedDisciplines : undefined,
-    seedingComplete: markers.seedingComplete,
-    readyTransition,
-    missingArtifacts,
+    seedingComplete: false,
+    readyTransition: false,
   }
 }
 
@@ -1069,11 +1073,27 @@ async function reconcileDisciplineState(
     // this runs, so the in-memory state alone is insufficient).
     if (isAwaitingGateFor(state, d)) break
     if (preClearGateDiscipline === d) break
+    // If there's already a discipline awaiting approval, don't propose
+    // another one — only one can be pending at a time.
+    if (state.discipline_awaiting_approval) break
     const check = verifyDisciplineArtifact(projectDir, d)
     if (check.ok) {
-      await markDisciplineComplete(projectDir, d)
-      complete.add(d)
+      setAwaitingApproval(projectDir, d)
+      await updateDisciplineStatusInState(projectDir, d, 'awaiting_approval')
       newlyComplete.push(d)
+
+      const isKill = d === 'taste' && check.killVerdict
+      const approvalContent = isKill
+        ? `**Taste verdict: KILL.** The idea didn't pass the taste gate. Review the graveyard entry and archive this project, or revise to continue.`
+        : `**${d}** artifact verified on disk. Accept to continue to the next discipline, or reply with feedback to revise.`
+      appendChatMessage(projectDir, {
+        id: genId(),
+        role: 'rouge',
+        content: approvalContent,
+        timestamp: new Date().toISOString(),
+        kind: 'approve_prompt',
+        metadata: { discipline: d, killVerdict: isKill || undefined },
+      })
     } else {
       // First real gap — don't look further. If brainstorming genuinely
       // has no artifact, we cannot mark competition etc. as complete

--- a/dashboard/src/bridge/seed-handler.ts
+++ b/dashboard/src/bridge/seed-handler.ts
@@ -441,11 +441,56 @@ async function runSeedingTurn(
       clearPendingGate(projectDir)
     }
 
-    // If a discipline is awaiting approval and the user sends a message
-    // (instead of clicking Accept), treat it as revision feedback.
-    // Clear the approval state so the discipline reverts to active.
+    // If a discipline is awaiting approval and the user sends a message:
+    // - Acceptance words ("accept", "approve", "yes", "ok", "continue",
+    //   "lgtm") → treat as clicking Accept & continue
+    // - Anything else → treat as revision feedback
     const preApprovalState = readSeedingState(projectDir)
     if (isAwaitingApproval(preApprovalState)) {
+      const trimmedLower = text.trim().toLowerCase().replace(/[.!,]/g, '')
+      const isAcceptance = ['accept', 'approve', 'approved', 'yes', 'ok', 'okay',
+        'continue', 'lgtm', 'looks good', 'accept recommendations',
+        'accept and continue', 'accept & continue'].includes(trimmedLower)
+
+      if (isAcceptance && preApprovalState.discipline_awaiting_approval) {
+        console.log(`[seeding] user typed "${trimmedLower}" while ${preApprovalState.discipline_awaiting_approval} awaiting approval — treating as Accept`)
+        const disc = preApprovalState.discipline_awaiting_approval
+        clearAwaitingApproval(projectDir)
+        await markDisciplineComplete(projectDir, disc)
+        // Don't process the text through Claude — just advance
+        // The approval endpoint would fire a kickoff, but since we're
+        // inside runSeedingTurn already, we need to let the continuation
+        // logic below handle the kickoff. Set acceptedDisciplines so
+        // the return signals the advancement.
+        // We skip the Claude call by returning early here.
+        appendChatMessage(projectDir, {
+          id: genId(),
+          role: 'human',
+          content: text,
+          timestamp: new Date().toISOString(),
+          metadata: { discipline: disc },
+        })
+        appendChatMessage(projectDir, {
+          id: genId(),
+          role: 'rouge',
+          content: `${disc} approved. Advancing to the next discipline.`,
+          timestamp: new Date().toISOString(),
+          kind: 'system_note',
+          metadata: { discipline: disc },
+        })
+        // Read the new state and fire kickoff for the next discipline
+        const postApprovalState = readSeedingState(projectDir)
+        const nextDisc = postApprovalState.current_discipline
+        if (nextDisc && !(postApprovalState.disciplines_complete ?? []).includes(nextDisc) && nextDisc !== 'sizing') {
+          await runContinuationTurn(projectDir, [
+            `[SYSTEM] Discipline ${disc} approved by user. State has advanced.`,
+            `You are now entering ${nextDisc.toUpperCase()}. The sub-prompt for that discipline is attached to this turn; follow its rules exactly.`,
+            `Begin the new discipline by asking its first question to the human.`,
+          ].join(' '), 0, `kickoff-${nextDisc}`)
+        }
+        return { ok: true, status: 200, disciplineComplete: [disc], seedingComplete: false, readyTransition: false }
+      }
+
       console.log(`[seeding] user sent message while ${preApprovalState.discipline_awaiting_approval} awaiting approval — treating as revision`)
       clearAwaitingApproval(projectDir)
       // Also clear the final approval flag if set

--- a/dashboard/src/bridge/seed-handler.ts
+++ b/dashboard/src/bridge/seed-handler.ts
@@ -725,6 +725,7 @@ async function runSeedingTurn(
 
   const acceptedDisciplines: string[] = []
   const rejectedDisciplines: Array<{ discipline: string; reason: string }> = []
+  const deferredApprovalCards: Array<{ discipline: string; isKill: boolean }> = []
 
   // Process DISCIPLINE_COMPLETE markers (require artifact verification).
   for (const d of markers.disciplinesComplete) {
@@ -782,17 +783,13 @@ async function runSeedingTurn(
         await updateDisciplineStatusInState(projectDir, d, 'awaiting_approval')
         acceptedDisciplines.push(d)
 
-        const isKill = d === 'taste' && check.killVerdict
-        const approvalContent = isKill
-          ? `**Taste verdict: KILL.** The idea didn't pass the taste gate. Review the graveyard entry and archive this project, or revise to continue.`
-          : `**${d}** artifact verified on disk. Accept to continue to the next discipline, or reply with feedback to revise.`
-        appendChatMessage(projectDir, {
-          id: genId(),
-          role: 'rouge',
-          content: approvalContent,
-          timestamp: new Date().toISOString(),
-          kind: 'approve_prompt',
-          metadata: { discipline: d, killVerdict: isKill || undefined },
+        // Defer the approval card — append it AFTER Claude's response
+        // segments (which include [WROTE:] summaries) so the user sees
+        // what was produced before being asked to accept.
+        const isKill = d === 'taste' && check.killVerdict === true
+        deferredApprovalCards.push({
+          discipline: d,
+          isKill,
         })
       }
     } else {
@@ -942,6 +939,21 @@ async function runSeedingTurn(
   }
   // Reuse the segments parsed above for the gate-and-complete guard.
   appendSegmentedRougeMessages(projectDir, prelimSegments, activeDiscipline ?? undefined)
+  // Now append deferred approval cards — AFTER the response segments
+  // so [WROTE:] summaries appear before the "Accept" prompt.
+  for (const card of deferredApprovalCards) {
+    const approvalContent = card.isKill
+      ? `**Taste verdict: KILL.** The idea didn't pass the taste gate. Review the graveyard entry and archive this project, or revise to continue.`
+      : `**${card.discipline}** artifact verified on disk. Accept to continue to the next discipline, or reply with feedback to revise.`
+    appendChatMessage(projectDir, {
+      id: genId(),
+      role: 'rouge',
+      content: approvalContent,
+      timestamp: new Date().toISOString(),
+      kind: 'approve_prompt',
+      metadata: { discipline: card.discipline, killVerdict: card.isKill || undefined },
+    })
+  }
   applyMarkerStateEffects(projectDir, prelimSegments, activeDiscipline)
   if (rejectedDisciplines.length > 0) {
     // Claude-facing note keeps the [SYSTEM NOTE] prefix — that text is

--- a/dashboard/src/bridge/seed-handler.ts
+++ b/dashboard/src/bridge/seed-handler.ts
@@ -478,15 +478,15 @@ async function runSeedingTurn(
           kind: 'system_note',
           metadata: { discipline: disc },
         })
-        // Read the new state and fire kickoff for the next discipline
-        const postApprovalState = readSeedingState(projectDir)
-        const nextDisc = postApprovalState.current_discipline
-        if (nextDisc && !(postApprovalState.disciplines_complete ?? []).includes(nextDisc) && nextDisc !== 'sizing') {
+        // Fire a continuation that triggers the classifier (after
+        // brainstorming) and kicks off the next applicable discipline.
+        try {
           await runContinuationTurn(projectDir, [
             `[SYSTEM] Discipline ${disc} approved by user. State has advanced.`,
-            `You are now entering ${nextDisc.toUpperCase()}. The sub-prompt for that discipline is attached to this turn; follow its rules exactly.`,
-            `Begin the new discipline by asking its first question to the human.`,
-          ].join(' '), 0, `kickoff-${nextDisc}`)
+            `Continue with the next discipline.`,
+          ].join(' '), 0, `post-approval-${disc}`)
+        } catch (err) {
+          console.error(`[seeding] post-approval kickoff failed:`, err)
         }
         return { ok: true, status: 200, disciplineComplete: [disc], seedingComplete: false, readyTransition: false }
       }

--- a/dashboard/src/bridge/seed-handler.ts
+++ b/dashboard/src/bridge/seed-handler.ts
@@ -754,24 +754,47 @@ async function runSeedingTurn(
     }
     const check = verifyDisciplineArtifact(projectDir, d)
     if (check.ok) {
-      // Don't complete immediately — enter awaiting_approval so the
-      // user must click "Accept & continue" before state advances.
-      setAwaitingApproval(projectDir, d)
-      await updateDisciplineStatusInState(projectDir, d, 'awaiting_approval')
-      acceptedDisciplines.push(d)
+      // If the user answered a gate for this discipline this turn, they
+      // already gave consent — skip the approval card and complete
+      // directly. The approval card is only for when artifacts appear
+      // without a preceding gate answer (autonomous completion or
+      // reconciliation).
+      const userAnsweredGateForThis = preGatePending?.discipline === d
+      if (userAnsweredGateForThis) {
+        await markDisciplineComplete(projectDir, d)
+        acceptedDisciplines.push(d)
+        if (d === 'taste' && check.killVerdict) {
+          const ss = readSeedingState(projectDir)
+          ss.taste_kill = true
+          ss.taste_kill_at = new Date().toISOString()
+          writeSeedingState(projectDir, ss)
+        }
+        appendChatMessage(projectDir, {
+          id: genId(),
+          role: 'rouge',
+          content: `${d} complete — artifact verified. Advancing to the next discipline.`,
+          timestamp: new Date().toISOString(),
+          kind: 'system_note',
+          metadata: { discipline: d },
+        })
+      } else {
+        setAwaitingApproval(projectDir, d)
+        await updateDisciplineStatusInState(projectDir, d, 'awaiting_approval')
+        acceptedDisciplines.push(d)
 
-      const isKill = d === 'taste' && check.killVerdict
-      const approvalContent = isKill
-        ? `**Taste verdict: KILL.** The idea didn't pass the taste gate. Review the graveyard entry and archive this project, or revise to continue.`
-        : `**${d}** artifact verified on disk. Accept to continue to the next discipline, or reply with feedback to revise.`
-      appendChatMessage(projectDir, {
-        id: genId(),
-        role: 'rouge',
-        content: approvalContent,
-        timestamp: new Date().toISOString(),
-        kind: 'approve_prompt',
-        metadata: { discipline: d, killVerdict: isKill || undefined },
-      })
+        const isKill = d === 'taste' && check.killVerdict
+        const approvalContent = isKill
+          ? `**Taste verdict: KILL.** The idea didn't pass the taste gate. Review the graveyard entry and archive this project, or revise to continue.`
+          : `**${d}** artifact verified on disk. Accept to continue to the next discipline, or reply with feedback to revise.`
+        appendChatMessage(projectDir, {
+          id: genId(),
+          role: 'rouge',
+          content: approvalContent,
+          timestamp: new Date().toISOString(),
+          kind: 'approve_prompt',
+          metadata: { discipline: d, killVerdict: isKill || undefined },
+        })
+      }
     } else {
       console.warn(
         `[seeding] rejecting DISCIPLINE_COMPLETE(${d}) — ${check.reason}`,

--- a/dashboard/src/bridge/seeding-finalize.ts
+++ b/dashboard/src/bridge/seeding-finalize.ts
@@ -375,8 +375,8 @@ function ensureVision(projectDir: string): void {
     const manifest = JSON.parse(readFileSync(join(projectDir, 'infrastructure_manifest.json'), 'utf-8'))
     infrastructure = {
       deployment_target: manifest.deploy?.target,
-      needs_database: !!(manifest.database?.provider),
-      needs_auth: !!(manifest.auth?.strategy),
+      needs_database: !!(manifest.database?.provider && manifest.database.provider !== 'none'),
+      needs_auth: !!(manifest.auth?.strategy && manifest.auth.strategy !== 'none'),
     }
   } catch { /* no manifest */ }
 
@@ -475,8 +475,8 @@ function propagateInfrastructureFromManifest(projectDir: string): void {
   const target = manifest.deploy?.target
   if (!target || typeof target !== 'string') return
 
-  const needsDatabase = !!(manifest.database && manifest.database.provider)
-  const needsAuth = !!(manifest.auth && (manifest.auth.strategy || manifest.auth.provider))
+  const needsDatabase = !!(manifest.database && manifest.database.provider && manifest.database.provider !== 'none')
+  const needsAuth = !!(manifest.auth && manifest.auth.strategy && manifest.auth.strategy !== 'none')
 
   const visionPath = join(projectDir, 'vision.json')
   if (existsSync(visionPath)) {

--- a/dashboard/src/bridge/seeding-finalize.ts
+++ b/dashboard/src/bridge/seeding-finalize.ts
@@ -300,6 +300,149 @@ function ensureProductStandard(projectDir: string): void {
 }
 
 /**
+ * Generate vision.json from existing discipline artifacts if it doesn't exist.
+ * Assembles from brainstorming (product name, persona, problem), taste
+ * (scope), sizing (project_size), and infrastructure manifest (deploy target).
+ */
+function ensureVision(projectDir: string): void {
+  const visionPath = join(projectDir, 'vision.json')
+  if (existsSync(visionPath) && statSync(visionPath).size >= 200) return
+
+  // Read brainstorming artifact for product identity
+  let productName = 'Untitled'
+  let oneLiner = ''
+  let persona = ''
+  let problem = ''
+  for (const candidate of ['seed_spec/brainstorming.md', 'seed_spec/brainstorming-design-doc.md', 'docs/brainstorming.md']) {
+    const p = join(projectDir, candidate)
+    if (!existsSync(p)) continue
+    try {
+      const text = readFileSync(p, 'utf-8')
+      // Extract product name from first H1: "# Product Name — subtitle"
+      const h1 = text.match(/^#\s+(.+)/m)
+      if (h1) {
+        const parts = h1[1].split(/\s*[—–-]\s*/)
+        productName = parts[0].trim()
+        if (parts[1]) oneLiner = parts[1].trim()
+      }
+      // Extract persona from "## The User" or "**Persona:**" sections
+      const personaMatch = text.match(/(?:##\s*The User|Persona)[:\s]*\n+\*\*(.+?)\*\*/)
+        ?? text.match(/Persona[:\s]+(.+?)(?:\n|$)/i)
+      if (personaMatch) persona = personaMatch[1].trim()
+      // Extract problem from "## The Problem" section
+      const problemMatch = text.match(/##\s*The Problem\s*\n+([\s\S]*?)(?=\n##|\n$)/i)
+      if (problemMatch) problem = problemMatch[1].trim().split('\n')[0]
+      break
+    } catch { /* try next */ }
+  }
+
+  // Read taste for scope
+  let scope: { in: string[]; out: string[]; deferred: string[] } | undefined
+  for (const candidate of ['seed_spec/taste.md', 'seed_spec/taste_verdict.md']) {
+    const p = join(projectDir, candidate)
+    if (!existsSync(p)) continue
+    try {
+      const text = readFileSync(p, 'utf-8')
+      const jsonMatch = text.match(/```json\s*([\s\S]*?)```/)
+      if (jsonMatch) {
+        const data = JSON.parse(jsonMatch[1])
+        const brief = data.sharpened_brief
+        if (brief) {
+          scope = {
+            in: Array.isArray(brief.scope_in) ? brief.scope_in : [],
+            out: Array.isArray(brief.scope_out) ? brief.scope_out : [],
+            deferred: Array.isArray(brief.scope_deferred) ? brief.scope_deferred : [],
+          }
+          if (brief.one_liner) oneLiner = brief.one_liner
+          if (brief.persona) persona = brief.persona
+          if (brief.problem) problem = brief.problem
+        }
+      }
+      break
+    } catch { /* try next */ }
+  }
+
+  // Read sizing for project_size
+  let projectSize: string | undefined
+  try {
+    const sizing = JSON.parse(readFileSync(join(projectDir, 'seed_spec/sizing.json'), 'utf-8'))
+    projectSize = sizing.project_size
+  } catch { /* no sizing */ }
+
+  // Read infrastructure manifest
+  let infrastructure: Record<string, unknown> = {}
+  try {
+    const manifest = JSON.parse(readFileSync(join(projectDir, 'infrastructure_manifest.json'), 'utf-8'))
+    infrastructure = {
+      deployment_target: manifest.deploy?.target,
+      needs_database: !!(manifest.database?.provider),
+      needs_auth: !!(manifest.auth?.strategy),
+    }
+  } catch { /* no manifest */ }
+
+  const vision: Record<string, unknown> = {
+    product_name: productName,
+    one_liner: oneLiner || `${productName} — a ${projectSize ?? 'small'} project`,
+    persona: persona || 'users',
+    problem: problem || '',
+    infrastructure,
+    generated: true,
+    generated_at: new Date().toISOString(),
+  }
+  if (scope) vision.scope = scope
+  if (projectSize) {
+    vision.complexity_profile = {
+      primary: projectSize === 'XS' ? 'single-page' : 'multi-route',
+    }
+  }
+
+  writeJsonAtomic(visionPath, vision)
+}
+
+/**
+ * Generate task_ledger.json from seed_spec/milestones.json if it doesn't exist.
+ * The milestones file is schema-validated by the spec discipline's artifact
+ * check, so by the time finalization runs it's guaranteed to be well-formed.
+ */
+function ensureTaskLedger(projectDir: string): void {
+  const ledgerPath = join(projectDir, 'task_ledger.json')
+  if (existsSync(ledgerPath)) return
+
+  // Read milestones.json — the source of truth for story structure
+  const milestonesPath = join(projectDir, 'seed_spec/milestones.json')
+  if (!existsSync(milestonesPath)) return
+  let milestones: unknown[]
+  try {
+    const data = JSON.parse(readFileSync(milestonesPath, 'utf-8'))
+    milestones = Array.isArray(data.milestones) ? data.milestones : []
+  } catch {
+    return
+  }
+  if (milestones.length === 0) return
+
+  // Read project name from brainstorming
+  let projectName = 'untitled'
+  for (const candidate of ['seed_spec/brainstorming.md', 'seed_spec/brainstorming-design-doc.md']) {
+    const p = join(projectDir, candidate)
+    if (!existsSync(p)) continue
+    try {
+      const h1 = readFileSync(p, 'utf-8').match(/^#\s+(.+)/m)
+      if (h1) {
+        projectName = h1[1].split(/\s*[—–-]\s*/)[0].trim()
+      }
+      break
+    } catch { /* try next */ }
+  }
+
+  writeJsonAtomic(ledgerPath, {
+    project: projectName,
+    seeded_at: new Date().toISOString(),
+    seeded_by: 'bridge',
+    milestones,
+  })
+}
+
+/**
  * Mirror infrastructure decisions from `infrastructure_manifest.json` into
  * `vision.json.infrastructure` (and `cycle_context.json.vision.infrastructure`),
  * where the launcher's provisioner actually looks them up.
@@ -387,8 +530,10 @@ function propagateInfrastructureFromManifest(projectDir: string): void {
 }
 
 export async function finalizeSeeding(projectDir: string): Promise<FinalizeResult> {
-  // Generate product_standard.json from library defaults if no
-  // discipline wrote it. Must run before the artifact check below.
+  // Generate missing artifacts from existing discipline outputs.
+  // These run before the artifact check so the check validates them.
+  ensureVision(projectDir)
+  ensureTaskLedger(projectDir)
   ensureProductStandard(projectDir)
 
   // Propagate deployment_target and needs_* from the infrastructure

--- a/dashboard/src/bridge/seeding-finalize.ts
+++ b/dashboard/src/bridge/seeding-finalize.ts
@@ -663,17 +663,28 @@ export async function finalizeSeeding(projectDir: string): Promise<FinalizeResul
       }
 
       state.current_state = 'ready'
-      // Initialize the foundation field. Previously the orchestrator
-      // prompt was supposed to do this on human approval, but the bridge
-      // finalize path runs independently and left `foundation: null`
-      // behind — testimonial reached state=foundation with a null
-      // foundation field and rouge-loop crashed when it tried to read
-      // `state.foundation.status`. Setting `{ status: 'pending' }` here
-      // guarantees the shape is sound whenever state advances to 'ready'.
-      //
-      // If the caller (orchestrator) has already set foundation to
-      // something more specific (e.g., `{ status: 'complete' }` when the
-      // complexity profile waives foundation), preserve it.
+
+      // Copy milestones from task_ledger.json into state.json. The build
+      // loop reads task_ledger.json, but the dashboard reads state.json
+      // for the milestone timeline UI. Without this, state.milestones
+      // stays empty and the build escalates with "no milestones in state."
+      if (!state.milestones || state.milestones.length === 0) {
+        const lp = join(projectDir, 'task_ledger.json')
+        if (existsSync(lp)) {
+          try {
+            const ledger = JSON.parse(readFileSync(lp, 'utf-8'))
+            if (Array.isArray(ledger.milestones) && ledger.milestones.length > 0) {
+              state.milestones = ledger.milestones.map((m: { name: string; status?: string; stories?: unknown[] }) => ({
+                name: m.name,
+                status: m.status ?? 'pending',
+                stories: Array.isArray(m.stories) ? m.stories : [],
+              }))
+            }
+          } catch { /* malformed ledger — milestones stay empty, build will escalate */ }
+        }
+      }
+
+      // Initialize the foundation field.
       if (!state.foundation) {
         state.foundation = { status: 'pending' }
       }

--- a/dashboard/src/bridge/seeding-state.ts
+++ b/dashboard/src/bridge/seeding-state.ts
@@ -103,10 +103,10 @@ function nextDiscipline(complete: string[]): string {
  * inside a withStateLock block, use updateDisciplineStatusInStateUnlocked
  * instead to avoid deadlock.
  */
-async function updateDisciplineStatusInState(
+export async function updateDisciplineStatusInState(
   projectDir: string,
   discipline: string,
-  targetStatus: 'in-progress' | 'complete',
+  targetStatus: 'in-progress' | 'complete' | 'awaiting_approval',
 ): Promise<void> {
   await withStateLock(projectDir, async () => {
     await updateDisciplineStatusInStateUnlocked(projectDir, discipline, targetStatus)
@@ -120,7 +120,7 @@ async function updateDisciplineStatusInState(
 async function updateDisciplineStatusInStateUnlocked(
   projectDir: string,
   discipline: string,
-  targetStatus: 'in-progress' | 'complete',
+  targetStatus: 'in-progress' | 'complete' | 'awaiting_approval',
 ): Promise<void> {
   const stateFile = statePath(projectDir)
   if (!existsSync(stateFile)) return
@@ -132,8 +132,9 @@ async function updateDisciplineStatusInStateUnlocked(
     const entry = disciplines.find(d => d.discipline === discipline)
     if (!entry) return
 
-    // Monotonic forward-only promotion. Rank: pending < in-progress < complete.
-    const rank = (s: string) => (s === 'complete' ? 2 : s === 'in-progress' ? 1 : 0)
+    // Monotonic forward-only promotion. awaiting_approval sits between
+    // in-progress and complete (user must approve before it's truly done).
+    const rank = (s: string) => (s === 'complete' ? 3 : s === 'awaiting_approval' ? 2 : s === 'in-progress' ? 1 : 0)
     if (rank(targetStatus) > rank(entry.status)) {
       entry.status = targetStatus
     } else {
@@ -314,7 +315,7 @@ export function updateHeartbeat(projectDir: string): void {
  * treated as `running_autonomous` — matches pre-gated-autonomy behaviour
  * and keeps old projects reconciling the way they used to.
  */
-export function effectiveMode(state: SeedingSessionState): 'awaiting_gate' | 'running_autonomous' {
+export function effectiveMode(state: SeedingSessionState): 'awaiting_gate' | 'running_autonomous' | 'awaiting_approval' {
   return state.mode ?? 'running_autonomous'
 }
 
@@ -325,4 +326,38 @@ export function effectiveMode(state: SeedingSessionState): 'awaiting_gate' | 'ru
  */
 export function isAwaitingGateFor(state: SeedingSessionState, discipline: string): boolean {
   return effectiveMode(state) === 'awaiting_gate' && state.pending_gate?.discipline === discipline
+}
+
+/**
+ * Transition a discipline to "awaiting approval" — artifact is verified
+ * on disk, but the user hasn't accepted advancement yet. The bridge
+ * pauses here: no continuation turns fire, no discipline advancement.
+ */
+export function setAwaitingApproval(projectDir: string, discipline: string): void {
+  const state = readSeedingState(projectDir)
+  if (state.discipline_awaiting_approval === discipline) return
+  state.mode = 'awaiting_approval'
+  state.discipline_awaiting_approval = discipline
+  state.approval_requested_at = new Date().toISOString()
+  state.last_activity = new Date().toISOString()
+  writeSeedingState(projectDir, state)
+}
+
+/**
+ * Clear the approval gate. Called either when the user clicks "Accept"
+ * (before markDisciplineComplete) or when they send revision feedback
+ * (discipline reverts to active).
+ */
+export function clearAwaitingApproval(projectDir: string): void {
+  const state = readSeedingState(projectDir)
+  if (!state.discipline_awaiting_approval && state.mode !== 'awaiting_approval') return
+  state.mode = 'running_autonomous'
+  delete state.discipline_awaiting_approval
+  delete state.approval_requested_at
+  state.last_activity = new Date().toISOString()
+  writeSeedingState(projectDir, state)
+}
+
+export function isAwaitingApproval(state: SeedingSessionState): boolean {
+  return state.mode === 'awaiting_approval' && !!state.discipline_awaiting_approval
 }

--- a/dashboard/src/bridge/state-repair.ts
+++ b/dashboard/src/bridge/state-repair.ts
@@ -3,7 +3,7 @@ import { join } from 'path'
 import { statePath, writeStateJson } from './state-path'
 import { withStateLock } from './state-lock'
 import { finalizeSeeding } from './seeding-finalize'
-import { markSeedingComplete, readSeedingState } from './seeding-state'
+import { markSeedingComplete, readSeedingState, clearAwaitingApproval } from './seeding-state'
 import { DISCIPLINE_SEQUENCE } from './types'
 import { readSeedPid, clearSeedPid } from './seed-daemon-pid'
 import { hasQueuedMessages } from './seed-queue'
@@ -55,18 +55,19 @@ export async function repairProjectState(projectDir: string): Promise<RepairRepo
   }
 
   // Shape 1: stuck in seeding with all disciplines complete.
-  // finalizeSeeding / markSeedingComplete take the state-lock internally.
+  // With human-gated transitions, we no longer auto-finalize — the user
+  // must click "Approve & start build". This repair only flags the state;
+  // the dashboard renders the seeding_summary card for the user to act on.
   if (state.current_state === 'seeding') {
     const seeding = readSeedingState(projectDir)
     const allDone = (seeding.disciplines_complete?.length ?? 0) >= DISCIPLINE_SEQUENCE.length
-    if (allDone && !seeding.seeding_complete) {
-      const result = await finalizeSeeding(projectDir)
-      if (result.ok) {
-        markSeedingComplete(projectDir)
-        fixes.push('stuck-seeding: all 8 disciplines complete but seeding_complete was null → finalized')
-      }
-      // If finalize returned missing artifacts, don't claim a fix —
-      // the state really is incomplete.
+    if (allDone && !seeding.seeding_complete && !seeding.seeding_awaiting_final_approval) {
+      // Surface the final approval card — the user hasn't seen it yet
+      const { writeSeedingState: write } = await import('./seeding-state')
+      const ss = readSeedingState(projectDir)
+      ss.seeding_awaiting_final_approval = true
+      write(projectDir, ss)
+      fixes.push('stuck-seeding: all disciplines complete but no final approval card → surfaced')
     }
   }
 
@@ -88,6 +89,19 @@ export async function repairProjectState(projectDir: string): Promise<RepairRepo
   })
   if (shape2Fixed) {
     fixes.push('null-foundation: current_state=foundation with null foundation → set { status: "pending" }')
+  }
+
+  // Shape 2b: stale discipline_awaiting_approval — the discipline is
+  // already in disciplines_complete (e.g. from a crash mid-approval).
+  if (state.current_state === 'seeding') {
+    const seeding = readSeedingState(projectDir)
+    if (seeding.discipline_awaiting_approval) {
+      const complete = seeding.disciplines_complete ?? []
+      if (complete.includes(seeding.discipline_awaiting_approval)) {
+        clearAwaitingApproval(projectDir)
+        fixes.push(`stale-approval: ${seeding.discipline_awaiting_approval} awaiting approval but already in disciplines_complete → cleared`)
+      }
+    }
   }
 
   // Shape 3: current_state='escalation' but escalations[] has no pending

--- a/dashboard/src/bridge/types.ts
+++ b/dashboard/src/bridge/types.ts
@@ -179,6 +179,10 @@ export type SeedingMessageKind =
   // produced-work notification. Used heavily by spec for per-FA
   // completions.
   | 'wrote_artifact'
+  // Discipline approval prompt: artifact verified, user must accept or revise.
+  | 'approve_prompt'
+  // Final seeding summary: all disciplines done, user must approve to start build.
+  | 'seeding_summary'
 
 export interface SeedingChatMessage {
   id: string           // e.g. "msg-1712345678-abc"
@@ -195,6 +199,7 @@ export interface SeedingChatMessage {
     // anchor a reply to the right gate and lets the override mechanism
     // (PR 2) rewind to a specific decision.
     markerId?: string
+    killVerdict?: boolean
   }
 }
 
@@ -237,7 +242,7 @@ export interface SeedingSessionState {
   //   [HEARTBEAT:] markers. The next user message becomes an override,
   //   not a gate answer.
   // Undefined on legacy state files = treated as 'running_autonomous'.
-  mode?: 'awaiting_gate' | 'running_autonomous'
+  mode?: 'awaiting_gate' | 'running_autonomous' | 'awaiting_approval'
 
   // The gate Rouge is currently waiting on. Must be set iff
   // mode === 'awaiting_gate'.
@@ -262,6 +267,20 @@ export interface SeedingSessionState {
   applicable_disciplines?: string[]
   /** Project size tier from the auto-classifier. */
   project_size?: string
+
+  // ─── Discipline approval gate ─────────────────────────────────────
+  //
+  // Set when a discipline's artifact is verified but the user hasn't
+  // approved advancement yet. The bridge pauses here — no continuation
+  // turns fire, no discipline advancement happens — until the user
+  // clicks "Accept & continue" or sends revision feedback.
+
+  /** Discipline whose artifact is verified, awaiting user approval. */
+  discipline_awaiting_approval?: string
+  /** ISO 8601 timestamp when approval was requested. */
+  approval_requested_at?: string
+  /** True when all disciplines are approved but final seeding sign-off is pending. */
+  seeding_awaiting_final_approval?: boolean
 
   // ─── Taste kill gate ──────────────────────────────────────────────
   //

--- a/dashboard/src/components/chat-message.tsx
+++ b/dashboard/src/components/chat-message.tsx
@@ -65,9 +65,11 @@ interface ChatMessageProps {
   onApproveSeeding?: () => void
   /** True while an approval API call is in flight. */
   approvalLoading?: boolean
+  /** Called when user clicks a gate option chip (sends the letter as message). */
+  onSendGateAnswer?: (text: string) => void
 }
 
-export function ChatMessage({ message, onResume, resumeDisabled, onApproveDiscipline, onApproveSeeding, approvalLoading }: ChatMessageProps) {
+export function ChatMessage({ message, onResume, resumeDisabled, onApproveDiscipline, onApproveSeeding, approvalLoading, onSendGateAnswer }: ChatMessageProps) {
   const [reasoningOpen, setReasoningOpen] = useState(false)
 
   // Human messages
@@ -103,7 +105,7 @@ export function ChatMessage({ message, onResume, resumeDisabled, onApproveDiscip
   // into prose and gates visually demand an answer.
   if (message.kind === 'gate_question') {
     return (
-      <GateQuestionMessage message={message} />
+      <GateQuestionMessage message={message} onSendAnswer={onSendGateAnswer} answerDisabled={resumeDisabled} />
     )
   }
   if (message.kind === 'autonomous_decision') {
@@ -235,10 +237,43 @@ export function ChatMessage({ message, onResume, resumeDisabled, onApproveDiscip
   )
 }
 
-// A hard or soft gate — Rouge is waiting on the user. Render
-// prominently so it's visually distinct from prose/decisions and the
-// user knows this is the thing blocking progress.
-function GateQuestionMessage({ message }: { message: ChatMessageType }) {
+interface ParsedOption {
+  letter: string
+  text: string
+}
+
+function parseGateOptions(content: string): { body: string; options: ParsedOption[]; recommendation?: string } {
+  const lines = content.split('\n')
+  const options: ParsedOption[] = []
+  const bodyLines: string[] = []
+  let recommendation: string | undefined
+
+  for (const line of lines) {
+    const optMatch = line.match(/^([A-Z])\)\s+(.+)/)
+    const recMatch = line.match(/^Recommendation:\s*([A-Z])\b/)
+    if (optMatch) {
+      options.push({ letter: optMatch[1], text: optMatch[2] })
+    } else if (recMatch) {
+      recommendation = recMatch[1]
+    } else {
+      bodyLines.push(line)
+    }
+  }
+
+  return { body: bodyLines.join('\n').trim(), options, recommendation }
+}
+
+function GateQuestionMessage({
+  message,
+  onSendAnswer,
+  answerDisabled,
+}: {
+  message: ChatMessageType
+  onSendAnswer?: (text: string) => void
+  answerDisabled?: boolean
+}) {
+  const { body, options, recommendation } = parseGateOptions(message.content)
+
   return (
     <div
       data-testid="chat-message"
@@ -263,7 +298,43 @@ function GateQuestionMessage({ message }: { message: ChatMessageType }) {
           </Badge>
         )}
       </div>
-      <Markdown content={message.content} />
+      <Markdown content={body} />
+
+      {options.length > 0 && (
+        <div className="mt-3 flex flex-col gap-2" data-testid="gate-option-chips">
+          {options.map((opt) => (
+            <button
+              key={opt.letter}
+              type="button"
+              onClick={() => onSendAnswer?.(opt.letter)}
+              disabled={answerDisabled || !onSendAnswer}
+              className={cn(
+                'flex items-start gap-2.5 rounded-lg border px-3 py-2.5 text-left text-sm transition-colors',
+                'hover:bg-blue-100/80 disabled:opacity-50 disabled:cursor-not-allowed',
+                opt.letter === recommendation
+                  ? 'border-blue-400 bg-blue-100/50'
+                  : 'border-blue-200 bg-white',
+              )}
+              data-testid={`gate-option-${opt.letter}`}
+            >
+              <span className={cn(
+                'mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full text-xs font-bold',
+                opt.letter === recommendation
+                  ? 'bg-blue-600 text-white'
+                  : 'bg-blue-100 text-blue-700',
+              )}>
+                {opt.letter}
+              </span>
+              <span className="text-gray-800">{opt.text}</span>
+              {opt.letter === recommendation && (
+                <span className="ml-auto mt-0.5 shrink-0 text-[10px] font-medium uppercase tracking-wide text-blue-600">
+                  Recommended
+                </span>
+              )}
+            </button>
+          ))}
+        </div>
+      )}
     </div>
   )
 }

--- a/dashboard/src/components/chat-message.tsx
+++ b/dashboard/src/components/chat-message.tsx
@@ -260,6 +260,21 @@ function parseGateOptions(content: string): { body: string; options: ParsedOptio
     }
   }
 
+  // Fallback: if no lettered options found but the content contains
+  // acceptance language, synthesize an "Accept" chip so the user
+  // doesn't have to type.
+  if (options.length === 0) {
+    const lower = content.toLowerCase()
+    const hasAcceptLanguage = ['accept', 'sign off', 'approve', 'as-is',
+      'recommendations', 'accept the verdict', 'accept the'].some(
+      (phrase) => lower.includes(phrase),
+    )
+    if (hasAcceptLanguage) {
+      options.push({ letter: '✓', text: 'Accept' })
+      recommendation = '✓'
+    }
+  }
+
   return { body: bodyLines.join('\n').trim(), options, recommendation }
 }
 
@@ -306,7 +321,7 @@ function GateQuestionMessage({
             <button
               key={opt.letter}
               type="button"
-              onClick={() => onSendAnswer?.(opt.letter)}
+              onClick={() => onSendAnswer?.(opt.letter === '✓' ? 'accept' : opt.letter)}
               disabled={answerDisabled || !onSendAnswer}
               className={cn(
                 'flex items-start gap-2.5 rounded-lg border px-3 py-2.5 text-left text-sm transition-colors',

--- a/dashboard/src/components/chat-message.tsx
+++ b/dashboard/src/components/chat-message.tsx
@@ -8,7 +8,7 @@ import { Badge } from '@/components/ui/badge'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
-import { ChevronRight, HelpCircle, CircleDot, Activity, Info, Play, FileCheck2 } from 'lucide-react'
+import { ChevronRight, HelpCircle, CircleDot, Activity, Info, Play, FileCheck2, CheckCircle2, Rocket, Loader2 } from 'lucide-react'
 
 // Markdown renderer with tight spacing matched to the chat panel's style
 function Markdown({ content, className }: { content: string; className?: string }) {
@@ -59,9 +59,15 @@ interface ChatMessageProps {
   /** True while a send is in flight — disables the Continue button on
    *  resume prompts so it doesn't fire twice. */
   resumeDisabled?: boolean
+  /** Called when user clicks "Accept & continue" on an approve_prompt. */
+  onApproveDiscipline?: (discipline: string) => void
+  /** Called when user clicks "Approve & start build" on a seeding_summary. */
+  onApproveSeeding?: () => void
+  /** True while an approval API call is in flight. */
+  approvalLoading?: boolean
 }
 
-export function ChatMessage({ message, onResume, resumeDisabled }: ChatMessageProps) {
+export function ChatMessage({ message, onResume, resumeDisabled, onApproveDiscipline, onApproveSeeding, approvalLoading }: ChatMessageProps) {
   const [reasoningOpen, setReasoningOpen] = useState(false)
 
   // Human messages
@@ -127,6 +133,24 @@ export function ChatMessage({ message, onResume, resumeDisabled }: ChatMessagePr
   if (message.kind === 'wrote_artifact') {
     return (
       <WroteArtifactMessage message={message} />
+    )
+  }
+  if (message.kind === 'approve_prompt') {
+    return (
+      <ApprovePromptMessage
+        message={message}
+        onApprove={onApproveDiscipline}
+        loading={approvalLoading}
+      />
+    )
+  }
+  if (message.kind === 'seeding_summary') {
+    return (
+      <SeedingSummaryMessage
+        message={message}
+        onApprove={onApproveSeeding}
+        loading={approvalLoading}
+      />
     )
   }
 
@@ -611,5 +635,92 @@ function ReasoningBlock({
         </div>
       </CollapsibleContent>
     </Collapsible>
+  )
+}
+
+function ApprovePromptMessage({
+  message,
+  onApprove,
+  loading,
+}: {
+  message: ChatMessageType
+  onApprove?: (discipline: string) => void
+  loading?: boolean
+}) {
+  const discipline = message.metadata?.discipline ?? message.discipline ?? 'unknown'
+  const isKill = message.metadata?.killVerdict === true
+  return (
+    <div
+      data-testid="chat-message"
+      data-role="rouge"
+      data-kind="approve_prompt"
+      className="rounded-lg border-2 border-amber-300 bg-amber-50/60 px-4 py-3"
+    >
+      <div className="mb-2 flex items-center gap-2 text-sm font-semibold text-amber-900">
+        <CheckCircle2 className="size-4" />
+        {isKill ? 'Taste verdict: KILL' : `${discipline} ready for review`}
+      </div>
+      <div className="mb-3 text-sm leading-relaxed text-amber-800">
+        <Markdown content={message.content} />
+      </div>
+      <div className="flex items-center gap-2">
+        <Button
+          size="sm"
+          onClick={() => onApprove?.(discipline)}
+          disabled={loading || !onApprove}
+          className={cn(
+            'h-8 gap-1.5 text-xs font-medium',
+            isKill
+              ? 'bg-red-600 hover:bg-red-700 text-white'
+              : 'bg-green-600 hover:bg-green-700 text-white',
+          )}
+          data-testid="approve-discipline-button"
+        >
+          {loading ? <Loader2 className="size-3 animate-spin" /> : <CheckCircle2 className="size-3" />}
+          {isKill ? 'Archive project' : 'Accept & continue'}
+        </Button>
+        <span className="text-xs text-amber-700">or reply with feedback to revise</span>
+      </div>
+    </div>
+  )
+}
+
+function SeedingSummaryMessage({
+  message,
+  onApprove,
+  loading,
+}: {
+  message: ChatMessageType
+  onApprove?: () => void
+  loading?: boolean
+}) {
+  return (
+    <div
+      data-testid="chat-message"
+      data-role="rouge"
+      data-kind="seeding_summary"
+      className="rounded-lg border-2 border-green-300 bg-green-50/60 px-4 py-3"
+    >
+      <div className="mb-2 flex items-center gap-2 text-sm font-semibold text-green-900">
+        <Rocket className="size-4" />
+        Seeding complete — ready to build
+      </div>
+      <div className="mb-3 text-sm leading-relaxed text-green-800">
+        <Markdown content={message.content} />
+      </div>
+      <div className="flex items-center gap-2">
+        <Button
+          size="sm"
+          onClick={onApprove}
+          disabled={loading || !onApprove}
+          className="h-8 gap-1.5 bg-green-600 text-xs font-medium text-white hover:bg-green-700"
+          data-testid="approve-seeding-button"
+        >
+          {loading ? <Loader2 className="size-3 animate-spin" /> : <Rocket className="size-3" />}
+          Approve &amp; start build
+        </Button>
+        <span className="text-xs text-green-700">or reply to revise a discipline</span>
+      </div>
+    </div>
   )
 }

--- a/dashboard/src/components/chat-panel.tsx
+++ b/dashboard/src/components/chat-panel.tsx
@@ -139,8 +139,7 @@ export function ChatPanel({
       : DEFAULT_DISCIPLINE_SEQUENCE as unknown as string[]
     const result: DisciplineGroup[] = []
     for (const d of sequence) {
-      const msgs = messagesByDiscipline.get(d)
-      if (!msgs || msgs.length === 0) continue
+      const msgs = messagesByDiscipline.get(d) ?? []
       const status = complete.has(d)
         ? 'complete'
         : d === awaitingApprovalDiscipline
@@ -148,6 +147,10 @@ export function ChatPanel({
           : d === currentDiscipline
             ? 'current'
             : 'pending'
+      // Show disciplines that have messages, are complete, are currently
+      // active, or are awaiting approval. Skip pending disciplines with
+      // no messages — they haven't started yet.
+      if (msgs.length === 0 && status === 'pending') continue
       result.push({ discipline: d, messages: msgs, status })
     }
     return result
@@ -323,6 +326,19 @@ export function ChatPanel({
               />
             ))
           )}
+          {/* Project-level messages (seeding_summary, approve_prompt without
+              a discipline tag) render outside the discipline sections. These
+              are project-wide, not discipline-scoped. */}
+          {displayMessages
+            .filter((m) => (m.kind === 'seeding_summary' || (m.kind === 'approve_prompt' && !m._discipline)) && !m.isPending)
+            .map((msg) => (
+              <ChatMessage
+                key={msg.id}
+                message={msg}
+                onApproveSeeding={bridgeActive ? seeding.approveSeeding : onApproveSeeding}
+                approvalLoading={bridgeActive ? seeding.isApproving : approvalLoading}
+              />
+            ))}
           {/*
             Activity indicator — shows for the WHOLE time Rouge is
             working, not just during the HTTP send. Before Phase 2:
@@ -545,22 +561,36 @@ function DisciplineSection({
         </span>
       </button>
 
-      {expanded && (
-        <div className="mt-2 flex flex-col gap-4 border-l-2 border-gray-200 pl-4">
-          {group.messages.map((msg) => (
-            <ChatMessage
-              key={msg.id}
-              message={msg}
-              onResume={msg.id === lastMessageId ? onResume : undefined}
-              resumeDisabled={resumeDisabled}
-              onApproveDiscipline={onApproveDiscipline}
-              onApproveSeeding={onApproveSeeding}
-              approvalLoading={approvalLoading}
-              onSendGateAnswer={onSendGateAnswer}
-            />
-          ))}
-        </div>
-      )}
+      {expanded && (() => {
+        const lastApproveIdx = group.messages.reduce(
+          (idx, m, i) => (m.kind === 'approve_prompt' ? i : idx), -1,
+        )
+        return (
+          <div className="mt-2 flex flex-col gap-4 border-l-2 border-gray-200 pl-4">
+            {group.messages.length === 0 && group.status === 'current' && (
+              <div className="flex items-center gap-2 px-3 py-2 text-xs text-muted-foreground">
+                <Loader2 className="size-3 animate-spin" />
+                <span>Working...</span>
+              </div>
+            )}
+            {group.messages.map((msg, idx) => {
+              if (msg.kind === 'approve_prompt' && idx !== lastApproveIdx) return null
+              return (
+                <ChatMessage
+                  key={msg.id}
+                  message={msg}
+                  onResume={msg.id === lastMessageId ? onResume : undefined}
+                  resumeDisabled={resumeDisabled}
+                  onApproveDiscipline={onApproveDiscipline}
+                  onApproveSeeding={onApproveSeeding}
+                  approvalLoading={approvalLoading}
+                  onSendGateAnswer={onSendGateAnswer}
+                />
+              )
+            })}
+          </div>
+        )
+      })()}
     </div>
   )
 }

--- a/dashboard/src/components/chat-panel.tsx
+++ b/dashboard/src/components/chat-panel.tsx
@@ -339,6 +339,11 @@ export function ChatPanel({
                 approvalLoading={bridgeActive ? seeding.isApproving : approvalLoading}
               />
             ))}
+          {bridgeActive && seeding.approvalError && (
+            <div className="rounded-md border border-red-300 bg-red-50 px-4 py-3 text-sm text-red-800">
+              <strong>Approval failed:</strong> {seeding.approvalError}
+            </div>
+          )}
           {/*
             Activity indicator — shows for the WHOLE time Rouge is
             working, not just during the HTTP send. Before Phase 2:

--- a/dashboard/src/components/chat-panel.tsx
+++ b/dashboard/src/components/chat-panel.tsx
@@ -257,9 +257,11 @@ export function ChatPanel({
     }
   }
 
-  // Callback for the Continue button on resume_prompt messages. Routes
-  // through the same sendMessage path as typed input so the chain
-  // resumes with a fresh auto-continuation budget.
+  async function handleGateAnswer(text: string) {
+    if (!bridgeActive || seeding.isSending) return
+    await seeding.sendMessage(text)
+  }
+
   async function handleResume() {
     if (!bridgeActive || seeding.isSending) return
     await seeding.sendMessage('continue')
@@ -299,16 +301,11 @@ export function ChatPanel({
                 onApproveDiscipline={bridgeActive ? seeding.approveDiscipline : onApproveDiscipline}
                 onApproveSeeding={bridgeActive ? seeding.approveSeeding : onApproveSeeding}
                 approvalLoading={bridgeActive ? seeding.isApproving : approvalLoading}
+                onSendGateAnswer={bridgeActive ? handleGateAnswer : undefined}
               />
             ))
           ) : (
             groups.map((group) => (
-              // Transition banners between completed sections were
-              // removed — the "Complete" pill in the section header
-              // plus the left-sidebar stepper already convey handoff.
-              // Stacking both produced ladders of green between every
-              // completed discipline. See feedback from 2026-04-17 PR
-              // #164 dogfood.
               <DisciplineSection
                 key={group.discipline}
                 group={group}
@@ -320,6 +317,7 @@ export function ChatPanel({
                 onApproveDiscipline={bridgeActive ? seeding.approveDiscipline : onApproveDiscipline}
                 onApproveSeeding={bridgeActive ? seeding.approveSeeding : onApproveSeeding}
                 approvalLoading={bridgeActive ? seeding.isApproving : approvalLoading}
+                onSendGateAnswer={bridgeActive ? handleGateAnswer : undefined}
               />
             ))
           )}
@@ -488,6 +486,7 @@ function DisciplineSection({
   onApproveDiscipline,
   onApproveSeeding,
   approvalLoading,
+  onSendGateAnswer,
 }: {
   group: DisciplineGroup
   expanded: boolean
@@ -498,6 +497,7 @@ function DisciplineSection({
   onApproveDiscipline?: (discipline: string) => void
   onApproveSeeding?: () => void
   approvalLoading?: boolean
+  onSendGateAnswer?: (text: string) => void
 }) {
   const label = DISCIPLINE_LABELS[group.discipline] ?? group.discipline
 
@@ -554,6 +554,7 @@ function DisciplineSection({
               onApproveDiscipline={onApproveDiscipline}
               onApproveSeeding={onApproveSeeding}
               approvalLoading={approvalLoading}
+              onSendGateAnswer={onSendGateAnswer}
             />
           ))}
         </div>

--- a/dashboard/src/components/chat-panel.tsx
+++ b/dashboard/src/components/chat-panel.tsx
@@ -25,6 +25,10 @@ interface ChatPanelProps {
   currentDiscipline?: string
   selectedDiscipline?: string
   applicableDisciplines?: string[]
+  onApproveDiscipline?: (discipline: string) => void
+  onApproveSeeding?: () => void
+  approvalLoading?: boolean
+  awaitingApprovalDiscipline?: string
 }
 
 // Default ordering when no applicable list is provided
@@ -50,7 +54,7 @@ type MessageWithDiscipline = ChatMessageType & { _discipline?: string }
 interface DisciplineGroup {
   discipline: string
   messages: MessageWithDiscipline[]
-  status: 'complete' | 'current' | 'pending'
+  status: 'complete' | 'current' | 'pending' | 'awaiting_approval'
 }
 
 export function ChatPanel({
@@ -62,6 +66,10 @@ export function ChatPanel({
   currentDiscipline,
   selectedDiscipline,
   applicableDisciplines,
+  onApproveDiscipline,
+  onApproveSeeding,
+  approvalLoading,
+  awaitingApprovalDiscipline,
 }: ChatPanelProps) {
   const bridgeActive = isBridgeEnabled() && !!slug
   const seeding = useSeeding(bridgeActive ? slug : '')
@@ -131,11 +139,17 @@ export function ChatPanel({
     for (const d of sequence) {
       const msgs = messagesByDiscipline.get(d)
       if (!msgs || msgs.length === 0) continue
-      const status = complete.has(d) ? 'complete' : d === currentDiscipline ? 'current' : 'pending'
+      const status = complete.has(d)
+        ? 'complete'
+        : d === awaitingApprovalDiscipline
+          ? 'awaiting_approval'
+          : d === currentDiscipline
+            ? 'current'
+            : 'pending'
       result.push({ discipline: d, messages: msgs, status })
     }
     return result
-  }, [displayMessages, completedDisciplines, currentDiscipline, applicableDisciplines])
+  }, [displayMessages, completedDisciplines, currentDiscipline, applicableDisciplines, awaitingApprovalDiscipline])
 
   // Auto-expand logic:
   // - If currentDiscipline is provided: expand that one
@@ -280,13 +294,11 @@ export function ChatPanel({
               <ChatMessage
                 key={msg.id}
                 message={msg}
-                // Resume button is only live on the last message — a
-                // resume_prompt buried in history is stale (the user
-                // either resumed it manually or Rouge has since moved
-                // on). Non-last resume_prompts render with a disabled
-                // button.
                 onResume={msg.id === lastMessageId ? handleResume : undefined}
                 resumeDisabled={bridgeActive && seeding.isSending}
+                onApproveDiscipline={bridgeActive ? seeding.approveDiscipline : onApproveDiscipline}
+                onApproveSeeding={bridgeActive ? seeding.approveSeeding : onApproveSeeding}
+                approvalLoading={bridgeActive ? seeding.isApproving : approvalLoading}
               />
             ))
           ) : (
@@ -305,6 +317,9 @@ export function ChatPanel({
                 onResume={handleResume}
                 resumeDisabled={bridgeActive && seeding.isSending}
                 lastMessageId={lastMessageId}
+                onApproveDiscipline={bridgeActive ? seeding.approveDiscipline : onApproveDiscipline}
+                onApproveSeeding={bridgeActive ? seeding.approveSeeding : onApproveSeeding}
+                approvalLoading={bridgeActive ? seeding.isApproving : approvalLoading}
               />
             ))
           )}
@@ -470,6 +485,9 @@ function DisciplineSection({
   onResume,
   resumeDisabled,
   lastMessageId,
+  onApproveDiscipline,
+  onApproveSeeding,
+  approvalLoading,
 }: {
   group: DisciplineGroup
   expanded: boolean
@@ -477,17 +495,22 @@ function DisciplineSection({
   onResume?: () => void
   resumeDisabled?: boolean
   lastMessageId?: string | null
+  onApproveDiscipline?: (discipline: string) => void
+  onApproveSeeding?: () => void
+  approvalLoading?: boolean
 }) {
   const label = DISCIPLINE_LABELS[group.discipline] ?? group.discipline
 
-  // Status rendering as a pill next to the discipline name — replaces
-  // the icon-only status indicator. The pill is self-explanatory and
-  // removes the need for separate transition banners between sections.
   const statusPill =
     group.status === 'complete' ? (
       <span className="inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-0.5 text-[10px] font-medium text-green-700">
         <Check className="size-3" />
         Complete
+      </span>
+    ) : group.status === 'awaiting_approval' ? (
+      <span className="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-medium text-amber-700">
+        <span className="size-1.5 rounded-full bg-amber-500" />
+        Ready for review
       </span>
     ) : group.status === 'current' ? (
       <span className="inline-flex items-center gap-1 rounded-full bg-blue-100 px-2 py-0.5 text-[10px] font-medium text-blue-700">
@@ -503,6 +526,7 @@ function DisciplineSection({
         className={cn(
           'flex w-full items-center gap-2 rounded-md border border-gray-200 bg-gray-50 px-3 py-2 text-left transition-colors hover:bg-gray-100',
           group.status === 'current' && 'border-blue-200 bg-blue-50 hover:bg-blue-100',
+          group.status === 'awaiting_approval' && 'border-amber-300 bg-amber-50 hover:bg-amber-100',
           group.status === 'complete' && 'border-green-200'
         )}
         data-testid={`discipline-section-${group.discipline}`}
@@ -527,6 +551,9 @@ function DisciplineSection({
               message={msg}
               onResume={msg.id === lastMessageId ? onResume : undefined}
               resumeDisabled={resumeDisabled}
+              onApproveDiscipline={onApproveDiscipline}
+              onApproveSeeding={onApproveSeeding}
+              approvalLoading={approvalLoading}
             />
           ))}
         </div>

--- a/dashboard/src/components/chat-panel.tsx
+++ b/dashboard/src/components/chat-panel.tsx
@@ -88,6 +88,8 @@ export function ChatPanel({
         timestamp: m.timestamp,
         kind: m.kind,
         markerId: m.metadata?.markerId,
+        discipline: m.metadata?.discipline as import('@/lib/types').SeedingDiscipline | undefined,
+        metadata: m.metadata ? { discipline: m.metadata.discipline, killVerdict: m.metadata.killVerdict } : undefined,
         _discipline: m.metadata?.discipline,
       }))
       // Optimistic pending human message: append at the end so the

--- a/dashboard/src/components/discipline-stepper.tsx
+++ b/dashboard/src/components/discipline-stepper.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState } from 'react'
 import type { DisciplineProgress, SeedingDiscipline } from '@/lib/types'
 import { cn } from '@/lib/utils'
-import { Check, Circle, Loader2, Minus } from 'lucide-react'
+import { Check, Circle, Loader2, Minus, Clock } from 'lucide-react'
 
 const DISCIPLINE_ORDER: SeedingDiscipline[] = [
   'brainstorming',
@@ -61,6 +61,18 @@ function StatusIcon({
         className="flex size-6 items-center justify-center rounded-full bg-purple-100 text-purple-600"
       >
         <Loader2 className="size-3.5 animate-spin" />
+      </div>
+    )
+  }
+
+  if (status === 'awaiting_approval') {
+    return (
+      <div
+        data-testid="discipline-icon"
+        data-status="awaiting_approval"
+        className="flex size-6 items-center justify-center rounded-full bg-amber-100 text-amber-600"
+      >
+        <Clock className="size-3.5" />
       </div>
     )
   }

--- a/dashboard/src/components/spec-view.tsx
+++ b/dashboard/src/components/spec-view.tsx
@@ -220,7 +220,15 @@ function MilestonePlanCard({
                       {s.acceptance_criteria && s.acceptance_criteria.length > 0 && (
                         <ul className="mt-1 list-inside list-disc space-y-0.5 text-xs text-gray-600">
                           {s.acceptance_criteria.map((ac, i) => (
-                            <li key={i}>{ac}</li>
+                            <li key={i}>
+                              {typeof ac === 'string'
+                                ? ac
+                                : typeof ac === 'object' && ac !== null
+                                  ? (ac as Record<string, unknown>).name
+                                    ? `${(ac as Record<string, unknown>).name}: GIVEN ${(ac as Record<string, unknown>).given ?? ''} WHEN ${(ac as Record<string, unknown>).when ?? ''} THEN ${(ac as Record<string, unknown>).then ?? ''}`
+                                    : JSON.stringify(ac)
+                                  : String(ac)}
+                            </li>
                           ))}
                         </ul>
                       )}

--- a/dashboard/src/lib/bridge-client.ts
+++ b/dashboard/src/lib/bridge-client.ts
@@ -254,3 +254,25 @@ export async function sendSeedMessage(slug: string, text: string): Promise<SendS
   const data = await res.json()
   return { ...data, ok: res.ok }
 }
+
+export async function approveDiscipline(
+  slug: string,
+  discipline: string,
+): Promise<{ ok: boolean; nextDiscipline?: string; killed?: boolean; error?: string }> {
+  const res = await fetch(`${BRIDGE_URL}/api/projects/${slug}/approve-discipline`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ discipline }),
+  })
+  return res.json()
+}
+
+export async function approveSeeding(
+  slug: string,
+): Promise<{ ok: boolean; error?: string; missingArtifacts?: string[] }> {
+  const res = await fetch(`${BRIDGE_URL}/api/projects/${slug}/approve-seeding`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+  })
+  return res.json()
+}

--- a/dashboard/src/lib/bridge-client.ts
+++ b/dashboard/src/lib/bridge-client.ts
@@ -193,12 +193,11 @@ export interface SeedingChatMessage {
   timestamp: string
   // Marker kind for gated-autonomy messages — undefined on legacy
   // or plain prose. Drives distinct rendering in the chat UI.
-  kind?: 'prose' | 'gate_question' | 'autonomous_decision' | 'heartbeat' | 'system_note' | 'resume_prompt' | 'wrote_artifact'
+  kind?: 'prose' | 'gate_question' | 'autonomous_decision' | 'heartbeat' | 'system_note' | 'resume_prompt' | 'wrote_artifact' | 'approve_prompt' | 'seeding_summary'
   metadata?: {
     discipline?: string
-    // Gate id ('brainstorming/H2-north-star') or decision slug —
-    // lets the override mechanism address specific decisions.
     markerId?: string
+    killVerdict?: boolean
   }
 }
 

--- a/dashboard/src/lib/bridge-mapper.ts
+++ b/dashboard/src/lib/bridge-mapper.ts
@@ -25,7 +25,7 @@ const SEEDING_DISCIPLINES: readonly SeedingDiscipline[] = [
   'brainstorming', 'competition', 'taste', 'sizing', 'spec',
   'infrastructure', 'design', 'legal-privacy', 'marketing',
 ]
-const DISCIPLINE_STATUSES: readonly DisciplineStatus[] = ['pending', 'in-progress', 'complete', 'skipped']
+const DISCIPLINE_STATUSES: readonly DisciplineStatus[] = ['pending', 'in-progress', 'complete', 'skipped', 'awaiting_approval']
 const PROJECT_STATES: readonly ProjectState[] = [
   'seeding', 'ready', 'foundation', 'foundation-eval', 'story-building',
   'milestone-check', 'milestone-fix', 'analyzing', 'generating-change-spec',

--- a/dashboard/src/lib/types.ts
+++ b/dashboard/src/lib/types.ts
@@ -48,7 +48,7 @@ export type SeedingDiscipline =
   | 'design'
   | 'legal-privacy'
   | 'marketing'
-export type DisciplineStatus = 'pending' | 'in-progress' | 'complete' | 'skipped'
+export type DisciplineStatus = 'pending' | 'in-progress' | 'complete' | 'skipped' | 'awaiting_approval'
 export type DeployStatus = 'success' | 'failed' | 'rollback'
 export type EscalationTier = 0 | 1 | 2 | 3
 export type Provider = 'vercel' | 'cloudflare' | 'github-pages' | 'supabase' | 'sentry' | 'posthog'
@@ -69,6 +69,8 @@ export type ChatMessageKind =
   | 'system_note'
   | 'resume_prompt'
   | 'wrote_artifact'
+  | 'approve_prompt'
+  | 'seeding_summary'
 
 export type ActivityEventType =
   | 'deploy'
@@ -183,6 +185,10 @@ export interface SeedingProgress {
   applicableDisciplines?: SeedingDiscipline[]
   /** Project tier size (XS/S/M/L/XL). Set after classification. */
   projectSize?: string
+  /** Discipline whose artifact is verified, waiting for user to approve. */
+  awaitingApprovalDiscipline?: SeedingDiscipline
+  /** True when all disciplines approved but final seeding sign-off pending. */
+  seedingAwaitingFinalApproval?: boolean
 }
 
 export interface ConfidencePoint {

--- a/dashboard/src/lib/types.ts
+++ b/dashboard/src/lib/types.ts
@@ -345,6 +345,8 @@ export interface ChatMessage {
   /** The optimistic send failed (rate limit, network). UI renders
    *  the pending bubble with an error mark so the user can retry. */
   pendingErrored?: boolean
+  /** Metadata from the bridge — carries discipline, killVerdict, etc. */
+  metadata?: { discipline?: string; killVerdict?: boolean }
 }
 
 // ─── Activity Feed ───────────────────────────────────────────────────

--- a/dashboard/src/lib/use-seeding.ts
+++ b/dashboard/src/lib/use-seeding.ts
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect, useCallback, useMemo } from 'react'
-import { fetchSeedingMessages, fetchSeedingStatus, sendSeedMessage, type SeedingChatMessage, type SeedingLivenessStatus } from './bridge-client'
+import { fetchSeedingMessages, fetchSeedingStatus, sendSeedMessage, approveDiscipline as approveDisciplineApi, approveSeeding as approveSeedingApi, type SeedingChatMessage, type SeedingLivenessStatus } from './bridge-client'
 import { stallThresholdMsForDiscipline } from './discipline-timing'
 
 // Phase 2 of the seed-loop architecture plan (see
@@ -65,6 +65,9 @@ interface UseSeedingResult {
   heartbeatAgeMs: number | null
   sendMessage: (text: string) => Promise<void>
   refetch: () => Promise<void>
+  approveDiscipline: (discipline: string) => Promise<void>
+  approveSeeding: () => Promise<void>
+  isApproving: boolean
 }
 
 export function useSeeding(slug: string): UseSeedingResult {
@@ -208,6 +211,34 @@ export function useSeeding(slug: string): UseSeedingResult {
     return 'waiting'
   }, [status, heartbeatAgeMs])
 
+  const [isApproving, setIsApproving] = useState(false)
+
+  const approveDiscipline = useCallback(async (discipline: string) => {
+    if (!slug || isApproving) return
+    setIsApproving(true)
+    try {
+      await approveDisciplineApi(slug, discipline)
+      await refetch()
+    } catch (err) {
+      console.error('[useSeeding] approveDiscipline failed:', err)
+    } finally {
+      setIsApproving(false)
+    }
+  }, [slug, isApproving, refetch])
+
+  const approveSeeding = useCallback(async () => {
+    if (!slug || isApproving) return
+    setIsApproving(true)
+    try {
+      await approveSeedingApi(slug)
+      await refetch()
+    } catch (err) {
+      console.error('[useSeeding] approveSeeding failed:', err)
+    } finally {
+      setIsApproving(false)
+    }
+  }, [slug, isApproving, refetch])
+
   return {
     messages,
     status,
@@ -221,5 +252,8 @@ export function useSeeding(slug: string): UseSeedingResult {
     heartbeatAgeMs,
     sendMessage,
     refetch,
+    approveDiscipline,
+    approveSeeding,
+    isApproving,
   }
 }

--- a/dashboard/src/lib/use-seeding.ts
+++ b/dashboard/src/lib/use-seeding.ts
@@ -68,6 +68,7 @@ interface UseSeedingResult {
   approveDiscipline: (discipline: string) => Promise<void>
   approveSeeding: () => Promise<void>
   isApproving: boolean
+  approvalError: string | null
 }
 
 export function useSeeding(slug: string): UseSeedingResult {
@@ -213,14 +214,20 @@ export function useSeeding(slug: string): UseSeedingResult {
 
   const [isApproving, setIsApproving] = useState(false)
 
+  const [approvalError, setApprovalError] = useState<string | null>(null)
+
   const approveDiscipline = useCallback(async (discipline: string) => {
     if (!slug || isApproving) return
     setIsApproving(true)
+    setApprovalError(null)
     try {
-      await approveDisciplineApi(slug, discipline)
+      const result = await approveDisciplineApi(slug, discipline)
+      if (!result.ok) {
+        setApprovalError(result.error ?? 'Discipline approval failed')
+      }
       await refetch()
     } catch (err) {
-      console.error('[useSeeding] approveDiscipline failed:', err)
+      setApprovalError(err instanceof Error ? err.message : 'Discipline approval failed')
     } finally {
       setIsApproving(false)
     }
@@ -229,11 +236,18 @@ export function useSeeding(slug: string): UseSeedingResult {
   const approveSeeding = useCallback(async () => {
     if (!slug || isApproving) return
     setIsApproving(true)
+    setApprovalError(null)
     try {
-      await approveSeedingApi(slug)
+      const result = await approveSeedingApi(slug)
+      if (!result.ok) {
+        const detail = result.missingArtifacts?.length
+          ? `Missing: ${result.missingArtifacts.join(', ')}`
+          : result.error ?? 'Seeding approval failed'
+        setApprovalError(detail)
+      }
       await refetch()
     } catch (err) {
-      console.error('[useSeeding] approveSeeding failed:', err)
+      setApprovalError(err instanceof Error ? err.message : 'Seeding approval failed')
     } finally {
       setIsApproving(false)
     }
@@ -255,5 +269,6 @@ export function useSeeding(slug: string): UseSeedingResult {
     approveDiscipline,
     approveSeeding,
     isApproving,
+    approvalError,
   }
 }

--- a/docs/plans/discipline-transition-dogfood-fixes.md
+++ b/docs/plans/discipline-transition-dogfood-fixes.md
@@ -1,0 +1,86 @@
+# Discipline Transition Dogfood Fixes
+
+**Date:** 2026-05-04
+**Source:** Live dogfood testing of PR #218 (human-gated discipline transitions)
+**Project tested:** highlow (M-tier, all 9 disciplines)
+
+---
+
+## Bug 1: Seeding summary "Approve & start build" never renders
+
+**Severity:** HIGH — blocks the entire seeding-to-build transition
+**Observed:** All 9 disciplines green-checked, `seeding_awaiting_final_approval: true` in state, `seeding_summary` message in chat log — but nothing visible in the UI.
+
+**Root cause:** The `seeding_summary` message has no `metadata.discipline` tag. Chat panel groups messages by discipline. Untagged messages only render in the flat (no-groups) path, which is gated behind `groups.length === 0`. Since all 9 discipline groups exist, the untagged summary is invisible.
+
+**Fix:** Render `seeding_summary` messages as a banner/footer OUTSIDE the discipline section list — after the last group, at the bottom of the chat area. It's a project-level message, not a discipline-level one.
+
+**Files:** `dashboard/src/components/chat-panel.tsx`
+
+---
+
+## Bug 2: Autonomous disciplines invisible during work
+
+**Severity:** HIGH — user thinks nothing is happening for minutes
+**Observed:** Competition and infrastructure sections don't appear in the chat until they're already complete. During autonomous work (heartbeats, decisions, wrote markers), the user sees only a spinner with no progress indication.
+
+**Root cause:** Discipline sections only render when `messagesByDiscipline.get(d)` has messages. During autonomous continuation turns, heartbeat/decision/wrote messages ARE being written to the chat log with the correct discipline tag. But the chat panel's `displayMessages` comes from `seeding.messages` which is populated by polling every 2s. The messages DO arrive — but the section isn't auto-expanded when a new discipline becomes current mid-poll.
+
+The auto-expand effect (line 155) fires on `currentDiscipline` change. But `currentDiscipline` comes from the parent prop (seedingProgress.currentDiscipline), which is derived from state.json — a different file from seeding-chat.jsonl. The state may update before the messages arrive, or vice versa.
+
+**Fix:** Two parts:
+1. When `currentDiscipline` changes, ensure the new discipline's section is expanded even if it has zero messages yet — show an "In progress..." placeholder.
+2. When a new discipline's messages arrive on the next poll, they populate the section that's already expanded and visible.
+
+**Files:** `dashboard/src/components/chat-panel.tsx`
+
+---
+
+## Bug 3: Approval card appears BEFORE artifact summary
+
+**Severity:** MEDIUM — user asked to accept before seeing what they're accepting
+**Observed:** Infrastructure section shows "infrastructure ready for review" (amber approval card) ABOVE the "Rouge wrote infrastructure-manifest" message. User must scroll past the accept button to see what was produced.
+
+**Root cause:** In `seed-handler.ts`, the `approve_prompt` message is appended BEFORE the `appendSegmentedRougeMessages` call that writes the `[WROTE:]` summary. The approval card is emitted in the `[DISCIPLINE_COMPLETE]` handler (line ~760), but the Claude response segments (including the `[WROTE:]` marker) are appended later (line ~900).
+
+**Fix:** Move the `approve_prompt` append to AFTER `appendSegmentedRougeMessages`. The sequence should be: Claude's response messages (including WROTE summary) → then the approval card at the bottom.
+
+**Files:** `dashboard/src/bridge/seed-handler.ts`
+
+---
+
+## Bug 4: Stale approval cards not cleared on revision
+
+**Severity:** MEDIUM — confusing duplicate approval cards
+**Observed:** Marketing showed two "marketing ready for review" approval cards — the first from the initial completion, the second from re-completion after revision. The first should have been removed or visually deactivated when the user sent revision feedback.
+
+**Root cause:** The approval card is a chat message in seeding-chat.jsonl. When the user sends revision feedback, `clearAwaitingApproval` clears the state but doesn't remove or mark the old approval message as stale. On re-completion, a new approval message is appended, and both render.
+
+**Fix:** Two options:
+- **Option A:** When `clearAwaitingApproval` fires (user sent revision feedback), append a `system_note` that replaces/cancels the old approval card, OR mark the old approval message with a `stale: true` flag.
+- **Option B (simpler):** In the chat panel renderer, only render the LAST `approve_prompt` message per discipline. Earlier ones are stale by definition.
+
+**Files:** `dashboard/src/components/chat-panel.tsx` or `dashboard/src/bridge/seed-handler.ts`
+
+---
+
+## Bug 5: Gate chips not yet tested on fresh project
+
+**Severity:** LOW — code is committed but unverified
+**Status:** The smart fallback parser (synthetic "Accept" chip for accept-or-revise gates) shipped in the last commit but wasn't tested on a fresh project since highlow was mid-session. Needs verification.
+
+**Files:** Already committed in `dashboard/src/components/chat-message.tsx`
+
+---
+
+## Implementation Order
+
+| # | Bug | Effort | Blocks |
+|---|-----|--------|--------|
+| 1 | Seeding summary doesn't render | 20min | Seeding-to-build transition |
+| 3 | Approval card before artifact summary | 15min | User understanding of what they're approving |
+| 4 | Stale approval cards | 15min | Visual clarity |
+| 2 | Autonomous disciplines invisible | 45min | User confidence during autonomous work |
+| 5 | Gate chip verification | 10min | Nothing — just needs a test |
+
+Total: ~1.5 hours

--- a/src/prompts/seeding/00-swarm-orchestrator.md
+++ b/src/prompts/seeding/00-swarm-orchestrator.md
@@ -18,20 +18,7 @@ You have 9 disciplines available. Each is a distinct phase of thinking with its 
 | 8 | **LEGAL/PRIVACY** — GC input review + boilerplate generation | 06-legal-privacy.md | S |
 | 9 | **MARKETING** — Landing page copy + scaffold | 07-marketing.md | M |
 
-**Tier-based skipping (P1.5R PR 4):** After SIZING writes `seed_spec/sizing.json`, you know the project's `project_size`. Before invoking any discipline, check its `applicable_at` against that size. If the discipline's threshold is above the project_size, **SKIP** it — don't invoke its sub-prompt, don't write its artifact. Emit:
-
-```
-[DISCIPLINE_SKIPPED: <name> — applicable_at=<tier>; project_size=<size> is below threshold]
-```
-
-The bot records the skip as a discipline status of `skipped` (distinct from `complete`). Skipped disciplines count toward convergence — you don't need to run them again.
-
-**Examples:**
-- XS project (calculator): skip COMPETITION, INFRASTRUCTURE, DESIGN, LEGAL-PRIVACY, MARKETING. Run only BRAINSTORMING, TASTE, SIZING, SPEC.
-- S project (todo app): skip COMPETITION, MARKETING. Run the other 7.
-- M+ project: run all 9.
-
-The authoritative tier map lives in `src/launcher/discipline-registry.js`. If this prompt and the registry disagree, the registry wins — it's read by tests and the bot. Prompt edits that change tiers without also updating the registry will be caught by the discipline-registry test.
+**Tier-based skipping** is handled by the bridge automatically after the classifier runs. You do NOT need to emit `[DISCIPLINE_SKIPPED]` markers or check tier tables — the bridge auto-skips non-applicable disciplines and never injects their sub-prompts. If you're working on a discipline, it's because the bridge determined it's applicable.
 
 ### Progress Reporting
 
@@ -49,7 +36,7 @@ If a discipline is skipped due to tier gating, emit:
 [DISCIPLINE_SKIPPED: <name> — applicable_at=<tier>; project_size=<size> is below threshold]
 ```
 
-Both markers count toward convergence. This allows the dashboard to show real-time progress to the user.
+Both markers allow the dashboard to show real-time progress to the user.
 
 ## Gated Autonomy: Marker Vocabulary
 
@@ -139,7 +126,7 @@ Emit when a discipline's artifact is on disk with full content. See "Discipline 
 
 ### `[DISCIPLINE_SKIPPED: <name>]`
 
-Emit when a discipline's `applicable_at` tier is above the project's `project_size` (e.g., COMPETITION is M-tier, project is XS). The bridge marks the discipline as complete and advances to the next one — skipped disciplines count toward convergence the same way completed ones do.
+Emit when a discipline's `applicable_at` tier is above the project's `project_size` (e.g., COMPETITION is M-tier, project is XS). The bridge marks the discipline as complete and advances to the next one. However, the bridge handles tier-based skipping automatically — you should rarely need to emit this yourself.
 
 ## Chunked Turn Contract
 
@@ -171,7 +158,7 @@ Never emit `[DISCIPLINE_COMPLETE: <name>]` based on summaries, plans, intentions
 
 **Pre-emission check.** Before writing `[DISCIPLINE_COMPLETE: <name>]`, verify the artifact(s) above exist on disk with full content. If you are tempted to say "here is a summary of the acceptance criteria" — instead, write the criteria to the file. If you are tempted to emit the marker and "flesh out the file later" — don't. Write the file now, then emit the marker.
 
-**SEEDING_COMPLETE pre-check.** Before presenting the SEED SUMMARY or writing `.rouge/state.json` to `ready`, verify every discipline's expected artifact exists on disk with content beyond stubs. If any are missing or placeholder-only, do NOT declare seeding complete — return to the missing discipline and do the work properly.
+**Artifact verification.** The bridge verifies every discipline's artifact on disk before accepting `[DISCIPLINE_COMPLETE]`. If an artifact is missing or doesn't pass schema validation, your marker is rejected and you'll receive a correction note explaining what's wrong.
 
 **No false completion claims.** Never self-score a discipline as complete if the work is only in your head. Never invoke "background agents" or "async workers" to explain why an artifact isn't on disk yet (see Sequential execution below — there is only one worker, and it is you, and the work is done when the file exists with content).
 
@@ -197,115 +184,38 @@ Do not re-run any discipline marked complete. Resume at the next remaining disci
 
 **Rules**:
 1. **Trust the state block, not your memory.** If the block says COMPETITION is complete and you think you were still working on it, the block is right and your memory is wrong. Move on to the next remaining discipline.
-2. **Do not re-run completed disciplines.** If you already emitted `[DISCIPLINE_COMPLETE: <name>]` for a discipline and the bot recorded it, that discipline's artifact is on disk. Do not rewrite it, do not "improve" it unless a loop-back trigger explicitly fires.
+2. **Do not re-run completed disciplines.** If you already emitted `[DISCIPLINE_COMPLETE: <name>]` for a discipline and the bot recorded it, that discipline's artifact is on disk. Do not rewrite it or "improve" it.
 3. **If a discipline was interrupted mid-work, restart it cleanly.** Do not try to patch around where you think you stopped. Open the artifact file, read what is there, decide whether to start over or continue cleanly. Emit `[DISCIPLINE_COMPLETE: <name>]` only when the artifact is fully written.
 4. **The state block is always the source of truth for completion status.** Your job is to make progress on the next remaining discipline — not to re-evaluate whether prior completions were "really" complete.
 5. **The state block is empty on the very first turn of a session.** No injected block ≠ "no prior state" in a way you need to explain. Just start with BRAINSTORMING as normal.
 
 This mechanism exists because the colouring book seeding session (2026-04-10) hit multiple rate limits during seeding, and the discipline boundaries degraded with each resume cycle — Claude's self-maintained tracker could not survive the `--resume` cleanly. Persisted state + this Resumption contract is how we fix it.
 
-## Swarm Rules
+## Execution Model
 
-**Non-linear execution.** Disciplines don't run in fixed order. You start with BRAINSTORMING, but any discipline can trigger a loop-back to any other:
+**Sequential, one discipline at a time.** The bridge controls which discipline you work on. When you receive a `[SYSTEM]` message saying "entering DISCIPLINE_X," that's the bridge advancing to the next discipline — follow its sub-prompt rules exactly.
 
-- DESIGN challenges SPEC → loop back to SPEC (e.g., 3-click rule violated, journey needs restructuring)
-- TASTE challenges BRAINSTORMING → loop back to BRAINSTORMING (e.g., scope too broad, premise weak)
-- SPEC surfaces gap that COMPETITION should have caught → loop back to COMPETITION
-- LEGAL flags regulated domain → loop back to TASTE for scope adjustment
+**No parallel execution.** There are no background agents, no async workers, no parallel subprocesses. This is a single `claude -p` invocation. Each discipline's work must be bounded and must emit `[DISCIPLINE_COMPLETE: <name>]` before the next discipline begins.
 
-**Sequential execution only.** Non-linear order does NOT mean parallel execution. Always run disciplines **one at a time**. Even if multiple disciplines have their prerequisites met (e.g. after INFRASTRUCTURE completes, DESIGN, LEGAL-PRIVACY, and MARKETING all become eligible), **do not attempt to run them concurrently in a single turn**. Each discipline's work must be bounded and must emit `[DISCIPLINE_COMPLETE: <name>]` before the next discipline begins.
+**No loop-backs.** If you discover a contradiction with a prior discipline's output, note it in your current discipline's artifact (e.g., "SPEC note: brainstorming's feature area X may need revisiting"). The bridge and user will decide whether to loop back — you don't control the sequence.
 
-There are no background agents, no async workers, and no parallel subprocesses. This is a single `claude -p` invocation. Claims like "the DESIGN agent is still running, I'll wait for it" are hallucinations — if you say it, you're the one running it, and you're running it right now, sequentially. Running multiple disciplines in one turn will exceed `--max-turns` and the 10-minute subprocess timeout, killing the seeding session.
+## State Management — Bridge-Controlled
 
-**Loop-back triggers.** After each discipline completes, check:
-1. Did this discipline's output contradict or invalidate a previous discipline's output?
-2. If yes: loop back to the affected discipline with the new context
-3. If no: proceed to the next unfinished discipline
+The bridge (dashboard TypeScript code) is the state machine controller. You are the worker within a single discipline. The human approves at boundaries.
 
-**Convergence detection.** The swarm converges when:
-- all 9 disciplines have run at least once
-- No new loop-back triggers fired in the last pass
-- The human has approved the final summary
-
-**Mandatory sequence constraints:**
-- BRAINSTORMING must run before TASTE (need something to challenge)
-- BRAINSTORMING's output must include the `## Classifier Signals` block before SIZING runs
-- TASTE must pass before SIZING (no point sizing a killed idea)
-- SIZING must complete before SPEC (spec reads project_size to pick FA count + AC depth)
-- SPEC must complete before INFRASTRUCTURE (infra needs to know what features require)
-- INFRASTRUCTURE must complete before DESIGN (design needs infra constraints — e.g., no WebGL if headless deploy)
-- LEGAL must run before FINAL APPROVAL (legal flags can kill or reshape everything)
-- COMPETITION and MARKETING must run after SIZING (their skip eligibility depends on project_size — running them before SIZING wastes work if they'd have been skipped)
+1. **Emit `[DISCIPLINE_COMPLETE: X]` when an artifact is on disk.** The bridge verifies it and presents it to the user for approval. You do NOT control what happens next — the bridge pauses until the user clicks "Accept & continue."
+2. **Do NOT emit `SEEDING_COMPLETE`.** The bridge handles seeding finalization when the user approves the final summary. If you emit it, the bridge will ignore it.
+3. **Do NOT track discipline state.** The bridge tracks `disciplines_complete[]`, `current_discipline`, and `applicable_disciplines`. If you receive a `[SYSTEM]` message saying "entering DISCIPLINE_X," trust it — that's the bridge advancing.
+4. **Do NOT decide which disciplines to skip.** The bridge auto-skips based on the project's tier after the classifier runs. You never see non-applicable disciplines.
+5. **If the user sends revision feedback after you've emitted `[DISCIPLINE_COMPLETE]`,** the bridge has cleared the approval and you're still in the same discipline. Continue working on the user's feedback — don't advance to the next discipline.
+6. **Write artifacts to disk before emitting `[DISCIPLINE_COMPLETE]`.** The bridge verifies the artifact exists with correct structure. If it's missing, your marker is rejected and you'll receive a correction note.
 
 ## Your Job
 
-1. **Start with BRAINSTORMING.** Read the human's initial idea from the Slack message that triggered "rouge new." Run the brainstorming discipline.
-
-2. **Track discipline state.** Maintain a local tracker:
-```json
-{
-  "disciplines": {
-    "brainstorming": {"status": "pending|running|complete", "runs": 0, "last_output_summary": ""},
-    "competition": {"status": "...", "runs": 0, "last_output_summary": ""},
-    "taste": {"status": "...", "runs": 0, "last_output_summary": ""},
-    "spec": {"status": "...", "runs": 0, "last_output_summary": ""},
-    "design": {"status": "...", "runs": 0, "last_output_summary": ""},
-    "legal_privacy": {"status": "...", "runs": 0, "last_output_summary": ""},
-    "marketing": {"status": "...", "runs": 0, "last_output_summary": ""}
-  },
-  "loop_backs": [],
-  "convergence_checks": 0
-}
-```
-
-3. **After each discipline completes**, evaluate loop-back triggers. If triggered, explain to the human via Slack what changed and why you're looping back.
-
-4. **When all disciplines have run and no new triggers fire**, validate completion before presenting the final gate (P0-SEEDING-001 FIX):
-   
-   **Pre-Gate Validation:**
-   - Read `seeding-state.json` to get `disciplines_complete[]`
-   - Read `seed_spec/sizing.json` to get `project_size`
-   - Compare against the tier table (lines 10-19). For an XS project: brainstorming, taste, sizing, spec must be complete. For S: add infrastructure, design, legal-privacy. For M+: all 9.
-   - If any applicable discipline is missing from `disciplines_complete[]`, DO NOT proceed to final approval. Loop back to the first missing discipline.
-   - Skipped disciplines (those you emitted `[DISCIPLINE_SKIPPED: ...]` for) count as complete — they're in `disciplines_complete[]`.
-   
-   Only after validation passes, present the SEED SUMMARY to the human as a **hard gate** — the final approval before seeding closes. Emit `[GATE: seeding/H-final-approval]` at the top of this turn, then follow it with the summary body below. Stop and return after emitting the gate — do NOT continue writing artifacts or emit SEEDING_COMPLETE until the human has replied.
-
-   Summary body (under the gate marker):
-   - Product name and one-liner
-   - **Disciplines completed** — list only disciplines in `seeding-state.json.disciplines_complete[]`, not what you think should have run. If this is an S-tier project and the list shows only 3 disciplines, something went wrong — loop back, don't hallucinate completion.
-   - Milestone count (with names)
-   - Story count (total across all milestones)
-   - Stories per milestone (verify 3-8 cap per milestone)
-   - Story dependencies (count + any complex chains)
-   - Total user journeys
-   - Total acceptance criteria (QA-testable)
-   - Total PO checks
-   - Total screens
-   - Legal flags (if any)
-   - Estimated build milestones (not cycles — one milestone ≈ one sprint of stories)
-   - Definition of done
-   - Options: `approve` (lock and promote to ready) · `revise <discipline>` (loop back) · `edit <aspect>` (name a specific change)
-
-   Composing this summary is real work — if it's going to take you more than ~45s of gathering, emit a `[HEARTBEAT: assembling SEED SUMMARY]` first so the dashboard doesn't appear stalled.
-
-5. **On human approval** (the human replied `approve` or similar to the H-final-approval gate), write all artifacts to the project directory:
-   - **`task_ledger.json`** (P1-SEEDING-004 FIX) — V3 story/milestone tracking (schema: `schemas/task-ledger-v1.json`). This is the launcher's source of truth. Write the SAME milestones structure you're about to write to state.json. Each milestone has `name`, `status: "pending"`, `stories[]`. Each story has `id`, `name`, `status: "pending"`, `depends_on`, `affected_entities`, `affected_screens`.
-   - `vision.json` — structured vision document
-   - `product_standard.json` — inherited global + domain + project overrides
-   - `seed_spec/` — milestones with stories, each story with acceptance criteria, PO checks, dependencies, affected entities/screens
-   - `legal/` — T&Cs, privacy policy, cookie policy (if generated)
-   - `marketing/` — landing page copy
-   - Set `.rouge/state.json` to `ready` using the **V2 schema** (see `docs/design/state-schema-v2.md`):
-     - Write `milestones[]` with nested `stories[]` (not the deprecated `feature_areas[]` shape)
-     - Each story has: `id`, `name`, `status: "pending"`, `depends_on`, `affected_entities`, `affected_screens`
-     - Each milestone has: `name`, `status: "pending"`, `stories[]`
-     - Set `foundation.status` to `"pending"` if complexity profile requires foundation (NEVER `"complete"` — the foundation evaluator must run). The build-runner defends against this being null, but the orchestrator must set it explicitly so downstream tooling doesn't have to guess intent.
-     - Set `current_state` to `"ready"` (not `building` — the human triggers the loop explicitly)
-
-   Then emit `SEEDING_COMPLETE` as a bare word on its own line — this is the signal the bridge watches for. The bridge will call its own finalizer (verifying artifacts on disk, advancing state if not already advanced, marking `seeding_complete: true` in seeding-state.json). If you forget to emit it, the bridge's reconciler will eventually catch up on the next user message, but it's cleaner to emit it explicitly so the transition fires in the turn the human approved.
-
-6. **On human rejection or revision request**, loop back to the relevant discipline. Do NOT emit SEEDING_COMPLETE.
+1. **Start with BRAINSTORMING.** Read the human's initial idea. Run the brainstorming discipline following `01-brainstorming.md`.
+2. **Do the work the sub-prompt specifies.** Each discipline has a self-contained prompt with its own gates, artifacts, and completion requirements. Follow it exactly.
+3. **When the discipline's artifact is on disk with full content,** emit `[DISCIPLINE_COMPLETE: <name>]`. The bridge takes it from here — verifying the artifact, presenting it for user approval, and advancing to the next discipline when the user accepts.
+4. **Write all seeding artifacts** (task_ledger.json, vision.json, seed_spec/, legal/, marketing/) during the relevant discipline. The bridge's finalizer checks for these when all disciplines are approved.
 
 ## Interaction Model
 


### PR DESCRIPTION
## Summary

Replaces the broken auto-advancing discipline transition system with human-gated approval at every boundary. This is the architectural fix for Rouge's #1 UX problem (reported broken 10-15 times across sessions).

**Core principle:** Code controls transitions. LLM does work within one discipline. Human approves at boundaries.

### What changed

**New state: AWAITING_APPROVAL** — sits between "artifact verified" and "complete". Disciplines no longer jump straight to complete when the LLM emits `[DISCIPLINE_COMPLETE]`. Instead:
1. Bridge verifies the artifact on disk (schema validation, byte checks)
2. Bridge sets `discipline_awaiting_approval` and appends an approval card to chat
3. User sees "Accept & continue" button (green) or "Archive project" (red, for taste kills)
4. User clicks Accept → bridge calls `markDisciplineComplete()` → fires kickoff into next discipline
5. Or user types revision feedback → bridge clears approval, continues in same discipline

**Reconciliation neutered** — no longer auto-completes disciplines. When it finds an artifact on disk, it proposes approval instead of advancing state.

**SEEDING_COMPLETE ignored** — the LLM marker is caught and corrected. Only path to finalization is the `approve-seeding` endpoint triggered by user clicking "Approve & start build."

**Orchestrator prompt stripped** — removed 111 lines of state management instructions (discipline tracker, loop-back triggers, convergence detection, seed summary gate, SEEDING_COMPLETE emission). Replaced with 21-line "State Management — Bridge-Controlled" section with 6 clear rules.

### Files (14)

- `seed-handler.ts` — DISCIPLINE_COMPLETE → setAwaitingApproval, continuation suppressed, reconciliation neutered, message tagging fixed, SEEDING_COMPLETE ignored
- `seeding-state.ts` — setAwaitingApproval/clearAwaitingApproval/isAwaitingApproval + effectiveMode updated
- `types.ts` (bridge) — new mode, new state fields, new message kinds
- `types.ts` (lib) — DisciplineStatus + ChatMessageKind + SeedingProgress extended
- `approve-discipline/route.ts` — new POST endpoint for discipline approval
- `approve-seeding/route.ts` — new POST endpoint for final seeding approval
- `bridge-client.ts` — approveDiscipline() + approveSeeding() client functions
- `chat-message.tsx` — ApprovePromptMessage + SeedingSummaryMessage components
- `chat-panel.tsx` — collapse gates on 'complete' only, 'awaiting_approval' stays open with amber border
- `discipline-stepper.tsx` — amber clock icon for awaiting_approval status
- `use-seeding.ts` — approveDiscipline/approveSeeding actions + isApproving state
- `bridge-mapper.ts` — 'awaiting_approval' in DISCIPLINE_STATUSES
- `state-repair.ts` — stale approval cleanup, no auto-finalize
- `00-swarm-orchestrator.md` — stripped to session preamble + worker instructions

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx vitest run src/bridge/__tests__/` — 83/83 pass
- [x] `node --test tests/project-sizer.test.js` — 38/38 pass
- [ ] Create XS project, seed through brainstorming → verify approval card appears
- [ ] Click "Accept & continue" → verify taste starts, brainstorming collapses
- [ ] Complete all 4 XS disciplines → verify seeding summary appears
- [ ] Click "Approve & start build" → verify project transitions to ready
- [ ] Send revision feedback during awaiting_approval → verify discipline continues
- [ ] Verify messages always appear in correct discipline section

🤖 Generated with [Claude Code](https://claude.com/claude-code)