### PR TITLE
fix: deploy-readiness gate + Sentry/PostHog foundation guidance

### DIFF
--- a/src/launcher/rouge-loop.js
+++ b/src/launcher/rouge-loop.js
@@ -1214,6 +1214,27 @@ async function advanceState(projectDir) {
         break;
       }
 
+      // Deploy-readiness gate: if foundation_completion.deploy_ready is
+      // explicitly false, the product can't be evaluated after building
+      // (milestone-check needs a staging URL for product walk). Escalate
+      // now rather than building 7+ stories only to discover at eval time
+      // that there's no deployment. See #226.
+      const foundationCtx = readJson(contextFile);
+      if (foundationCtx?.foundation_completion?.deploy_ready === false) {
+        const gaps = (foundationCtx.foundation_completion.blocking_gaps || [])
+          .filter((g) => g.toLowerCase().includes('deploy') || g.toLowerCase().includes('database_url') || g.toLowerCase().includes('env'))
+          .slice(0, 3);
+        const gapDetail = gaps.length > 0 ? ` Blocking gaps: ${gaps.join('; ')}` : '';
+        log(`[${projectName}] Deploy not ready — escalating before story-building`);
+        next = escalate(state, {
+          id: `esc-deploy-not-ready-${Date.now()}`,
+          tier: 1,
+          classification: 'deploy-not-ready',
+          summary: `Foundation passed evaluation but deploy_ready=false. The staging deploy is not functional — building stories now would produce unevaluable code.${gapDetail} Fix the deployment (env vars, build errors) before resuming.`,
+        });
+        break;
+      }
+
       // Start first milestone. Informative escalations replace the
       // old `next = 'escalation'` fallbacks so users see WHY the loop
       // stopped, not a generic placeholder.

--- a/src/prompts/loop/00-foundation-building.md
+++ b/src/prompts/loop/00-foundation-building.md
@@ -70,6 +70,8 @@ Read `foundation_spec` from `cycle_context.json`. Your scope is EXACTLY what's l
   - Environment variable references (NEVER hardcode values)
   - Test stubs against sandbox/mock
   - Setup documentation for the project README
+- **Sentry (Next.js App Router):** Do NOT use `withSentryConfig` wrapper in `next.config.ts` — it auto-instruments route files by injecting `runtime` exports that conflict with explicit declarations. Instead use the `instrumentation.ts` pattern: create `instrumentation.ts` at app root with `Sentry.init()`, and `instrumentation-client.ts` for client-side. Set `autoInstrumentServerFunctions: false` if using the wrapper is unavoidable. Verify the build passes with a route that declares `export const runtime = 'nodejs'` before committing.
+- **Analytics (PostHog/similar):** If the vision includes analytics, either provision the project and set env vars during foundation OR defer the integration entirely to a later milestone. Do not add the SDK + consent banner without the API key — it creates a "done" appearance that's actually dead code needing manual env var configuration later.
 
 **External-system interaction policy (GC.2).** When you need to interact with an external system (Vercel, Supabase, GitHub, Cloudflare, etc.) during foundation building: for *inspecting* state (list deployments, read schema, fetch project metadata), prefer the relevant MCP server when one is wired into this phase. For *mutating* state (deploy, migrate schema, push, delete), always use the CLI tool via the Bash tool. CLIs leave a Bash-tool audit trail; MCPs do not. If the only way to perform a needed mutation is via an MCP because no CLI exists, escalate rather than silently mutating through a side channel.
 


### PR DESCRIPTION
## Summary

Three systemic fixes from Irish Planning's deploy failures:

- **Deploy gate** (`rouge-loop.js`): After foundation-eval passes, check `foundation_completion.deploy_ready`. If `false`, escalate immediately instead of building stories that can't be evaluated. Irish Planning built 7 stories, then milestone-check had no URL → product walk skipped → degraded evaluation.

- **Sentry guidance** (`00-foundation-building.md`): `withSentryConfig` wraps route files and injects conflicting `runtime` exports. Foundation must use the `instrumentation.ts` pattern instead, or disable `autoInstrumentServerFunctions`.

- **PostHog/analytics guidance**: Either provision the project + set env vars during foundation, or defer entirely. Don't add dead SDK + consent banner that looks done but is non-functional.

## Test plan

- [x] 2,011 tests pass, 0 failures
- [x] Foundation and building prompt behavioral tests pass (33/33)
- [x] Deploy gate uses existing `escalate()` helper with informative summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)